### PR TITLE
style: change authentication instruction

### DIFF
--- a/commands/cmdutils/remote_resolver.go
+++ b/commands/cmdutils/remote_resolver.go
@@ -72,7 +72,7 @@ func (rr *remoteResolver) Resolver() func() (glrepo.Remotes, error) {
 		}
 
 		if len(cachedRemotes) == 0 {
-			remotesError = errors.New("none of the git remotes configured for this repository points to a known GitLab host. Please use `glab config init` to configure a new host for glab")
+			remotesError = errors.New("none of the git remotes configured for this repository points to a known GitLab host. Please use `glab auth login` to authenticate and configure a new host for glab")
 			return nil, remotesError
 		}
 		return cachedRemotes, nil

--- a/commands/config/config.go
+++ b/commands/config/config.go
@@ -36,6 +36,9 @@ Current respected settings:
 	configCmd.AddCommand(NewCmdConfigGet(f))
 	configCmd.AddCommand(NewCmdConfigSet(f))
 	configCmd.AddCommand(NewCmdConfigInit(f))
+	
+	// TODO: deprecate `config init` command since it's been replaced by `auth login`
+	// targetedVersion: 1.12.0
 
 	return configCmd
 }

--- a/commands/config/config.go
+++ b/commands/config/config.go
@@ -36,7 +36,7 @@ Current respected settings:
 	configCmd.AddCommand(NewCmdConfigGet(f))
 	configCmd.AddCommand(NewCmdConfigSet(f))
 	configCmd.AddCommand(NewCmdConfigInit(f))
-	
+
 	// TODO: deprecate `config init` command since it's been replaced by `auth login`
 	// targetedVersion: 1.12.0
 


### PR DESCRIPTION
- Tell users to authenticate glab using `glab auth login` instead of `glab config init`
