### PR TITLE
fix(config): Use ioutil.WriteFile on Windows

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/profclems/glab/internal/manip"
 
-	"github.com/google/renameio"
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/tcnksm/go-gitconfig"
@@ -159,7 +158,7 @@ func SetEnv(key, value string) {
 		newData += newConfig
 	}
 	_ = os.MkdirAll(filepath.Join(cFile, ".."), 0755)
-	if err = renameio.WriteFile(cFile, []byte(newData), 0666); err != nil {
+	if err = WriteFile(cFile, []byte(newData), 0600); err != nil {
 		log.Println("Failed to update config file:", err)
 		return
 	}

--- a/internal/config/writefile.go
+++ b/internal/config/writefile.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package config
+
+import (
+	"os"
+
+	"github.com/google/renameio"
+)
+
+func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return renameio.WriteFile(filename, data, perm)
+}

--- a/internal/config/writefile_windows.go
+++ b/internal/config/writefile_windows.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"os"
+	"io/ioutil"
+)
+
+// Note: this is not atomic, but apparently there's no way to atomically
+//       replace a file on windows which is why renameio doesn't support
+//       windows.
+func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}


### PR DESCRIPTION
As reported renameio doesn't work on Windows and apparently there's
no way to do atomic file replace on Windows.

We thus create a helper function in a separate file that uses renameio
but say it should not be built on windows, then hook in a windows-
specific implementation of that function which uses ioutil.WriteFile
which is not safe but gets the job done.

While at it also tighten up the permissions on the config file as
it might contain sensitive information (like the token).

Fixes #210