### PR TITLE
style: Remove additional newline after version output

### DIFF
--- a/commands/version/version.go
+++ b/commands/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewCmdVersion(version, build string) *cobra.Command {
-	versionOutput := fmt.Sprintf("glab %s (%s)\n", version, build)
+	versionOutput := fmt.Sprintf("glab %s (%s)", version, build)
 	var versionCmd = &cobra.Command{
 		Use:     "version",
 		Short:   "show glab version information",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
`Fprintln` on Line 17 and `Sprintf` on Line 10 lead to two newlines after the version output

**Related Issue**
https://github.com/profclems/glab/issues/234

**Motivation and Context**
The intention is to standardize the version output.

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
