### PR TITLE
refactor: Redirect all list printing to common utility 

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -29,7 +29,7 @@ func displayAllIssues(m []*gitlab.Issue) {
 				return issue.Title
 			case 2:
 				if len(issue.Labels) > 0 {
-					return fmt.Sprintf("(%s)", strings.Trim(strings.Join(issue.Labels, ", "), ","))
+					return color.Cyan.Sprintf("(%s)", strings.Trim(strings.Join(issue.Labels, ", "), ","))
 				}
 				return ""
 			case 3:

--- a/commands/release.go
+++ b/commands/release.go
@@ -2,13 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"glab/internal/git"
 	"glab/internal/utils"
 
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
 
-	"github.com/gosuri/uitable"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -18,21 +16,28 @@ func displayRelease(r *gitlab.Release) {
 }
 
 func displayAllReleases(rs []*gitlab.Release) {
-	if len(rs) > 0 {
-
-		table := uitable.New()
-		table.MaxColWidth = 70
-		fmt.Println()
-		fmt.Printf("Showing releases %d of %d on %s\n\n", len(rs), len(rs), git.GetRepo())
-		for _, r := range rs {
-			duration := utils.TimeToPrettyTimeAgo(*r.CreatedAt)
-			author := fmt.Sprintf("%s (%s)", r.Author.Name, r.Author.Username)
-			table.AddRow(r.Name, r.TagName, author, r.Description, duration)
-		}
-		fmt.Println(table)
-	} else {
-		fmt.Println("No releases available on " + git.GetRepo())
-	}
+	DisplayList(ListInfo{
+		Name:    "releases",
+		Columns: []string{"Name", "TagName", "Author", "Description", "CreatedAt"},
+		Total:   len(rs),
+		GetCellValue: func(ri int, ci int) interface{} {
+			row := rs[ri]
+			switch ci {
+			case 0:
+				return row.Name
+			case 1:
+				return row.TagName
+			case 2:
+				return fmt.Sprintf("%s (%s)", row.Author.Name, row.Author.Username)
+			case 3:
+				return row.Description
+			case 4:
+				return utils.TimeToPrettyTimeAgo(*row.CreatedAt)
+			default:
+				return ""
+			}
+		},
+	})
 }
 
 // releaseCmd is release command


### PR DESCRIPTION
Define a common utility for list printing. And redirect all list printing to this to have control of printing lists at once place.

**Description**
Having one utility to print lists on console is necessary to maintain consistent outputs across all commands. And easy to tryout and switch to better library to print lists.
The utility "DisplayList" takes care of printing table along with empty messages and short description of the results.

**How Has This Been Tested?**
Verified listing of all effected commands.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
