### PR TITLE
Root commands flags not documented (in generated docs)

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -59,7 +59,6 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root command.
 func Execute() (*cobra.Command, error) {
-	RootCmd.Flags().BoolP("version", "v", false, "show glab version information")
 	return RootCmd.ExecuteC()
 }
 
@@ -82,6 +81,7 @@ var configCmd = &cobra.Command{
 }
 
 func init() {
+	RootCmd.Flags().BoolP("version", "v", false, "show glab version information")
 	RootCmd.AddCommand(updateCmd)
 	initConfigCmd()
 	RootCmd.AddCommand(configCmd)

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 )
 
-// glab environment cache: <file: <key: value>>
-var envCache map[string]map[string]string
-
 // ReadAndAppend : appends string to file
 func ReadAndAppend(file, text string) {
 	// If the file doesn't exist, create it, or append to the file
@@ -25,37 +22,23 @@ func ReadAndAppend(file, text string) {
 	}
 }
 
-func readConfig(filePath string) map[string]string {
-	var config = make(map[string]string)
+// GetKeyValueInFile : returns env variable value
+func GetKeyValueInFile(filePath, key string) string {
 	data, _ := ioutil.ReadFile(filePath)
+
 	file := string(data)
+	line := 0
 	temp := strings.Split(file, "\n")
 	for _, item := range temp {
 		//fmt.Println("[",line,"]",item)
 		env := strings.Split(item, "=")
-		if len(env) > 1 {
-			config[env[0]] = env[1]
+		if env[0] == key {
+			if len(env) > 1 {
+				return env[1]
+			}
+			return "OK"
 		}
-	}
-	return config
-}
-
-// GetKeyValueInFile : returns env variable value
-func GetKeyValueInFile(filePath, key string) string {
-	configCache, okConfig := envCache[filePath]
-	if !okConfig {
-		configCache = readConfig(filePath)
-		if envCache == nil {
-			envCache = make(map[string]map[string]string)
-		}
-		envCache[filePath] = configCache
-	}
-
-	if cachedEnv, okEnv := configCache[key]; okEnv {
-		if cachedEnv == "" {
-			cachedEnv = "OK"
-		}
-		return cachedEnv
+		line++
 	}
 	return "NOTFOUND"
 }


### PR DESCRIPTION
Root command flags like `version` were not generated since those were registered on execution.

Register them on init to get considered in docs generation.

**How Has This Been Tested?**
`glab -v`

**Screenshots (if appropriate):**
Current root options doesn't display version flag, only listing default help flag:
![image](https://user-images.githubusercontent.com/6123002/90769114-577b4d80-e30d-11ea-8154-9d7648fea3c4.png)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
