### PR TITLE
feat: label auto completion

### DIFF
--- a/commands/issue_create.go
+++ b/commands/issue_create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
+	"glab/internal/config"
 	"glab/internal/git"
 	"glab/internal/manip"
 )
@@ -46,7 +47,13 @@ var issueCreateCmd = &cobra.Command{
 		if label, _ := cmd.Flags().GetString("label"); label != "" {
 			issueLabel = strings.Trim(label, "[] ")
 		} else {
-			issueLabel = manip.AskQuestionWithInput("Label(s) [Comma Separated]", "", false)
+			labelsEntry := config.GetEnv("PROJECT_LABELS")
+			if labelsEntry != "" {
+				labels := strings.Split(labelsEntry, ",")
+				issueLabel = strings.Join(manip.AskQuestionWithMultiSelect("Label(s)", labels), ",")
+			} else {
+				issueLabel = manip.AskQuestionWithInput("Label(s) [Comma Separated]", "", false)
+			}
 		}
 		l.Title = gitlab.String(issueTitle)
 		l.Labels = &gitlab.Labels{issueLabel}

--- a/commands/label_list.go
+++ b/commands/label_list.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
+	"glab/internal/config"
 	"glab/internal/git"
 	"strings"
 )
@@ -41,6 +42,17 @@ func listLabels(cmd *cobra.Command, args []string) {
 	for _, label := range labels {
 		color.HEX(strings.Trim(label.Color, "#")).Printf("#%d %s\n", label.ID, label.Name)
 	}
+
+	// Cache labels if local configuration is used
+	if !config.UseGlobalConfig {
+		labelNames := make([]string, 0, len(labels))
+		for _, label := range labels {
+			labelNames = append(labelNames, label.Name)
+		}
+		labelsEntry := strings.Join(labelNames, ",")
+		config.SetEnv("PROJECT_LABELS", labelsEntry)
+	}
+
 }
 
 func init() {

--- a/internal/manip/manip.go
+++ b/internal/manip/manip.go
@@ -51,6 +51,19 @@ func AskQuestionWithInput(question, defaultVal string, isRequired bool) string {
 	return str
 }
 
+func AskQuestionWithMultiSelect(question string, options []string) []string {
+	labels := []string{}
+	prompt := &survey.MultiSelect{
+		Message: question,
+		Options: options,
+	}
+	err := survey.AskOne(prompt, &labels)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return labels
+}
+
 func AskQuestionMultiline(question string, defaultVal string) string {
 	str := ""
 	prompt := &survey.Multiline{


### PR DESCRIPTION
- Adds auto-completition for the label prompt during issue creation
- Adds caching of labels during `$ glab label list` if local configuration is enabled

## Usage

#### Create an issue with normal label prompt

At this point, nothing is cached.

```bash
$ glab issue new -t "title" -d "description"
? Label(s) [Comma Separated] Label1, Label2
#36 title (less than a minute ago)
...
```
#### Retrieve a label list

Retrieving a list of labels will store them, comma-separated under key `PROJECT_LABELS` in `.glab-cli/config/.env`.

```bash
$ glab label list
Showing label 2 of 2 on XXX/YYY
#67 Label1
#68 Label2
```
#### Next time we create an issue, we can select from the list of cached labels.

```bash
$ glab issue new -t "title" -d "description"
? Label(s)  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [ ]  Label1
  [ ]  Label2
...
```

##  Questions

- [x] How to deal with *new labels* when prompting via multi select? => Users should use the `-l` command line option to specify *new labels*.
- [x] Does Gitlab allow label names to contain commas? => **no**, thus no problem in storing them comma-separated