### PR TITLE
feat: Add mr update flag to assinge to change current assigne

### DIFF
--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -77,6 +77,13 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			if m, _ := cmd.Flags().GetString("description"); m != "" {
 				l.Description = gitlab.String(m)
 			}
+			if assignee, _ := cmd.Flags().GetString("assignee"); assignee != "" {
+				user, err := api.UserByName(apiClient, assignee)
+				if err != nil {
+					return err
+				}
+				l.AssigneeID = gitlab.Int(user.ID)
+			}
 			mr, err := api.UpdateMR(apiClient, repo.FullName(), mergeID, l)
 			if err != nil {
 				return err
@@ -93,6 +100,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().StringP("title", "t", "", "Title of merge request")
 	mrUpdateCmd.Flags().BoolP("lock-discussion", "", false, "Lock discussion on merge request")
 	mrUpdateCmd.Flags().StringP("description", "d", "", "merge request description")
+	mrUpdateCmd.Flags().StringP("assignee", "a", "", "merge request assignee")
 
 	return mrUpdateCmd
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
<!--- Describe your changes in detail -->

Add flag `-a --assignee` to `mr update` command to change the current assignee for a specific MR

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#262 

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->

With this command you don't have to use the UI to change assignee of a MR.

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Did this with no problems, on a project in self hosted GitLab.

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
