### PR TITLE
fix: File content modification made a bit more safe and sane

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gdamore/tcell v1.4.0
+	github.com/google/renameio v0.1.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gookit/color v1.2.9
 	github.com/gosuri/uilive v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f h1:5CjVwnuUcp5adK4gmY6i72gpVFVnZDP2h5TmPScB6u4=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
+github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
+github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/gookit/color v1.2.9 h1:1gwRqF/u6wZrxzn+thlROF7D4Toi9eVGUidZNAxAZHE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,7 +165,7 @@ func SetEnv(key, value string) {
 	}
 
 	if !UseGlobalConfig && !CheckFileHasLine(".gitignore", configFileFileParentDir) {
-		ReadAndAppend(".gitignore", configFileFileParentDir)
+		ReadAndAppend(".gitignore", configFileFileParentDir + "\n")
 	}
 }
 

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -54,7 +54,7 @@ func ReadAndAppend(file, text string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if _, err := f.Write([]byte("\n" + text)); err != nil {
+	if _, err := f.Write([]byte(text)); err != nil {
 		log.Fatal(err)
 	}
 	if err := f.Close(); err != nil {


### PR DESCRIPTION
**Description**
Atomically replace file that was previously truncated and then modified content written out again (without any error handling). New code also does some basic error handling. Replacing the old code with using renameio.WriteFile instead also got rid of the missing/implicit file Close(). See commit message for futher details!

While at it also fix up the ReadAndAppend method usage and implementation that is used to extent .gitignore so that it behaves better with regard to newline handling.

**Testing**
Some trivial manual testing has been done to try to verify the code works as expected, but could certainly be better and more extensively.