### PR TITLE
feat: detect MR for current branch

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/profclems/glab/pkg/tableprinter"
 	"io"
 	"log"
 	"net"
@@ -95,6 +96,8 @@ func main() {
 			os.Exit(0)
 		}
 	}
+
+	tableprinter.DefaultSeparator = "  " // Change the default separator of tableprinter
 
 	rootCmd.SetArgs(expandedArgs)
 

--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/profclems/glab/pkg/tableprinter"
 	"io"
 	"log"
 	"net"
@@ -11,6 +10,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/profclems/glab/pkg/tableprinter"
 
 	"github.com/profclems/glab/commands"
 	"github.com/profclems/glab/commands/alias/expand"

--- a/commands/mr/approve/mr_approve.go
+++ b/commands/mr/approve/mr_approve.go
@@ -21,7 +21,7 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 		glab mr approve 235
 		glab mr approve    # Finds open merge request from current branch
 		`),
-		Args:  cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -38,8 +38,8 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 
 			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
 				WorkInProgress: true,
-				Closed: true,
-				Merged: true,
+				Closed:         true,
+				Merged:         true,
 			}); err != nil {
 				return err
 			}

--- a/commands/mr/approve/mr_approve.go
+++ b/commands/mr/approve/mr_approve.go
@@ -2,22 +2,26 @@ package approve
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
-
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
 
 func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 	var mrApproveCmd = &cobra.Command{
-		Use:   "approve <id> [flags]",
+		Use:   "approve {<id> | <branch>}",
 		Short: `Approve merge requests`,
 		Long:  ``,
-		Args:  cobra.ExactArgs(1),
+		Example: heredoc.Doc(`
+		glab mr approve 235
+		glab mr approve    # Finds open merge request from current branch
+		`),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -27,22 +31,26 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := strings.Trim(args[0], " ")
-			l := &gitlab.ApproveMergeRequestOptions{}
-			if s, _ := cmd.Flags().GetString("sha"); s != "" {
-				l.SHA = gitlab.String(s)
+			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
+				WorkInProgress: true,
+				Closed: true,
+				Merged: true,
+			}); err != nil {
+				return err
 			}
-			//if s, _ := cmd.Flags().GetString("password"); s  {
-			// ToDo:
-			//}
 
-			fmt.Fprintf(out, "- Approving Merge Request !%s\n", mergeID)
-			_, err = api.ApproveMR(apiClient, repo.FullName(), utils.StringToInt(mergeID), l)
+			opts := &gitlab.ApproveMergeRequestOptions{}
+			if s, _ := cmd.Flags().GetString("sha"); s != "" {
+				opts.SHA = gitlab.String(s)
+			}
+
+			fmt.Fprintf(out, "- Approving Merge Request !%d\n", mr.IID)
+			_, err = api.ApproveMR(apiClient, repo.FullName(), mr.IID, opts)
 			if err != nil {
 				return err
 			}

--- a/commands/mr/approvers/mr_approvers.go
+++ b/commands/mr/approvers/mr_approvers.go
@@ -2,6 +2,7 @@ package approvers
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/pkg/api"
 	"github.com/profclems/glab/pkg/tableprinter"

--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -18,7 +18,7 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 		Use:   "close <id>",
 		Short: `Close merge requests`,
 		Long:  ``,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -28,8 +28,15 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
+				return err
+			}
+
+			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
+				Closed: true,
+				Merged: true,
+			}); err != nil {
 				return err
 			}
 

--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -99,6 +99,13 @@ func TestNewCmdCreate_autofill(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		git = exec.Command("git", "pull", "origin", "test-cli")
+		b, err = git.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+
 		output, err := cmdtest.RunCommand(cmd, "-f -b master")
 		if err != nil {
 			t.Error(err)
@@ -108,7 +115,7 @@ func TestNewCmdCreate_autofill(t *testing.T) {
 		out := stripansi.Strip(output.String())
 		outErr := stripansi.Strip(output.Stderr())
 
-		assert.Contains(t, cmdtest.FirstLine([]byte(out)), `!1 SOme changes happened'`)
+		assert.Contains(t, cmdtest.FirstLine([]byte(out)), `!1 Update somefile.txt`)
 		cmdtest.Eq(t, outErr, "")
 		assert.Contains(t, out, "https://gitlab.com/glab-cli/test/-/merge_requests/1")
 

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -2,9 +2,8 @@ package delete
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 
@@ -20,7 +19,6 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		Example: "$ glab delete 123",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
 			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
