### PR TITLE
fix: build_docs CI failure when no doc changes found.

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -12,5 +12,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add docs
-          git commit -m "docs(update): latest"
+          git commit -m "docs(update): latest" || echo "No document(s) updates found!"
           git push


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
build_docs CI failing when no command changes happened. Underlying failing was `git commit` since no changes found to commit. Silently skip it when no new changes found in git commit command.

**Motivation and Context**
Fix generate documentation CI.

**How Has This Been Tested?**
Tested on git bash with no changes to commit.
