### PR TITLE
feat: Add aliases for long commands

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -10,9 +10,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"glab/commands"
 	"glab/internal/config"
+
+	"github.com/spf13/cobra"
 )
 
 // Version is set at build

--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -13,6 +13,7 @@ import (
 	"glab/commands"
 	"glab/internal/config"
 
+	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 )
 
@@ -34,10 +35,68 @@ func main() {
 	if usageMode == "dev" {
 		debug = true
 	}
-	if cmd, err := commands.Execute(); err != nil {
+
+	expandedArgs := []string{}
+	if len(os.Args) > 0 {
+		expandedArgs = os.Args[1:]
+	}
+
+	cmd, _, err := commands.RootCmd.Traverse(expandedArgs)
+	if err != nil || cmd == commands.RootCmd {
+		originalArgs := expandedArgs
+		expandedArgs, err = expandAlias(os.Args)
+		if err != nil {
+			fmt.Printf("Failed to process alias: %s\n", err)
+		}
+
+		if debug {
+			fmt.Printf("%v -> %v\n", originalArgs, expandedArgs)
+		}
+	}
+
+	commands.RootCmd.SetArgs(expandedArgs)
+
+	if cmd, err := commands.RootCmd.ExecuteC(); err != nil {
 		printError(os.Stderr, err, cmd, debug)
 		os.Exit(1)
 	}
+}
+
+func expandAlias(args []string) (expanded []string, err error) {
+	if len(args) < 2 {
+		// No subcommand
+		return
+	}
+	expanded = args[1:]
+
+	expansion := config.GetAlias(args[1])
+	if expansion == "" {
+		return
+	}
+
+	extraArgs := []string{}
+	for i, a := range args[2:] {
+		if !strings.Contains(expansion, "$") {
+			extraArgs = append(extraArgs, a)
+		} else {
+			expansion = strings.ReplaceAll(expansion, fmt.Sprintf("$%d", i+1), a)
+		}
+	}
+
+	leftoverChecker := regexp.MustCompile(`\$\d`)
+	if leftoverChecker.MatchString(expansion) {
+		err = fmt.Errorf("Not enough arguments for alias: %s", expansion)
+		return
+	}
+
+	var newArgs []string
+	newArgs, err = shlex.Split(expansion)
+	if err != nil {
+		return
+	}
+
+	expanded = append(newArgs, extraArgs...)
+	return
 }
 
 func initConfig() {

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -1,0 +1,16 @@
+package commands
+
+import "github.com/spf13/cobra"
+
+var aliasCmd = &cobra.Command{
+	Use:   "alias [command] [flags]",
+	Short: `Create, list and delete aliases`,
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(aliasCmd)
+}

--- a/commands/alias_delete.go
+++ b/commands/alias_delete.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"glab/internal/config"
+	"log"
+
 	"github.com/spf13/cobra"
 )
 
@@ -8,8 +11,12 @@ var aliasDeleteCmd = &cobra.Command{
 	Use:   "delete <alias name> [flags]",
 	Short: `Delete an alias.`,
 	Long:  ``,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		_ = cmd.Help()
+		err := config.DeleteAlias(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 	},
 }
 

--- a/commands/alias_delete.go
+++ b/commands/alias_delete.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var aliasDeleteCmd = &cobra.Command{
+	Use:   "delete <alias name> [flags]",
+	Short: `Delete an alias.`,
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasDeleteCmd)
+}

--- a/commands/alias_delete.go
+++ b/commands/alias_delete.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
+	"fmt"
 	"glab/internal/config"
-	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,8 @@ var aliasDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := config.DeleteAlias(args[0])
 		if err != nil {
-			log.Fatal(err)
+			fmt.Println(err)
+			os.Exit(1)
 		}
 	},
 }

--- a/commands/alias_list.go
+++ b/commands/alias_list.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var aliasListCmd = &cobra.Command{
+	Use:   "list [flags]",
+	Short: `List the available aliases.`,
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasListCmd)
+}

--- a/commands/alias_list.go
+++ b/commands/alias_list.go
@@ -14,7 +14,7 @@ var aliasListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		aliasMap := config.GetAllAliases()
 
