### PR TITLE
feat: add `mr list` flag `mine`

### DIFF
--- a/commands/mr_list.go
+++ b/commands/mr_list.go
@@ -47,6 +47,10 @@ func listMergeRequest(cmd *cobra.Command, args []string) error {
 		l.PerPage = p
 	}
 
+	if mine, _ := cmd.Flags().GetBool("mine"); mine {
+		l.Scope = gitlab.String("assigned_to_me")
+	}
+
 	gitlabClient, repo := git.InitGitlabClient()
 	if r, _ := cmd.Flags().GetString("repo"); r != "" {
 		repo, _ = fixRepoNamespace(r)
@@ -68,5 +72,6 @@ func init() {
 	mrListCmd.Flags().BoolP("merged", "m", false, "Get only merged merge requests")
 	mrListCmd.Flags().IntP("page", "p", 1, "Page number")
 	mrListCmd.Flags().IntP("per-page", "P", 20, "Number of items to list per page")
+	mrListCmd.Flags().BoolP("mine", "", false, "Get only merge requests assigned to me")
 	mrCmd.AddCommand(mrListCmd)
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

**Description**
Add flag `mine` that allows filtering merge request that only are
assigned to the user.
This uses the `scope` option of the merge request API, using the v11
snake_case version in favor of the kebab-case which is deprecated.
See more:
https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/18935
https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#167 
**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on some of my private repos on gitlab.com and it workd just fine :) 

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
