### PR TITLE
feat: add ability to set git protocol

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -89,10 +89,13 @@ func initConfig() {
 	config.UseGlobalConfig = true
 
 	if config.GetEnv("GITLAB_URI") == "" {
-		config.SetEnv("GITLAB_URI", "https://gitlab.com")
+		_ = config.SetEnv("GITLAB_URI", "https://gitlab.com")
 	}
 	if config.GetEnv("GIT_REMOTE_URL_VAR") == "" {
-		config.SetEnv("GIT_REMOTE_URL_VAR", "origin")
+		_ = config.SetEnv("GIT_REMOTE_URL_VAR", "origin")
+	}
+	if config.GetEnv("GIT_PROTOCOL") == "" {
+		_ = config.SetEnv("GIT_PROTOCOL", "ssh")
 	}
 
 	config.UseGlobalConfig = false

--- a/commands/project.go
+++ b/commands/project.go
@@ -7,7 +7,7 @@ import (
 )
 
 func getProject(projectID interface{}) (*gitlab.Project, error) {
-	gitlabClient, _ := git.InitGitlabClient()
+	gitlabClient, _ := git.InitGitlabClient(false)
 	opts := &gitlab.GetProjectOptions{
 		Statistics:           gitlab.Bool(true),
 		License:              gitlab.Bool(true),

--- a/commands/project_create.go
+++ b/commands/project_create.go
@@ -137,11 +137,15 @@ func runCreateProject(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		fmt.Fprintf(out, "%s Created repository %s on GitLab: %s\n", greenCheck, project.NameWithNamespace, project.WebURL)
 		if isPath {
-			_, err := git.AddRemote("origin", project.SSHURLToRepo)
+			remote, err := gitRemoteURL(project, &remoteArgs{})
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(out, "%s Added remote %s\n", greenCheck, project.SSHURLToRepo)
+			_, err = git.AddRemote("origin", remote)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "%s Added remote %s\n", greenCheck, remote)
 
 		} else if isTTY {
 			doSetup, err := manip.Confirm(fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace))

--- a/commands/repo_clone.go
+++ b/commands/repo_clone.go
@@ -42,7 +42,6 @@ var repoCloneCmd = &cobra.Command{
 		)
 
 		repo := args[0]
-		fmt.Println(repo)
 		u, _ := currentUser()
 		if !git.IsValidURL(repo) {
 			// Assuming that repo is a project ID if it is an integer

--- a/commands/repo_clone.go
+++ b/commands/repo_clone.go
@@ -83,6 +83,9 @@ var repoCloneCmd = &cobra.Command{
 					return err
 				}
 				repoURL, err := gitRemoteURL(fProject, &remoteArgs{})
+				if err != nil {
+					return err
+				}
 				err = git.AddUpstreamRemote(repoURL, dir)
 				if err != nil {
 					return err

--- a/commands/repo_clone.go
+++ b/commands/repo_clone.go
@@ -55,7 +55,10 @@ var repoCloneCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			repo = project.SSHURLToRepo
+			repo, err = gitRemoteURL(project, &remoteArgs{})
+			if err != nil {
+				return err
+			}
 		} else if !strings.HasSuffix(repo, ".git") {
 			repo += ".git"
 		}
@@ -79,7 +82,8 @@ var repoCloneCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				err = git.AddUpstreamRemote(fProject.SSHURLToRepo, dir)
+				repoURL, err := gitRemoteURL(fProject, &remoteArgs{})
+				err = git.AddUpstreamRemote(repoURL, dir)
 				if err != nil {
 					return err
 				}

--- a/commands/root.go
+++ b/commands/root.go
@@ -185,18 +185,19 @@ func DisplayList(lInfo ListInfo, repo ...string) {
 	}
 
 }
+
 type remoteArgs struct {
 	protocol string
-	token	 string
-	url		 string
+	token    string
+	url      string
 	username string
 }
 
-// gitRemoteURL returns correct git clone URL of a repo 
+// gitRemoteURL returns correct git clone URL of a repo
 // based on the user's git_protocol preference
 // args should be arranged as protocol, token, url, username
 
-func gitRemoteURL(project *gitlab.Project, args *remoteArgs) (string, error)  {
+func gitRemoteURL(project *gitlab.Project, args *remoteArgs) (string, error) {
 	var err error
 
 	if args.protocol == "" {

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -204,19 +204,19 @@ func Test_gitRemoteURL(t *testing.T) {
 		args    args
 		want    string
 		wantErr bool
-	} {
+	}{
 		{
 			name: "is_https",
 			args: args{
 				project: &gitlab.Project{
-					SSHURLToRepo: "git@gitlab.com:profclems/glab.git",
-					HTTPURLToRepo: "https://gitlab.com/profclems/glab.git",
+					SSHURLToRepo:      "git@gitlab.com:profclems/glab.git",
+					HTTPURLToRepo:     "https://gitlab.com/profclems/glab.git",
 					PathWithNamespace: "profclems/glab",
 				},
 				args: &remoteArgs{
 					protocol: "https",
-					token: "token",
-					url: "https://gitlab.com",
+					token:    "token",
+					url:      "https://gitlab.com",
 					username: "user",
 				},
 			},

--- a/commands/user.go
+++ b/commands/user.go
@@ -9,7 +9,7 @@ import (
 )
 
 func currentUser() (string, error) {
-	gLab, _ := git.InitGitlabClient()
+	gLab, _ := git.InitGitlabClient(false)
 	u, _, err := gLab.Users.CurrentUser()
 	if err != nil {
 		return "", err
@@ -18,7 +18,7 @@ func currentUser() (string, error) {
 }
 
 func getUser(uid int) (*gitlab.User, error) {
-	gLab, _ := git.InitGitlabClient()
+	gLab, _ := git.InitGitlabClient(false)
 	u, _, err := gLab.Users.GetUser(uid)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func getUsername(uid int) string {
 }
 
 func getUserActivities() ([]*gitlab.UserActivity, error) {
-	gLab, _ := git.InitGitlabClient()
+	gLab, _ := git.InitGitlabClient(false)
 	l := &gitlab.GetUserActivitiesOptions{}
 	ua, _, err := gLab.Users.GetUserActivities(l)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9 // indirect
 	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200911040025-d179df38ff46 // indirect
+	golang.org/x/tools v0.0.0-20200911193555-6422fca01df9 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ golang.org/x/tools v0.0.0-20200910222312-571a207697e7 h1:SJWJaZU+0cpPpc8YPrjwTiN
 golang.org/x/tools v0.0.0-20200910222312-571a207697e7/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20200911040025-d179df38ff46 h1:raJJRwvMVMFKqxzg7RylyOftEg8WyqM4BjTmQyG+U48=
 golang.org/x/tools v0.0.0-20200911040025-d179df38ff46/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20200911193555-6422fca01df9 h1:M8mz5B5dntyYZSIscpClTVyMIJbg6kKKIyysZM++kf8=
+golang.org/x/tools v0.0.0-20200911193555-6422fca01df9/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -83,12 +83,20 @@ func init() {
 // TODO: GetDefaultBranch looks really messy and should be fixed properly
 
 // GetDefaultBranch finds the repo's default branch
+// Expects a maximum of two params with the first as remote and second as username
 func GetDefaultBranch(remote ...string) (string, error) {
 	var org string
+	var currentUser string
 	if len(remote) > 0 {
 		org = remote[0]
+		if len(remote) > 1 {
+			currentUser = remote[1]
+		}
 	} else {
 		org = config.GetEnv("GIT_REMOTE_URL_VAR")
+	}
+	if currentUser == "" {
+		currentUser = "oauth2"
 	}
 	if strings.Contains(org, "/") {
 		t := config.GetEnv("GITLAB_TOKEN")
@@ -100,8 +108,8 @@ func GetDefaultBranch(remote ...string) (string, error) {
 			u = strings.TrimPrefix(u, "http://")
 			p = "http://"
 		}
-		org = fmt.Sprintf("%soauth2:%s@%s/%s.git",
-			p, t, u, org)
+		org = fmt.Sprintf("%s%s:%s@%s/%s.git",
+			p, currentUser, t, u, org)
 	}
 	getDefBranch := exec.Command("git",
 		"remote", "show", org)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Following #219, users should be able to set the git protocol that `glab` should use for git operations. Defaults to ssh

**Related Issue**
#219 
Also fixes #198 

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
