### PR TITLE
fix(repo search): Remove argument expectations

### DIFF
--- a/commands/project/search/project_search.go
+++ b/commands/project/search/project_search.go
@@ -18,7 +18,7 @@ func NewCmdSearch(f *cmdutils.Factory) *cobra.Command {
 		Use:     "search [flags]",
 		Short:   `Search for GitLab repositories and projects by name`,
 		Long:    ``,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"find", "lookup"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Description**
<!--- Describe your changes in detail -->
Repo search documents that it expects no arguments. In reality the
command doesn't expect anything, but it has marked that it expects
exactly one argument. Removing this requirement fixes the problem.


**Related Issue**
Fixes #295
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