-		if aliasMap == nil || len(aliasMap) == 0 {
+		if len(aliasMap) == 0 {
 			fmt.Println("There are currently no aliases")
 			fmt.Println("See 'glab alias set --help' for more info")
 			return

--- a/commands/alias_list.go
+++ b/commands/alias_list.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"fmt"
+	"glab/internal/config"
+
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +12,17 @@ var aliasListCmd = &cobra.Command{
 	Short: `List the available aliases.`,
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		_ = cmd.Help()
+		aliasMap := config.GetAllAliases()
+
+		if aliasMap == nil || len(aliasMap) == 0 {
+			fmt.Println("There are currently no aliases")
+			fmt.Println("See 'glab alias set --help' for more info")
+			return
+		}
+
+		for name, command := range aliasMap {
+			fmt.Println(name + ": " + command)
+		}
 	},
 }
 

--- a/commands/alias_set.go
+++ b/commands/alias_set.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+)
+
+var aliasSetCmd = &cobra.Command{
+	Use:   "set <alias name> '<command>' [flags]",
+	Short: `Set an alias.`,
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+	Example: heredoc.Doc(`
+	$ glab alias set createissue 'glab create issue --title "$1"'
+	$ glab createissue "My Issue" --description "Something is broken."
+	# => glab create issue --title "My Issue" --description "Something is broken."
+	`),
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasSetCmd)
+}

--- a/commands/alias_set.go
+++ b/commands/alias_set.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"glab/internal/config"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
@@ -9,8 +11,11 @@ var aliasSetCmd = &cobra.Command{
 	Use:   "set <alias name> '<command>' [flags]",
 	Short: `Set an alias.`,
 	Long:  ``,
+	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		_ = cmd.Help()
+		aliasName := args[0]
+		aliasedCommand := args[1]
+		config.SetAlias(aliasName, aliasedCommand)
 	},
 	Example: heredoc.Doc(`
 	$ glab alias set createissue 'glab create issue --title "$1"'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ var (
 	configFileFileDir       = configFileFileParentDir + "/config"
 	configFile              = configFileFileDir + "/.env"
 	globalConfigFile        = configFile
-	aliasFile               = configFileFileDir + "/aliases.txt"
+	aliasFile               = configFileFileParentDir + "/config/aliases.format"
 )
 
 func SetGlobalPathDir() string {
@@ -34,6 +34,7 @@ func SetGlobalPathDir() string {
 	}
 	globalPathDir = usr.HomeDir
 	globalConfigFile = globalPathDir + "/" + globalConfigFile
+	aliasFile = globalPathDir + "/" + configFileFileParentDir + "/config/aliases.format"
 	return globalPathDir
 }
 
@@ -90,8 +91,8 @@ func SetEnv(key, value string) {
 	if !keyExists {
 		newData += newConfig
 	}
-	_ = os.Mkdir(cFileFileParentDir, 0700)
-	_ = os.Mkdir(cFileDir, 0700)
+	_ = os.Mkdir(cFileFileParentDir, 0755)
+	_ = os.Mkdir(cFileDir, 0755)
 	f, _ := os.Create(cFile) // Create a writer
 	w := bufio.NewWriter(f)
 	_, _ = w.WriteString(strings.Trim(newData, "\n"))
@@ -104,9 +105,10 @@ func SetEnv(key, value string) {
 // SetAlias sets an alias for a command
 func SetAlias(name string, command string) {
 	if !CheckFileExists(aliasFile) {
-		_, err := os.Stat(configFileFileDir)
+		aliasDir := globalPathDir + "/" + configFileFileDir
+		_, err := os.Stat(aliasDir)
 		if os.IsNotExist(err) {
-			errDir := os.MkdirAll(configFileFileDir, 0700)
+			errDir := os.MkdirAll(aliasDir, 0700)
 			if errDir != nil {
 				log.Fatalln(err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,7 +106,7 @@ func SetAlias(name string, command string) {
 	if !CheckFileExists(aliasFile) {
 		_, err := os.Stat(configFileFileDir)
 		if os.IsNotExist(err) {
-			errDir := os.MkdirAll(configFileFileDir, 0755)
+			errDir := os.MkdirAll(configFileFileDir, 0700)
 			if errDir != nil {
 				log.Fatalln(err)
 			}
@@ -115,7 +115,11 @@ func SetAlias(name string, command string) {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		f.Close()
+
+		err = f.Close()
+		if err != nil {
+			log.Println(err)
+		}
 	}
 
 	contents, err := ioutil.ReadFile(aliasFile)

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -10,6 +10,15 @@ import (
 // glab environment cache: <file: <key: value>>
 var envCache map[string]map[string]string
 
+// CheckFileExists : checks if a file exists and is not a directory.
+func CheckFileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
 // ReadAndAppend : appends string to file
 func ReadAndAppend(file, text string) {
 	// If the file doesn't exist, create it, or append to the file


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
It would be nice if a user could create aliases for long commands that they use a lot. The changes made will be based upon the [GitHub CLI](https://cli.github.com/manual/gh_alias_set) format.

**Related Issue**
#108 

**Motivation and Context**
This makes long commands easier to use.

**How Has This Been Tested?**
See screenshot below:
![image](https://user-images.githubusercontent.com/32489229/90878756-d5873500-e39d-11ea-8e23-b9ce9dc3a18a.png)


**Screenshots (if appropriate):**

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
