### PR TITLE
feat: Add Update Sub-command to Issue Command

### DIFF
--- a/commands/issue/issue.go
+++ b/commands/issue/issue.go
@@ -11,6 +11,7 @@ import (
 	issueSubscribeCmd "github.com/profclems/glab/commands/issue/subscribe"
 	issueUnsubscribeCmd "github.com/profclems/glab/commands/issue/unsubscribe"
 	issueViewCmd "github.com/profclems/glab/commands/issue/view"
+  issueUpdateCmd "github.com/profclems/glab/commands/issue/update"
 
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,7 @@ func NewCmdIssue(f *cmdutils.Factory) *cobra.Command {
 	issueCmd.AddCommand(issueViewCmd.NewCmdView(f))
 	issueCmd.AddCommand(issueSubscribeCmd.NewCmdSubscribe(f))
 	issueCmd.AddCommand(issueUnsubscribeCmd.NewCmdUnsubscribe(f))
+	issueCmd.AddCommand(issueUpdateCmd.NewCmdUpdate(f))
 	issueCmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the OWNER/REPO format or the project ID. Supports group namespaces")
 	return issueCmd
 }

--- a/commands/issue/issue.go
+++ b/commands/issue/issue.go
@@ -11,7 +11,7 @@ import (
 	issueSubscribeCmd "github.com/profclems/glab/commands/issue/subscribe"
 	issueUnsubscribeCmd "github.com/profclems/glab/commands/issue/unsubscribe"
 	issueViewCmd "github.com/profclems/glab/commands/issue/view"
-  issueUpdateCmd "github.com/profclems/glab/commands/issue/update"
+	issueUpdateCmd "github.com/profclems/glab/commands/issue/update"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -59,10 +59,13 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			if m, _ := cmd.Flags().GetStringArray("unlabel"); len(m) != 0 {
 				l.RemoveLabels = gitlab.Labels(m)
 			}
+			fmt.Fprintln(out, fmt.Sprintf("- Updating issue #%d", issueID))
 			issue, err := api.UpdateIssue(apiClient, repo.FullName(), issueID, l)
 			if err != nil {
 				return err
 			}
+
+			fmt.Fprintln(out, utils.GreenCheck(), "Updated")
 
 			fmt.Fprintln(out, issueutils.DisplayIssue(issue))
 			return nil

--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -1,0 +1,79 @@
+package update
+
+import (
+	"fmt"
+
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
+	var issueUpdateCmd = &cobra.Command{
+		Use:   "update <id>",
+		Short: `Update issue`,
+		Long:  ``,
+		Example: heredoc.Doc(`
+	$ glab issue update 42 --label ui,ux
+	$ glab issue update 42 --unlabel working
+	`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			out := utils.ColorableOut(cmd)
+			if r, _ := cmd.Flags().GetString("repo"); r != "" {
+				f, err = f.NewClient(r)
+				if err != nil {
+					return err
+				}
+			}
+			apiClient, err := f.HttpClient()
+			if err != nil {
+				return err
+			}
+			repo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+
+			issueID := utils.StringToInt(args[0])
+			l := &gitlab.UpdateIssueOptions{}
+
+			if m, _ := cmd.Flags().GetString("title"); m != "" {
+				l.Title = gitlab.String(m)
+			}
+			if m, _ := cmd.Flags().GetBool("lock-discussion"); m {
+				l.DiscussionLocked = gitlab.Bool(m)
+			}
+			if m, _ := cmd.Flags().GetString("description"); m != "" {
+				l.Description = gitlab.String(m)
+			}
+			if m, _ := cmd.Flags().GetStringArray("label"); len(m) != 0 {
+				l.AddLabels = gitlab.Labels(m)
+			}
+			if m, _ := cmd.Flags().GetStringArray("unlabel"); len(m) != 0 {
+				l.RemoveLabels = gitlab.Labels(m)
+			}
+			issue, err := api.UpdateIssue(apiClient, repo.FullName(), issueID, l)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out, issueutils.DisplayIssue(issue))
+			return nil
+		},
+	}
+
+	issueUpdateCmd.Flags().StringP("title", "t", "", "Title of merge request")
+	issueUpdateCmd.Flags().BoolP("lock-discussion", "", false, "Lock discussion on merge request")
+	issueUpdateCmd.Flags().StringP("description", "d", "", "merge request description")
+	issueUpdateCmd.Flags().StringArrayP("label", "l", []string{}, "add labels")
+	issueUpdateCmd.Flags().StringArrayP("unlabel", "u", []string{}, "remove labels")
+
+	return issueUpdateCmd
+}

--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -69,9 +69,9 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 		},
 	}
 
