### PR TITLE
fix(config): SetEnv appends to gitignore every time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ func SetEnv(key, value string) {
 	w := bufio.NewWriter(f)
 	_, _ = w.WriteString(strings.Trim(newData, "\n"))
 	_ = w.Flush()
-	if !CheckFileHasLine(".gitignore", configFileFileParentDir) {
+	if !UseGlobalConfig && !CheckFileHasLine(".gitignore", configFileFileParentDir) {
 		ReadAndAppend(".gitignore", configFileFileParentDir)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ func SetEnv(key, value string) {
 	w := bufio.NewWriter(f)
 	_, _ = w.WriteString(strings.Trim(newData, "\n"))
 	_ = w.Flush()
-	if GetKeyValueInFile(".gitignore", configFileFileParentDir) == "NOTFOUND" {
+	if !CheckFileHasLine(".gitignore", configFileFileParentDir) {
 		ReadAndAppend(".gitignore", configFileFileParentDir)
 	}
 }

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bufio"
 	"io/ioutil"
 	"log"
 	"os"
@@ -24,6 +25,26 @@ func CheckFileExists(filename string) bool {
 		return false
 	}
 	return !info.IsDir()
+}
+
+// CheckFileHasLine : returns true if line exists in file, otherwise false (also for non-existant file).
+func CheckFileHasLine(filePath, line string) bool {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	fs := bufio.NewScanner(f)
+	fs.Split(bufio.ScanLines)
+
+	for fs.Scan() {
+		if fs.Text() == line {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ReadAndAppend : appends string to file


### PR DESCRIPTION
**Description**
This change fixes so that my .gitignore doesn't grow an additional ".glab-cli" line every time I run the command (which thus far has been only to test `./bin/glab config --global`).

**How Has This Been Tested?**
I've run `rm -rf ~/.config/glab-cli ; ./bin/glab config --global` under the following circumstances and observed the behaviour:
* Default `.gitignore` already containing `.glab-cli` -> without fix: .glab-cli appended to .gitignore twice(!) -> with fix: no change of .gitignore file
* Both(!) occurances of `.glab-cli` removed from `.gitignore` -> without fix: .glab-cli appended to .gitignore twice(!) -> with fix: .glab-cli appended to .gitignore
* With `.gitignore` file removed -> without fix: .gitignore created and .glab-cli appended to .gitignore twice(!) -> with fix: .gitignore created and .glab-cli appended to .gitignore

Note: testing was done *before* the second commit, obviously using --global flag for test would not be useful.