### PR TITLE
fix(config): use ioutil.WriteFile instead of renameio

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f h1:5CjVwnuUcp5adK4gmY6i72gpVFVnZDP2h5TmPScB6u4=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
-github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
-github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/gookit/color v1.2.9 h1:1gwRqF/u6wZrxzn+thlROF7D4Toi9eVGUidZNAxAZHE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/profclems/glab/internal/manip"
 
-	"github.com/google/renameio"
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/tcnksm/go-gitconfig"
@@ -159,7 +158,7 @@ func SetEnv(key, value string) {
 		newData += newConfig
 	}
 	_ = os.MkdirAll(filepath.Join(cFile, ".."), 0755)
-	if err = renameio.WriteFile(cFile, []byte(newData), 0666); err != nil {
+	if err = ioutil.WriteFile(cFile, []byte(newData), 0600); err != nil {
 		log.Println("Failed to update config file:", err)
 		return
 	}


### PR DESCRIPTION
As reported apparently renameio does not work on windows and there's
no obvious way to even make an atomic file overwrite on windows at all,
thus renameio is looking at dropping Windows support.

This change simply switches to ioutil.WriteFile which is not atomic
but the code should still be nicer than the previous one we replaced.

While at it also cut down on the readability part of the files
permissions as the config file could contain sensitive information
(like the token).

Fixes #210