### PR TITLE
feat: support "Run pipeline"

### DIFF
--- a/commands/pipeline/pipeline.go
+++ b/commands/pipeline/pipeline.go
@@ -6,6 +6,7 @@ import (
 	pipeDeleteCmd "github.com/profclems/glab/commands/pipeline/delete"
 	pipeListCmd "github.com/profclems/glab/commands/pipeline/list"
 	pipeStatusCmd "github.com/profclems/glab/commands/pipeline/status"
+	pipeRunCmd "github.com/profclems/glab/commands/pipeline/run"
 
 	"github.com/spf13/cobra"
 )
@@ -23,5 +24,6 @@ func NewCmdPipeline(f *cmdutils.Factory) *cobra.Command {
 	pipelineCmd.AddCommand(pipeDeleteCmd.NewCmdDelete(f))
 	pipelineCmd.AddCommand(pipeListCmd.NewCmdList(f))
 	pipelineCmd.AddCommand(pipeStatusCmd.NewCmdStatus(f))
+	pipelineCmd.AddCommand(pipeRunCmd.NewCmdRun(f))
 	return pipelineCmd
 }

--- a/commands/pipeline/run/pipeline_run.go
+++ b/commands/pipeline/run/pipeline_run.go
@@ -38,6 +38,7 @@ func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
 	var pipelineRunCmd = &cobra.Command{
 		Use:   "run [flags]",
 		Short: `Create a new pipeline run`,
+		Aliases: []string{"create"},
 		Example: heredoc.Doc(`
 	$ glab pipeline run
 	$ glab pipeline run -b trunk

--- a/commands/pipeline/run/pipeline_run.go
+++ b/commands/pipeline/run/pipeline_run.go
@@ -1,0 +1,97 @@
+package run
+
+import (
+	"fmt"
+
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/git"
+	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func getDefaultBranch(f *cmdutils.Factory) (string) {
+	repo, err := f.BaseRepo()
+	if err != nil {
+		return "master"
+	}
+
+	remotes, err := f.Remotes()
+	if err != nil {
+		return "master"
+	}
+
+	repoRemote, err := remotes.FindByRepo(repo.RepoOwner(), repo.RepoName())
+	if err != nil {
+		return "master"
+	}
+
+	branch, _ := git.GetDefaultBranch(repoRemote.Name)
+
+	return branch
+}
+
+func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
+	var pipelineRunCmd = &cobra.Command{
+		Use:   "run [flags]",
+		Short: `Create a new pipeline run`,
+		Example: heredoc.Doc(`
+	$ glab pipeline run
+	$ glab pipeline run -b trunk
+	`),
+		Long: ``,
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			out := utils.ColorableOut(cmd)
+			if r, _ := cmd.Flags().GetString("repo"); r != "" {
+				f, err = f.NewClient(r)
+				if err != nil {
+					return err
+				}
+			}
+			apiClient, err := f.HttpClient()
+			if err != nil {
+				return err
+			}
+			repo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+
+			// TODO: support setting pipeline variables via cli.
+			v := []*gitlab.PipelineVariable {
+				{
+					Key: "GLAB_CLI_KEY",
+					Value: "GLAB_CLI_VAL",
+					VariableType: "env_var",
+				},
+			}
+
+			c := &gitlab.CreatePipelineOptions{
+				Variables: v,
+			}
+
+			if m, _ := cmd.Flags().GetString("branch"); m != "" {
+				c.Ref = gitlab.String(m)
+			} else {
+				c.Ref = gitlab.String(getDefaultBranch(f))
+			}
+
+			pipe, err := api.CreatePipeline(apiClient, repo.FullName(), c)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(out, "Created pipeline (id:", pipe.ID, "), status:", pipe.Status,", ref:", pipe.Ref, ", weburl: ", pipe.WebURL, ")")
+			return nil
+		},
+	}
+	pipelineRunCmd.Flags().StringP("branch", "b", "", "Create pipeline on branch/ref <string>")
+
+	return pipelineRunCmd
+}

--- a/pkg/api/pipeline.go
+++ b/pkg/api/pipeline.go
@@ -315,3 +315,11 @@ var ListProjectPipelines = func(client *gitlab.Client, projectID interface{}, op
 	}
 	return pipes, nil
 }
+
+var CreatePipeline = func(client *gitlab.Client, projectID interface{}, opts *gitlab.CreatePipelineOptions) (*gitlab.Pipeline, error) {
+	if client == nil {
+		client = apiClient
+	}
+	pipe, _, err := client.Pipelines.CreatePipeline(projectID, opts)
+	return pipe, err
+}


### PR DESCRIPTION
**Description**

The API calls it "create pipeline", but the gitlab
web interface button to do this says "Run pipeline".

I named the command run as that's likely to be more familiar
to users.

With this you can now support starting a pipeline via
"glab pipeline run -b mybranch".

Note that setting Ref when calling the CreatePipeline API
seems required or we'll end up with an "Internal Server Error".
We thus do a best-effort attempt at figuring out the default
when the branch argument is not specified.


**Motivation and Context**
I have pipelines that I need to regularly trigger manually. Rather than using the "Run pipeline" button in the web interface it would be convenient to be able to do this via the cli.

**How Has This Been Tested?**
I triggered a pipeline run on one of my repos and looked at the web interface to see it run.

Please help test this on a repo where the default branch is not named "master" (and "master" doesn't exist at all).

**Types of changes**
- [x] New feature (non-breaking change which adds functionality)
