### PR TITLE
fix: Root commands flags not documented (in generated docs)

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -59,7 +59,6 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root command.
 func Execute() (*cobra.Command, error) {
-	RootCmd.Flags().BoolP("version", "v", false, "show glab version information")
 	return RootCmd.ExecuteC()
 }
 
@@ -82,6 +81,7 @@ var configCmd = &cobra.Command{
 }
 
 func init() {
+	RootCmd.Flags().BoolP("version", "v", false, "show glab version information")
 	RootCmd.AddCommand(updateCmd)
 	initConfigCmd()
 	RootCmd.AddCommand(configCmd)


### PR DESCRIPTION
Root command flags like `version` were not generated since those were registered on execution.

Register them on init to get considered in docs generation.

**How Has This Been Tested?**
`glab -v`

**Screenshots (if appropriate):**
Current root options doesn't display version flag, only listing default help flag:
![image](https://user-images.githubusercontent.com/6123002/90769114-577b4d80-e30d-11ea-8154-9d7648fea3c4.png)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