-	issueUpdateCmd.Flags().StringP("title", "t", "", "Title of merge request")
-	issueUpdateCmd.Flags().BoolP("lock-discussion", "", false, "Lock discussion on merge request")
-	issueUpdateCmd.Flags().StringP("description", "d", "", "merge request description")
+	issueUpdateCmd.Flags().StringP("title", "t", "", "Title of issue")
+	issueUpdateCmd.Flags().BoolP("lock-discussion", "", false, "Lock discussion on issue")
+	issueUpdateCmd.Flags().StringP("description", "d", "", "Issue description")
 	issueUpdateCmd.Flags().StringArrayP("label", "l", []string{}, "add labels")
 	issueUpdateCmd.Flags().StringArrayP("unlabel", "u", []string{}, "remove labels")
 

--- a/commands/issue/update/issue_update_test.go
+++ b/commands/issue/update/issue_update_test.go
@@ -1,0 +1,108 @@
+package update
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/google/shlex"
+	"testing"
+	"time"
+
+	"github.com/acarl005/stripansi"
+	"github.com/profclems/glab/commands/cmdtest"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestNewCmdUpdate(t *testing.T) {
+	t.Parallel()
+
+	oldUpdateIssue := api.UpdateIssue
+	timer, _ := time.Parse(time.RFC3339, "2014-11-12T11:45:26.371Z")
+	testIssue := &gitlab.Issue{
+		ID:          1,
+		IID:         1,
+		State:       "closed",
+		Labels: 	 gitlab.Labels{"bug, test, removeable-label"},
+		Description: "Dummy description for issue 1",
+		DiscussionLocked: false,
+		Author: &gitlab.IssueAuthor{
+			ID:       1,
+			Name:     "John Dev Wick",
+			Username: "jdwick",
+		},
+		CreatedAt: &timer,
+	}
+	api.UpdateIssue = func(client *gitlab.Client, projectID interface{}, issueID int, opts *gitlab.UpdateIssueOptions) (*gitlab.Issue, error) {
+		if projectID == "" || projectID == "WRONG_REPO" || projectID == "expected_err" || issueID != testIssue.ID {
+			return nil, fmt.Errorf("error expected")
+		}
+		if *opts.Title != "" {
+			testIssue.Title = *opts.Title
+		}
+		if *opts.Description != "" {
+			testIssue.Description = *opts.Description
+		}
+		if opts.AddLabels != nil {
+			testIssue.Labels = opts.AddLabels
+		}
+		return testIssue, nil
+	}
+
+	testCases := []struct {
+		Name        string
+		Issue       string
+		ExpectedMsg []string
+		wantErr     bool
+	}{
+		{
+			Name:        "Issue Exists",
+			Issue:       `1 -t "New Title" -d "A new description" --lock-discussion -l newLabel --unlabel bug`,
+			ExpectedMsg: []string{"- Updating issue #1", "✓ Updated", "#1 New Title"},
+		},
+		{
+			Name:        "Issue Exists on different repo",
+			Issue:       `1 -R glab_cli/test`,
+			ExpectedMsg: []string{"- Updating issue #1", "✓ Updated"},
+		},
+		{
+			Name:        "Issue Does Not Exist",
+			Issue:       "0",
+			ExpectedMsg: []string{"- Updating issue #0", "error expected"},
+			wantErr:     true,
+		},
+	}
+
+	cmd := NewCmdUpdate(cmdtest.StubFactory("https://gitlab.com/glab-cli/test"))
+	cmd.Flags().StringP("repo", "R", "", "")
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			var stdout bytes.Buffer
+
+			args, _ := shlex.Split(tc.Issue)
+			cmd.SetArgs(args)
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			_, err := cmd.ExecuteC()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			out := stripansi.Strip(stdout.String())
+			//outErr := stripansi.Strip(stderr.String())
+
+			for _, msg := range tc.ExpectedMsg {
+				assert.Contains(t, out, msg)
+			}
+		})
+	}
+
+	api.UpdateIssue = oldUpdateIssue
+}


### PR DESCRIPTION
This PR will add `update` sub-command to `issue` command.
`update` sub-command edits gitlab issue.
Currently supported flags are:
* --label: add labels takes comma separated values
* --unlabel: remove labels takes comma separated values
* --title: update title of the issue
* --description: update descriptions of the issue
* --lock-discussion: lock comments takes boolean value

**Related Issue**
Addresses Issue #230 

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
