### PR TITLE
chore: Add benchmark to env config loading from FS

### DIFF
--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -1,0 +1,9 @@
+package config
+
+import "testing"
+
+func BenchmarkGetEnv(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		GetKeyValueInFile(configFile, "foo")
+	}
+}


### PR DESCRIPTION
Add a benckmark to evaluate performance of config `GetKeyValueInFile`

**Related Issue**
#144 

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
Improves the overall performance of the command when environment provided through file.

**How Has This Been Tested?**
`go test -bench=. --count=5`

**Screenshots (if appropriate):**
Current results:
```
BenchmarkGetEnv-4   	   50974	     23479 ns/op	     816 B/op	       6 allocs/op
BenchmarkGetEnv-4   	   51392	     23192 ns/op	     816 B/op	       6 allocs/op
BenchmarkGetEnv-4   	   51847	     24126 ns/op	     816 B/op	       6 allocs/op
BenchmarkGetEnv-4   	   51861	     23541 ns/op	     816 B/op	       6 allocs/op
BenchmarkGetEnv-4   	   51854	     23891 ns/op	     816 B/op	       6 allocs/op
```
OS: Windows 10

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
