### PR TITLE
fix: mr merge priviledge

### DIFF
--- a/commands/mr/diff/diff_test.go
+++ b/commands/mr/diff/diff_test.go
@@ -222,6 +222,18 @@ func TestMRDiff_notty(t *testing.T) {
     "state": "merged"}]`), nil
 		},
 	)
+	httpmock.RegisterResponder("GET", `https://gitlab.com/api/v4/projects/OWNER%2FREPO/merge_requests/123`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(200, `{
+    "id": 123,
+    "iid": 123,
+    "project_id": 3,
+    "title": "test1",
+    "description": "fixed login page css paddings",
+    "state": "merged"}`), nil
+		},
+	)
+
 	testDiff := DiffTest()
 	output, err := runCommand(nil, false, "")
 	if err != nil {

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -139,12 +139,13 @@ func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrep
 		if err != nil {
 			return nil, nil, err
 		}
-	} else {
-		mr, err = api.GetMR(apiClient, baseRepo.FullName(), mrID, &gitlab.GetMergeRequestsOptions{})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get merge request %d: %w", mrID, err)
-		}
-
+		mrID = mr.IID
+	}
+	// fetching multiple MRs does not return many major params in the payload
+	// so we fetch again using the single mr endpoint
+	mr, err = api.GetMR(apiClient, baseRepo.FullName(), mrID, &gitlab.GetMergeRequestsOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get merge request %d: %w", mrID, err)
 	}
 
 	return mr, baseRepo, nil


### PR DESCRIPTION
Fetching multiple MRs does not return many major params in the reponse payload including `user: {"can_merge": boolean}` parameter which is needed to check if a user can merge the merge request.
It is returned with the response payload of the single MR endpoint so we fetch again using the single MR endpoint

Resolves #268 