@@ -28,23 +26,19 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := strings.TrimSpace(args[0])
+			fmt.Fprintf(out, "- Deleting Merge Request !%d\n", mr.IID)
 
-			arrIds := strings.Split(strings.Trim(mergeID, "[] "), ",")
-			for _, i2 := range arrIds {
-				fmt.Fprintln(out, "- Deleting Merge Request !"+i2)
-				err := api.DeleteMR(apiClient, repo.FullName(), utils.StringToInt(i2))
-				if err != nil {
-					return err
-				}
-
-				fmt.Fprintf(out, "%s Merge request !%s deleted\n", utils.RedCheck(), i2)
+			if err = api.DeleteMR(apiClient, repo.FullName(), mr.IID); err != nil {
+				return err
 			}
+
+			fmt.Fprintf(out, "%s Merge request !%d deleted\n", utils.RedCheck(), mr.IID)
+
 			return nil
 		},
 	}

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -17,7 +17,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Short:   `Delete merge requests`,
 		Long:    ``,
 		Aliases: []string{"del"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		Example: "$ glab delete 123",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := utils.ColorableOut(cmd)

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"

--- a/commands/mr/delete/mr_delete_test.go
+++ b/commands/mr/delete/mr_delete_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/profclems/glab/internal/config"
+
 	"github.com/acarl005/stripansi"
 	"github.com/profclems/glab/commands/cmdtest"
 	"github.com/profclems/glab/pkg/api"
@@ -18,7 +20,14 @@ func TestMain(m *testing.M) {
 }
 
 func Test_deleteMergeRequest(t *testing.T) {
+	defer config.StubConfig(`---
+hosts:
+  gitlab.com:
+    username: monalisa
+    token: OTOKEN
+`, "")()
 	t.Parallel()
+	stubFactory, _ := cmdtest.StubFactoryWithConfig("")
 	oldDeleteMR := api.DeleteMR
 
 	api.DeleteMR = func(client *gitlab.Client, projectID interface{}, mrID int) error {
@@ -26,6 +35,30 @@ func Test_deleteMergeRequest(t *testing.T) {
 			return fmt.Errorf("error expected")
 		}
 		return nil
+	}
+
+	api.GetMR = func(client *gitlab.Client, projectID interface{}, mrID int, opts *gitlab.GetMergeRequestsOptions) (*gitlab.MergeRequest, error) {
+		if projectID == "" || projectID == "WRONG_REPO" || projectID == "expected_err" {
+			return nil, fmt.Errorf("error expected")
+		}
+		repo, err := stubFactory.BaseRepo()
+		if err != nil {
+			return nil, err
+		}
+		return &gitlab.MergeRequest{
+			ID:          mrID,
+			IID:         mrID,
+			Title:       "mrTitle",
+			Labels:      gitlab.Labels{"test", "bug"},
+			State:       "opened",
+			Description: "mrBody",
+			Author: &gitlab.BasicUser{
+				ID:       mrID,
+				Name:     "John Dev Wick",
+				Username: "jdwick",
+			},
+			WebURL: fmt.Sprintf("https://%s/%s/-/merge_requests/%d", repo.RepoHost(), repo.FullName(), mrID),
+		}, nil
 	}
 
 	tests := []struct {
@@ -41,7 +74,7 @@ func Test_deleteMergeRequest(t *testing.T) {
 			wantErr: true,
 
 			assertFunc: func(t *testing.T, out string) {
-				assert.Contains(t, out, "error expected")
+				assert.Contains(t, out, "invalid merge request ID provided")
 			},
 		},
 		{
@@ -66,7 +99,7 @@ func Test_deleteMergeRequest(t *testing.T) {
 			name:    "delete no args",
 			wantErr: true,
 			assertFunc: func(t *testing.T, out string) {
-				assert.Contains(t, out, "accepts 1 arg(s), received 0")
+				assert.Contains(t, out, "no open merge request availabe for \"master\"")
 			},
 		},
 	}

--- a/commands/mr/delete/mr_delete_test.go
+++ b/commands/mr/delete/mr_delete_test.go
@@ -61,6 +61,10 @@ hosts:
 		}, nil
 	}
 
+	api.ListMRs = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectMergeRequestsOptions) ([]*gitlab.MergeRequest, error) {
+		return []*gitlab.MergeRequest{}, nil
+	}
+
 	tests := []struct {
 		name       string
 		args       []string

--- a/commands/mr/issues/mr_issues.go
+++ b/commands/mr/issues/mr_issues.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/issue/issueutils"
 	"github.com/profclems/glab/commands/mr/mrutils"

--- a/commands/mr/issues/mr_issues.go
+++ b/commands/mr/issues/mr_issues.go
@@ -2,10 +2,9 @@ package issues
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 	"github.com/spf13/cobra"
@@ -19,7 +18,7 @@ func NewCmdIssues(f *cmdutils.Factory) *cobra.Command {
 		Short:   `Get issues related to a particular merge request.`,
 		Long:    ``,
 		Aliases: []string{"issue"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		Example: "$ glab mr issues 46",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
@@ -30,15 +29,14 @@ func NewCmdIssues(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := strings.TrimSpace(args[0])
 			l := &gitlab.GetIssuesClosedOnMergeOptions{}
 
-			mrIssues, err := api.GetMRLinkedIssues(apiClient, repo.FullName(), utils.StringToInt(mergeID), l)
+			mrIssues, err := api.GetMRLinkedIssues(apiClient, repo.FullName(), mr.IID, l)
 			if err != nil {
 				return err
 			}

--- a/commands/mr/merge/mr_merge.go
+++ b/commands/mr/merge/mr_merge.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"fmt"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
@@ -22,7 +23,7 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 		glab mr merge 235
 		glab mr merge    # Finds open merge request from current branch
 		`),
-		Args:    cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -39,9 +40,9 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 
 			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
 				WorkInProgress: true,
-				Closed: true,
-				Merged: true,
-				Conflict: true,
+				Closed:         true,
+				Merged:         true,
+				Conflict:       true,
 				PipelineStatus: true,
 			}); err != nil {
 				return err

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -2,11 +2,70 @@ package mrutils
 
 import (
 	"fmt"
-
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
 	"github.com/profclems/glab/pkg/tableprinter"
 	"github.com/xanzy/go-gitlab"
+	"strconv"
 )
+
+type MRCheckErrOptions struct {
+	// WorkInProgress: check and return err if merge request is a DRAFT
+	WorkInProgress bool
+	// Closed : check and return err if merge request is closed
+	Closed bool
+	// Merged : check and return err if merge request is already merged
+	Merged bool
+	// Opened : check and return err if merge request is already opened
+	Opened bool
+	// Conflict : check and return err if there are merge conflicts
+	Conflict bool
+	// PipelineStatus : check and return err pipeline did not succeed and it is required before merging
+	PipelineStatus bool
+	// MergePermitted : check and return err if user is not authorized to merge
+	MergePermitted bool
+	// Subscribed : check and return err if user is already subscribed to MR
+	Subscribed bool
+	// Unsubscribed : check and return err if user is already unsubscribed to MR
+	Unsubscribed bool
+}
+
+// MRCheckErrors checks and return merge request errors specified in MRCheckErrOptions{}
+func MRCheckErrors(mr *gitlab.MergeRequest, opts MRCheckErrOptions) error {
+	if mr.WorkInProgress && opts.WorkInProgress {
+		return fmt.Errorf("this merge request is still a work in progress. Run `glab mr update %d --ready` to mark it as ready for review", mr.IID)
+	}
+
+	if mr.MergeWhenPipelineSucceeds && opts.PipelineStatus && mr.Pipeline != nil {
+		if mr.Pipeline.Status != "success" {
+			return fmt.Errorf("pipeline for this merge request has failed. Pipeline is required to succeed before merging")
+		}
+	}
+
+	if mr.State == "merged" && opts.Merged {
+		return fmt.Errorf("this merge request has already been merged")
+	}
+
+	if mr.State == "closed" && opts.Closed {
+		return fmt.Errorf("this merge request has been closed")
+	}
+
+	if mr.State == "opened" && opts.Opened {
+		return fmt.Errorf("this merge request is already open")
+	}
+
+	if mr.Subscribed && opts.Subscribed {
+		return fmt.Errorf("you are already subscribed to this merge request")
+	}
+
+	if !mr.Subscribed && opts.Unsubscribed {
+		return fmt.Errorf("you are already unsubscribed to this merge request")
+	}
+
+	return nil
+}
 
 func DisplayMR(mr *gitlab.MergeRequest) string {
 	mrID := MRState(mr)
@@ -34,4 +93,64 @@ func DisplayAllMRs(mrs []*gitlab.MergeRequest, projectID string) string {
 	}
 
 	return table.Render()
+}
+
+func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrepo.Interface, error) {
+	var mrID int
+	var mr *gitlab.MergeRequest
+
+	apiClient, err := f.HttpClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	baseRepo, err := f.BaseRepo()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	branch, err := f.Branch()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(args) > 0 {
+		mrID, err = strconv.Atoi(args[0])
+		if err != nil {
+			branch = args[0]
+		} else if mrID == 0 { // to check for cases where the user explicitly specified mrID to be zero
+			return nil, nil, fmt.Errorf("invalid merge request ID provided")
+		}
+	}
+	
+	if mrID == 0 {
+		mr, err = GetOpenMRForBranch(apiClient, baseRepo, branch)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		mr, err = api.GetMR(apiClient, baseRepo.FullName(), mrID, &gitlab.GetMergeRequestsOptions{})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get merge request %d: %w", mrID, err)
+		}
+
+	}
+
+	return mr, baseRepo, nil
+}
+
+func GetOpenMRForBranch(apiClient *gitlab.Client, baseRepo glrepo.Interface, currentBranch string) (*gitlab.MergeRequest, error)  {
+	mrs, err := api.ListMRs(apiClient, baseRepo.FullName(), &gitlab.ListProjectMergeRequestsOptions{
+		SourceBranch: gitlab.String(currentBranch),
+		State: gitlab.String("opened"),
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get open merge request for %q: %w", currentBranch, err)
+	}
+	if len(mrs) == 0 {
+		return nil, fmt.Errorf("no open merge request availabe for %q", currentBranch)
+	}
+	// A single result is expected since gitlab does not allow multiple merge requests for a single source branch
+	return mrs[0], nil
 }

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -2,13 +2,14 @@ package mrutils
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 	"github.com/profclems/glab/pkg/tableprinter"
 	"github.com/xanzy/go-gitlab"
-	"strconv"
 )
 
 type MRCheckErrOptions struct {
@@ -122,7 +123,7 @@ func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrep
 			return nil, nil, fmt.Errorf("invalid merge request ID provided")
 		}
 	}
-	
+
 	if mrID == 0 {
 		mr, err = GetOpenMRForBranch(apiClient, baseRepo, branch)
 		if err != nil {
@@ -139,10 +140,10 @@ func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrep
 	return mr, baseRepo, nil
 }
 
-func GetOpenMRForBranch(apiClient *gitlab.Client, baseRepo glrepo.Interface, currentBranch string) (*gitlab.MergeRequest, error)  {
+func GetOpenMRForBranch(apiClient *gitlab.Client, baseRepo glrepo.Interface, currentBranch string) (*gitlab.MergeRequest, error) {
 	mrs, err := api.ListMRs(apiClient, baseRepo.FullName(), &gitlab.ListProjectMergeRequestsOptions{
 		SourceBranch: gitlab.String(currentBranch),
-		State: gitlab.String("opened"),
+		State:        gitlab.String("opened"),
 	})
 
 	if err != nil {

--- a/commands/mr/note/mr_note_create.go
+++ b/commands/mr/note/mr_note_create.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"fmt"
+	"github.com/profclems/glab/commands/mr/mrutils"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/utils"
@@ -17,7 +18,7 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"comment"},
 		Short:   "Add a comment or note to merge request",
 		Long:    ``,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -27,18 +28,17 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mID := args[0]
 			body, err := cmd.Flags().GetString("message")
-
 			if err != nil {
 				return err
 			}
-			mr, err := api.GetMR(apiClient, repo.FullName(), utils.StringToInt(mID), &gitlab.GetMergeRequestsOptions{})
+
+			mr, err = api.GetMR(apiClient, repo.FullName(), mr.IID, &gitlab.GetMergeRequestsOptions{})
 			if err != nil {
 				return err
 			}
@@ -53,7 +53,7 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 				return fmt.Errorf("aborted... Note has an empty message")
 			}
 
-			noteInfo, err := api.CreateMRNote(apiClient, repo.FullName(), utils.StringToInt(mID), &gitlab.CreateMergeRequestNoteOptions{
+			noteInfo, err := api.CreateMRNote(apiClient, repo.FullName(), mr.IID, &gitlab.CreateMergeRequestNoteOptions{
 				Body: &body,
 			})
 			if err != nil {

--- a/commands/mr/note/mr_note_create.go
+++ b/commands/mr/note/mr_note_create.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/mr/mrutils"
 
 	"github.com/profclems/glab/commands/cmdutils"

--- a/commands/mr/rebase/mr_rebase.go
+++ b/commands/mr/rebase/mr_rebase.go
@@ -2,6 +2,7 @@ package rebase
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -2,8 +2,6 @@ package reopen
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
@@ -19,10 +17,8 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 		Short:   `Reopen merge requests`,
 		Long:    ``,
 		Aliases: []string{"open"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			var err error
 			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
@@ -30,26 +26,30 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := strings.TrimSpace(args[0])
+			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
+				Opened: true,
+				Merged: true,
+			}); err != nil {
+				return err
+			}
 
 			l := &gitlab.UpdateMergeRequestOptions{}
 			l.StateEvent = gitlab.String("reopen")
-			arrIds := strings.Split(strings.Trim(mergeID, "[] "), ",")
 
-			for _, i2 := range arrIds {
-				fmt.Fprintf(out, "- Reopening Merge request !%s...\n", i2)
-				mr, err := api.UpdateMR(apiClient, repo.FullName(), utils.StringToInt(i2), l)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(out, "%s Merge request !%s reopened\n", utils.GreenCheck(), i2)
-				fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintf(out, "- Reopening Merge request !%d...\n", mr.IID)
+
+			mr, err = api.UpdateMR(apiClient, repo.FullName(), mr.IID, l)
+			if err != nil {
+				return err
 			}
+
+			fmt.Fprintf(out, "%s Merge request !%d reopened\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintln(out, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -2,6 +2,7 @@ package reopen
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"

--- a/commands/mr/revoke/mr_revoke.go
+++ b/commands/mr/revoke/mr_revoke.go
@@ -2,6 +2,7 @@ package revoke
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
@@ -33,8 +34,8 @@ func NewCmdRevoke(f *cmdutils.Factory) *cobra.Command {
 
 			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
 				WorkInProgress: true,
-				Closed: true,
-				Merged: true,
+				Closed:         true,
+				Merged:         true,
 			}); err != nil {
 				return err
 			}

--- a/commands/mr/subscribe/mr_subscribe.go
+++ b/commands/mr/subscribe/mr_subscribe.go
@@ -2,6 +2,7 @@ package subscribe
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
@@ -30,7 +31,7 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			
+
 			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
 				Subscribed: true,
 			}); err != nil {
@@ -44,7 +45,7 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out,"%s You have successfully subscribed to merge request !%d\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintf(out, "%s You have successfully subscribed to merge request !%d\n", utils.GreenCheck(), mr.IID)
 			fmt.Fprintln(out, mrutils.DisplayMR(mr))
 
 			return nil

--- a/commands/mr/subscribe/mr_subscribe_test.go
+++ b/commands/mr/subscribe/mr_subscribe_test.go
@@ -46,7 +46,7 @@ hosts:
 			Labels:      gitlab.Labels{"bug", "test"},
 			State:       "opened",
 			Description: "mrbody",
-			Subscribed: false,
+			Subscribed:  false,
 			Author: &gitlab.BasicUser{
 				ID:       1,
 				Name:     "John Dev Wick",

--- a/commands/mr/subscribe/mr_subscribe_test.go
+++ b/commands/mr/subscribe/mr_subscribe_test.go
@@ -46,6 +46,7 @@ hosts:
 			Labels:      gitlab.Labels{"bug", "test"},
 			State:       "opened",
 			Description: "mrbody",
+			Subscribed: false,
 			Author: &gitlab.BasicUser{
 				ID:       1,
 				Name:     "John Dev Wick",

--- a/commands/mr/subscribe/mr_subscribe_test.go
+++ b/commands/mr/subscribe/mr_subscribe_test.go
@@ -57,6 +57,30 @@ hosts:
 		}, nil
 	}
 
+	api.GetMR = func(client *gitlab.Client, projectID interface{}, mrID int, opts *gitlab.GetMergeRequestsOptions) (*gitlab.MergeRequest, error) {
+		if projectID == "" || projectID == "WRONG_REPO" || projectID == "expected_err" {
+			return nil, fmt.Errorf("error expected")
+		}
+		repo, err := stubFactory.BaseRepo()
+		if err != nil {
+			return nil, err
+		}
+		return &gitlab.MergeRequest{
+			ID:          mrID,
+			IID:         mrID,
+			Title:       "mrTitle",
+			Labels:      gitlab.Labels{"test", "bug"},
+			State:       "opened",
+			Description: "mrBody",
+			Author: &gitlab.BasicUser{
+				ID:       mrID,
+				Name:     "John Dev Wick",
+				Username: "jdwick",
+			},
+			WebURL: fmt.Sprintf("https://%s/%s/-/merge_requests/%d", repo.RepoHost(), repo.FullName(), mrID),
+		}, nil
+	}
+
 	testCases := []struct {
 		Name        string
 		Issue       string

--- a/commands/mr/todo/mr_todo.go
+++ b/commands/mr/todo/mr_todo.go
@@ -2,6 +2,7 @@ package todo
 
 import (
 	"fmt"
+	"github.com/profclems/glab/commands/mr/mrutils"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/utils"
@@ -16,7 +17,7 @@ func NewCmdTodo(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"add-todo"},
 		Short:   "Add a ToDo to merge request",
 		Long:    ``,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -26,18 +27,18 @@ func NewCmdTodo(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mID := args[0]
-
-			_, err = api.MRTodo(apiClient, repo.FullName(), utils.StringToInt(mID), nil)
+			_, err = api.MRTodo(apiClient, repo.FullName(), mr.IID, nil)
 			if err != nil {
 				return err
 			}
+
 			fmt.Fprintln(out, utils.GreenCheck(), "Done!!")
+
 			return nil
 		},
 	}

--- a/commands/mr/todo/mr_todo.go
+++ b/commands/mr/todo/mr_todo.go
@@ -2,6 +2,7 @@ package todo
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/mr/mrutils"
 
 	"github.com/profclems/glab/commands/cmdutils"

--- a/commands/mr/unsubscribe/mr_unsubscribe.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe.go
@@ -2,8 +2,6 @@ package unsubscribe
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
@@ -18,7 +16,7 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 		Short:   `Unsubscribe from merge requests`,
 		Long:    ``,
 		Aliases: []string{"unsub"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -28,24 +26,26 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := args[0]
-
-			arrIds := strings.Split(strings.Trim(mergeID, "[] "), ",")
-			for _, i2 := range arrIds {
-				fmt.Fprintln(out, "- Unsubscribing from Merge Request !"+i2)
-				mr, err := api.UnsubscribeFromMR(apiClient, repo.FullName(), utils.StringToInt(i2), nil)
-				if err != nil {
-					return err
-				}
-
-				fmt.Fprintln(out, utils.GreenCheck(), "You have successfully unsubscribed from merge request !"+i2)
-				fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			if err = mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
+				Unsubscribed: true,
+			}); err != nil {
+				return err
 			}
+
+			fmt.Fprintf(out, "- Unsubscribing from Merge Request !%d\n", mr.IID)
+
+			mr, err = api.UnsubscribeFromMR(apiClient, repo.FullName(), mr.IID, nil)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(out,"%s You have successfully unsubscribed from merge request !%d\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintln(out, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/unsubscribe/mr_unsubscribe.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe.go
@@ -2,6 +2,7 @@ package unsubscribe
 
 import (
 	"fmt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/internal/utils"
@@ -44,7 +45,7 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out,"%s You have successfully unsubscribed from merge request !%d\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintf(out, "%s You have successfully unsubscribed from merge request !%d\n", utils.GreenCheck(), mr.IID)
 			fmt.Fprintln(out, mrutils.DisplayMR(mr))
 
 			return nil

--- a/commands/mr/unsubscribe/mr_unsubscribe_test.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe_test.go
@@ -45,7 +45,7 @@ hosts:
 			Labels:      gitlab.Labels{"bug", "test"},
 			State:       "opened",
 			Description: "mrbody",
-			Subscribed: false,
+			Subscribed:  false,
 			Author: &gitlab.BasicUser{
 				ID:       1,
 				Name:     "John Dev Wick",

--- a/commands/mr/unsubscribe/mr_unsubscribe_test.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe_test.go
@@ -45,6 +45,7 @@ hosts:
 			Labels:      gitlab.Labels{"bug", "test"},
 			State:       "opened",
 			Description: "mrbody",
+			Subscribed: false,
 			Author: &gitlab.BasicUser{
 				ID:       1,
 				Name:     "John Dev Wick",

--- a/commands/mr/unsubscribe/mr_unsubscribe_test.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe_test.go
@@ -56,6 +56,31 @@ hosts:
 		}, nil
 	}
 
+	api.GetMR = func(client *gitlab.Client, projectID interface{}, mrID int, opts *gitlab.GetMergeRequestsOptions) (*gitlab.MergeRequest, error) {
+		if projectID == "" || projectID == "WRONG_REPO" || projectID == "expected_err" {
+			return nil, fmt.Errorf("error expected")
+		}
+		repo, err := stubFactory.BaseRepo()
+		if err != nil {
+			return nil, err
+		}
+		return &gitlab.MergeRequest{
+			ID:          mrID,
+			IID:         mrID,
+			Title:       "mrTitle",
+			Labels:      gitlab.Labels{"test", "bug"},
+			State:       "opened",
+			Description: "mrBody",
+			Subscribed:  true,
+			Author: &gitlab.BasicUser{
+				ID:       mrID,
+				Name:     "John Dev Wick",
+				Username: "jdwick",
+			},
+			WebURL: fmt.Sprintf("https://%s/%s/-/merge_requests/%d", repo.RepoHost(), repo.FullName(), mrID),
+		}, nil
+	}
+
 	testCases := []struct {
 		Name        string
 		Issue       string

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -79,7 +79,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			if m, _ := cmd.Flags().GetString("description"); m != "" {
 				l.Description = gitlab.String(m)
 			}
-      
+
 			if assignee, _ := cmd.Flags().GetString("assignee"); assignee != "" {
 				user, err := api.UserByName(apiClient, assignee)
 				if err != nil {
@@ -87,8 +87,8 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				}
 				l.AssigneeID = gitlab.Int(user.ID)
 			}
-      
-			mr, err := api.UpdateMR(apiClient, repo.FullName(), mergeID, l)
+
+			mr, err = api.UpdateMR(apiClient, repo.FullName(), mr.IID, l)
 			if err != nil {
 				return err
 			}

--- a/commands/mr/view/mr_view.go
+++ b/commands/mr/view/mr_view.go
@@ -2,9 +2,10 @@ package view
 
 import (
 	"fmt"
-	"github.com/profclems/glab/commands/mr/mrutils"
 	"strings"
 	"time"
+
+	"github.com/profclems/glab/commands/mr/mrutils"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/utils"
@@ -100,8 +101,8 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			Assignees: %v
 			Milestone: %v
 			`, prettifyNilEmptyValues(labels, "None"),
-			prettifyNilEmptyValues(assignees, "None"),
-			prettifyNilEmptyValues(mr.Milestone, "None"))
+				prettifyNilEmptyValues(assignees, "None"),
+				prettifyNilEmptyValues(mr.Milestone, "None"))
 
 			if mr.State == "closed" {
 				now := time.Now()

--- a/commands/mr/view/mr_view.go
+++ b/commands/mr/view/mr_view.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"fmt"
+	"github.com/profclems/glab/commands/mr/mrutils"
 	"strings"
 	"time"
 
@@ -17,11 +18,11 @@ import (
 
 func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 	var mrViewCmd = &cobra.Command{
-		Use:     "view <id>",
+		Use:     "view {<id> | <branch>}",
 		Short:   `Display the title, body, and other information about a merge request.`,
 		Long:    ``,
 		Aliases: []string{"show"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			out := utils.ColorableOut(cmd)
@@ -31,32 +32,33 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			mr, repo, err := mrutils.MRFromArgs(f, args)
 			if err != nil {
 				return err
 			}
-
-			pid := utils.StringToInt(args[0])
 
 			opts := &gitlab.GetMergeRequestsOptions{}
 			opts.IncludeDivergedCommitsCount = gitlab.Bool(true)
 			opts.RenderHTML = gitlab.Bool(true)
 			opts.IncludeRebaseInProgress = gitlab.Bool(true)
 
-			mr, err := api.GetMR(apiClient, repo.FullName(), pid, opts)
+			mr, err = api.GetMR(apiClient, repo.FullName(), mr.IID, opts)
 			if err != nil {
 				return err
 			}
+
 			if lb, _ := cmd.Flags().GetBool("web"); lb { //open in browser if --web flag is specified
 				fmt.Fprintf(cmd.ErrOrStderr(), "Opening %s in your browser.\n", utils.DisplayURL(mr.WebURL))
 				cfg, _ := f.Config()
 				browser, _ := cfg.Get(repo.RepoHost(), "browser")
 				return utils.OpenInBrowser(mr.WebURL, browser)
 			}
+
 			showSystemLog, _ := cmd.Flags().GetBool("system-logs")
+
 			var mrState string
 			if mr.State == "opened" {
-				mrState = utils.Green(mr.State)
+				mrState = utils.Green("open")
 			} else if mr.State == "merged" {
 				mrState = utils.Blue(mr.State)
 			} else {
@@ -65,12 +67,11 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			now := time.Now()
 			ago := now.Sub(*mr.CreatedAt)
 
-			mrPrintDetails := "\n" + mr.Title
+			mrPrintDetails := mrState
+			mrPrintDetails += utils.Gray(fmt.Sprintf(" • opened by %s (%s) %s\n", mr.Author.Username, mr.Author.Name, utils.PrettyTimeAgo(ago)))
+			mrPrintDetails += mr.Title
 			mrPrintDetails += fmt.Sprintf("!%d", mr.IID)
-			mrPrintDetails += fmt.Sprintf("(%s)", mrState)
-			mrPrintDetails += utils.Gray(fmt.Sprintf(" • opened by %s (%s) %s\n", mr.Author.Username,
-				mr.Author.Name,
-				utils.PrettyTimeAgo(ago)))
+			mrPrintDetails += "\n"
 
 			if mr.Description != "" {
 				cfg, _ := f.Config()
@@ -82,8 +83,6 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			mrPrintDetails += utils.Gray(fmt.Sprintf("\n%d upvotes • %d downvotes • %d comments\n\n",
 				mr.Upvotes, mr.Downvotes, mr.UserNotesCount))
 
-			fmt.Fprintln(out, mrPrintDetails)
-
 			var labels string
 			for _, l := range mr.Labels {
 				labels += " " + l + ","
@@ -94,26 +93,26 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			for _, a := range mr.Assignees {
 				assignees += " " + a.Username + "(" + a.Name + "),"
 			}
+
 			assignees = strings.Trim(assignees, ", ")
-			table := uitable.New()
-			table.MaxColWidth = 70
-			table.Wrap = true
-			table.AddRow("Project ID:", mr.ProjectID)
-			table.AddRow("Labels:", prettifyNilEmptyValues(labels, "None"))
-			table.AddRow("Milestone:", prettifyNilEmptyValues(mr.Milestone, "None"))
-			table.AddRow("Assignees:", prettifyNilEmptyValues(assignees, "None"))
-			table.AddRow("Discussion Locked:", prettifyNilEmptyValues(mr.DiscussionLocked, "false"))
-			table.AddRow("Subscribed:", prettifyNilEmptyValues(mr.Subscribed, "false"))
+			mrPrintDetails += heredoc.Docf(`
+			Labels: %v
+			Assignees: %v
+			Milestone: %v
+			`, prettifyNilEmptyValues(labels, "None"),
+			prettifyNilEmptyValues(assignees, "None"),
+			prettifyNilEmptyValues(mr.Milestone, "None"))
 
 			if mr.State == "closed" {
 				now := time.Now()
 				ago := now.Sub(*mr.ClosedAt)
-				table.AddRow("Closed By:",
-					fmt.Sprintf("%s (%s) %s", mr.ClosedBy.Username, mr.ClosedBy.Name, utils.PrettyTimeAgo(ago)))
+				mrPrintDetails += fmt.Sprintf("Closed By: %s (%s) %s", mr.ClosedBy.Username, mr.ClosedBy.Name, utils.PrettyTimeAgo(ago))
 			}
-			table.AddRow("Web URL:", mr.WebURL)
-			fmt.Fprintln(out, table)
-			fmt.Fprint(out, "\n") // Empty Line
+
+			mrPrintDetails += utils.Gray(fmt.Sprintf("\nView this pull request on GitLab: %s", mr.WebURL))
+			mrPrintDetails += "\n"
+
+			fmt.Fprintln(out, mrPrintDetails)
 
 			if c, _ := cmd.Flags().GetBool("comments"); c {
 				l := &gitlab.ListMergeRequestNotesOptions{}
@@ -123,7 +122,7 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				if p, _ := cmd.Flags().GetInt("per-page"); p != 0 {
 					l.PerPage = p
 				}
-				notes, err := api.ListMRNotes(apiClient, repo.FullName(), pid, l)
+				notes, err := api.ListMRNotes(apiClient, repo.FullName(), mr.IID, l)
 				if err != nil {
 					return err
 				}
@@ -155,6 +154,7 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 					fmt.Fprintln(out, "There are no comments on this mr")
 				}
 			}
+
 			return nil
 		},
 	}

--- a/pkg/tableprinter/table_printer.go
+++ b/pkg/tableprinter/table_printer.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	DefaultSeparator        = " "
+	DefaultSeparator        = "\t"
 	DefaultMaxColWidth uint = 70
 )
 


### PR DESCRIPTION
This PR adds merge request autodetect feature to MR commands: when user does not explicitly specify the ID of the merge request, the open merge request for the current branch is used. 