### PR TITLE
fix: glab pipeline list always says "No pipelines..."

### DIFF
--- a/commands/pipeline/pipelineutils/utils.go
+++ b/commands/pipeline/pipelineutils/utils.go
@@ -40,6 +40,8 @@ func DisplayMultiplePipelines(p []*gitlab.PipelineInfo, projectID string) string
 
 			pipelinePrint += fmt.Sprintf("%s\t%s\t%s\n", pipeState, pipeline.Ref, utils.Magenta("("+duration+")"))
 		}
+
+		return pipelinePrint
 	}
 
 	return "No Pipelines available on " + projectID


### PR DESCRIPTION
This commit fixes up previous commit 6c4fe1c2e82fd36f086b3
"Isolate commands into separate sub-packages (#229)"

**Description**
Before the `glab pipeline list` command would always result in:
`No Pipelines available on project/path`

**How Has This Been Tested?**
Running on a project path which I knew had pipelines. With the fix they show up.