### PR TITLE
fix(config): Make SetEnv invalidate cache used by GetEnv

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,9 @@ func SetEnv(key, value string) {
 	if UseGlobalConfig {
 		cFile = globalConfigFile
 	}
+
+	defer InvalidateEnvCacheForFile(cFile)
+
 	data, _ := ioutil.ReadFile(cFile)
 
 	file := string(data)

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -56,6 +56,11 @@ func readConfig(filePath string) map[string]string {
 	return config
 }
 
+// InvalidateEnvCacheForFile : Invalidates the cached content of a file used by eg. GetKeyValueInFile
+func InvalidateEnvCacheForFile(filePath string) {
+	delete(envCache, filePath)
+}
+
 // GetKeyValueInFile : returns env variable value
 func GetKeyValueInFile(filePath, key string) string {
 	configCache, okConfig := envCache[filePath]


### PR DESCRIPTION
The golden rule about caches is that if there's no way
to invalidate them then they're broken...

And indeed if config.SetEnv("foo", ...) is called followed
by config.GetEnv("foo") then you'll get the old value (when
both read/write from the same file). And example of this
is on clean start where initConfig sets up the default
values for missing/empty env vars.

A testcase for this:

```
rm -rf ~/.config/glab-cli/ .glab-cli/config/.env

./bin/glab config --global
```

Before this patch it would say:

```
? Enter default Gitlab Host (Current Value: ):
```

After patch it correctly lists the default/current value
as set by initConfig():

```
? Enter default Gitlab Host (Current Value: https://gitlab.com):
```
