### PR TITLE
fix: default GIT_REMOTE_URL_VAR to origin if not specified by user

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -34,14 +34,13 @@ func GetRemoteURL() string {
 	if remoteNickname == "" {
 		remoteNickname = "origin"
 	}
-	remoteVar := config.GetEnv("GIT_REMOTE_URL_VAR")
 
-	if remoteVar != "origin"{
-		gitlabUrl := strings.TrimSpace(config.GetEnv("GITLAB_URI"))
-		rUrl := gitlabUrl + "/"+ remoteVar +".git"
-		return rUrl
+	if remoteNickname != "origin"{
+		gitlabURL := strings.TrimSpace(config.GetEnv("GITLAB_URI"))
+		gitRemoteURL := gitlabURL + "/"+ remoteNickname +".git"
+		return gitRemoteURL
 	}else {
-		gitRemoteURL, err := gitconfig.Local("remote." + remoteVar + ".url")
+		gitRemoteURL, err := gitconfig.Local("remote." + remoteNickname + ".url")
 		if err != nil {
 			log.Fatal("Could not find remote url for gitlab. Run glab config -g")
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -34,11 +34,19 @@ func GetRemoteURL() string {
 	if remoteNickname == "" {
 		remoteNickname = "origin"
 	}
-	gitRemoteURL, err := gitconfig.Local("remote." + config.GetEnv("GIT_REMOTE_URL_VAR") + ".url")
-	if err != nil {
-		log.Fatal("Could not find remote url for gitlab. Run glab config -g")
+	remoteVar := config.GetEnv("GIT_REMOTE_URL_VAR")
+
+	if remoteVar != "origin"{
+		gitlabUrl := strings.TrimSpace(config.GetEnv("GITLAB_URI"))
+		rUrl := gitlabUrl + "/"+ remoteVar +".git"
+		return rUrl
+	}else {
+		gitRemoteURL, err := gitconfig.Local("remote." + remoteVar + ".url")
+		if err != nil {
+			log.Fatal("Could not find remote url for gitlab. Run g config -g")
+		}
+		return gitRemoteURL
 	}
-	return gitRemoteURL
 }
 
 func GetRemoteBaseURL() string {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -43,7 +43,7 @@ func GetRemoteURL() string {
 	}else {
 		gitRemoteURL, err := gitconfig.Local("remote." + remoteVar + ".url")
 		if err != nil {
-			log.Fatal("Could not find remote url for gitlab. Run g config -g")
+			log.Fatal("Could not find remote url for gitlab. Run glab config -g")
 		}
 		return gitRemoteURL
 	}


### PR DESCRIPTION
Reolves #97 