### PR TITLE
fix: Migrate config dir to XDG_CONFIG_HOME

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -10,6 +10,13 @@ import (
 // glab environment cache: <file: <key: value>>
 var envCache map[string]map[string]string
 
+func CheckPathExists(path string) bool {
+	if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+		return true
+	}
+	return false
+}
+
 // CheckFileExists : checks if a file exists and is not a directory.
 func CheckFileExists(filename string) bool {
 	info, err := os.Stat(filename)


### PR DESCRIPTION
**Note: bugfix included**
While doing this a bug in the original code was spotted where the
wrong error variable would be printed on a fatal error:

```
-                               log.Fatalln(err)
+                               log.Fatalln(errDir)
```

**Related Issue**

Fixes #186

**Motivation and Context**

Using the legacy scheme of every application putting files in the users home directory where ever they preferred caused alot of clutter and no consistency. For example erasing all cache files to free up disk space and/or backing up (only) config files would require intimate knowledge of every applications way to save their files. XDG Base Dir Specification was created to solve these issues. With the changes included here we migrate the old files over to use the XDG Base Dir spec location and use it.

**How Has This Been Tested?**

Only this trivial test was performed (using the new code, creating a config file, manually moving the file back to the old location, then triggering a migration):

```
make build
./bin/glab --global config
mkdir -p ~/.glab-cli/config
mv ~/.config/glab-cli/.env ~/.glab-cli/config/
rmdir ~/.config/glab-cli

./bin/glab --help 2>&1 | head -n 1

ls -lRa ~/.glab-cli/ ~/.config/glab-cli/
```

Note: no alias file testing has been done. Help with further testing welcome!