### PR TITLE
Remove empty alias for check-update

### DIFF
--- a/commands/update/checkupdate.go
+++ b/commands/update/checkupdate.go
@@ -16,7 +16,7 @@ func NewCheckUpdateCmd(version, build string) *cobra.Command {
 		Use:     "check-update",
 		Short:   "Check for latest glab releases",
 		Long:    ``,
-		Aliases: []string{"update", ""},
+		Aliases: []string{"update"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return CheckUpdate(cmd, version, build, false)
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
The `check-update` command has an empty alias, which breaks at least the bash-completion. Trying to use completion would look like this:
```console
$ glab <tab>-bash: aliashash[""]: bad array subscript
```

This is because the empty alias causes this in the generated bash-completion:
```bash
_glab_root_command()
{
    last_command="glab"

    command_aliases=()

    commands=()
    commands+=("alias")
    commands+=("auth")
    commands+=("check-update")
    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
        command_aliases+=("")        # <---
        aliashash[""]="check-update" # <---
        command_aliases+=("update")
        aliashash["update"]="check-update"
    fi
```

**Related Issue**
#287

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->

**How Has This Been Tested?**
```console
# With released version
$ glab completion -s bash > before.compl
# With PR build
$ ./glab completion -s bash > after.compl
# Only broken parts changed
$ diff before.compl after.compl
2546a2547,2548
>         command_aliases+=("")
>         aliashash[""]="check-update"
# Also, completion works
$ source after.compl
$ glab con<tab>
$ glab config
```

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
