### PR TITLE
feat: Add ability to mark branch to be deleted from update

### DIFF
--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -88,6 +88,10 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				l.AssigneeID = gitlab.Int(user.ID)
 			}
 
+			if removeSource, _ := cmd.Flags().GetBool("remove-source-branch"); removeSource {
+				l.RemoveSourceBranch = gitlab.Bool(true)
+			}
+
 			mr, err = api.UpdateMR(apiClient, repo.FullName(), mr.IID, l)
 			if err != nil {
 				return err
@@ -105,6 +109,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().BoolP("lock-discussion", "", false, "Lock discussion on merge request")
 	mrUpdateCmd.Flags().StringP("description", "d", "", "merge request description")
 	mrUpdateCmd.Flags().StringP("assignee", "a", "", "merge request assignee")
+	mrUpdateCmd.Flags().BoolP("remove-source-branch", "", false, "Remove Source Branch on merge")
 
 	return mrUpdateCmd
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
This MR adds option to mark branch to be deleted form update command.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#273 
**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
We can create MR that are marked to be deleted, but we can't update that. This fixes that.
**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
