### PR TITLE
Feat: Added pagination

### DIFF
--- a/commands/issue_list.go
+++ b/commands/issue_list.go
@@ -37,7 +37,12 @@ var issueListCmd = &cobra.Command{
 		if lb, _ := cmd.Flags().GetBool("confidential"); lb {
 			l.Confidential = gitlab.Bool(lb)
 		}
-
+		if p, _ := cmd.Flags().GetInt("page"); p != 0 {
+			l.Page = p
+		}
+		if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
+			l.PerPage = p
+		}
 		gitlabClient, repo := git.InitGitlabClient()
 		if r, _ := cmd.Flags().GetString("repo"); r != "" {
 			repo = r
@@ -59,5 +64,7 @@ func init() {
 	issueListCmd.Flags().BoolP("closed", "c", false, "Get only closed issues")
 	issueListCmd.Flags().BoolP("opened", "o", false, "Get only opened issues")
 	issueListCmd.Flags().BoolP("confidential", "", false, "Filter by confidential issues")
+	issueListCmd.Flags().IntP("page", "p", 1, "Page number")
+	issueListCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
 	issueCmd.AddCommand(issueListCmd)
 }

--- a/commands/issue_view.go
+++ b/commands/issue_view.go
@@ -105,6 +105,12 @@ var issueViewCmd = &cobra.Command{
 
 		if c, _ := cmd.Flags().GetBool("comments"); c { //open in browser if --web flag is specified
 			l := &gitlab.ListIssueNotesOptions{}
+			if p, _ := cmd.Flags().GetInt("page"); p != 0 {
+				l.Page = p
+			}
+			if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
+				l.PerPage = p
+			}
 			notes, _, err := gitlabClient.Notes.ListIssueNotes(repo, pid, l)
 			if err != nil {
 				return err
@@ -155,5 +161,7 @@ func init() {
 	issueViewCmd.Flags().StringP("repo", "r", "", "Select another repository using the OWNER/REPO format. Supports group namespaces")
 	issueViewCmd.Flags().BoolP("comments", "c", false, "Show issue comments and activities")
 	issueViewCmd.Flags().BoolP("web", "w", false, "Open issue in a browser. Uses default browser or browser specified in BROWSER variable")
+	issueViewCmd.Flags().IntP("page", "p", 1, "Page number")
+	issueViewCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
 	issueCmd.AddCommand(issueViewCmd)
 }

--- a/commands/label_list.go
+++ b/commands/label_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
 	"glab/internal/git"
 	"strings"
 )
@@ -18,12 +19,20 @@ var labelListCmd = &cobra.Command{
 }
 
 func listLabels(cmd *cobra.Command, args []string) {
+	l := &gitlab.ListLabelsOptions{}
+	if p, _ := cmd.Flags().GetInt("page"); p != 0 {
+		l.Page = p
+	}
+	if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
+		l.PerPage = p
+	}
+
 	gitlabClient, repo := git.InitGitlabClient()
 	if r, _ := cmd.Flags().GetString("repo"); r != "" {
 		repo = r
 	}
 	// List all labels
-	labels, _, err := gitlabClient.Labels.ListLabels(repo, nil)
+	labels, _, err := gitlabClient.Labels.ListLabels(repo, l)
 	if err != nil {
 		er(err)
 	}
@@ -35,5 +44,7 @@ func listLabels(cmd *cobra.Command, args []string) {
 }
 
 func init() {
+	labelListCmd.Flags().IntP("page", "p", 1, "Page number")
+	labelListCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
 	labelCmd.AddCommand(labelListCmd)
 }

--- a/commands/mr_list.go
+++ b/commands/mr_list.go
@@ -39,6 +39,12 @@ func listMergeRequest(cmd *cobra.Command, args []string) error {
 	if lb, _ := cmd.Flags().GetString("milestone"); lb != "" {
 		l.Milestone = gitlab.String(lb)
 	}
+	if p, _ := cmd.Flags().GetInt("page"); p != 0 {
+		l.Page = p
+	}
+	if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
+		l.PerPage = p
+	}
 
 	gitlabClient, repo := git.InitGitlabClient()
 	if r, _ := cmd.Flags().GetString("repo"); r != "" {
@@ -59,5 +65,7 @@ func init() {
 	mrListCmd.Flags().BoolP("closed", "c", false, "Get only closed merge requests")
 	mrListCmd.Flags().BoolP("opened", "o", false, "Get only opened merge requests")
 	mrListCmd.Flags().BoolP("merged", "m", false, "Get only merged merge requests")
+	mrListCmd.Flags().IntP("page", "p", 1, "Page number")
+	mrListCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
 	mrCmd.AddCommand(mrListCmd)
 }

--- a/commands/mr_view.go
+++ b/commands/mr_view.go
@@ -107,6 +107,12 @@ var mrViewCmd = &cobra.Command{
 
 		if c, _ := cmd.Flags().GetBool("comments"); c {
 			l := &gitlab.ListMergeRequestNotesOptions{}
+			if p, _ := cmd.Flags().GetInt("page"); p != 0 {
+				l.Page = p
+			}
+			if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
+				l.PerPage = p
+			}
 			notes, _, err := gitlabClient.Notes.ListMergeRequestNotes(repo, pid, l)
 			if err != nil {
 				er(err)
@@ -147,5 +153,7 @@ func init() {
 	mrViewCmd.Flags().BoolP("comments", "c", false, "Show mr comments and activities")
 	mrViewCmd.Flags().BoolP("system-logs", "s", false, "Show system activities / logs")
 	mrViewCmd.Flags().BoolP("web", "w", false, "Open mr in a browser. Uses default browser or browser specified in BROWSER variable")
+	mrViewCmd.Flags().IntP("page", "p", 1, "Page number")
+	mrViewCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
 	mrCmd.AddCommand(mrViewCmd)
 }

--- a/commands/pipeline_list.go
+++ b/commands/pipeline_list.go
@@ -34,6 +34,13 @@ func listPipelines(cmd *cobra.Command, args []string) {
 	if m, _ := cmd.Flags().GetString("sort"); m != "" {
 		l.Sort = gitlab.String(m)
 	}
+	if p, _ := cmd.Flags().GetInt("page"); p != 0 {
+		l.Page = p
+	}
+	if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
+		l.PerPage = p
+	}
+
 	pipes, _, err := gitlabClient.Pipelines.ListProjectPipelines(repo, l)
 	if err != nil {
 		er(err)
@@ -46,5 +53,7 @@ func init() {
 	pipelineListCmd.Flags().StringP("status", "s", "", "Get pipeline with status: {running|pending|success|failed|canceled|skipped|created|manual}")
 	pipelineListCmd.Flags().StringP("orderBy", "o", "", "Order pipeline by <string>")
 	pipelineListCmd.Flags().StringP("sort", "", "desc", "Sort pipeline by {asc|desc}. (Defaults to desc)")
+	pipelineListCmd.Flags().IntP("page", "p", 1, "Page number")
+	pipelineListCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
 	pipelineCmd.AddCommand(pipelineListCmd)
 }


### PR DESCRIPTION
**Description**
Added pagination to all listing commands: pipeline list, mr list, mr view, label list, issue view issue list

Added options `-p`(`--page`) and `-P`(`--per-page`) for control API pagination.

**Motivation and Context**
In my GL installation I have many issues and merge requests, but cannot view more than first 20 items (by GitLab API behaviour).  API allow view more items by [pagination](https://docs.gitlab.com/ce/api/README.html#pagination) and used API package [supports pagination](https://github.com/xanzy/go-gitlab/blob/8b267e0e3b206bb6b240e1a87810b0fdf17ccf9e/gitlab.go#L181-L187).

**Test**
Tests was not added because project have not good tests at all.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
