### PR TITLE
style: switch remaining commands to iostream package

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -123,7 +123,7 @@ func main() {
 
 	checkUpdate, _ := cfg.Get("", "check_update")
 	if checkUpdate, err := strconv.ParseBool(checkUpdate); err == nil && checkUpdate {
-		err = update.CheckUpdate(rootCmd, version, build, true)
+		err = update.CheckUpdate(rootCmd, cmdFactory.IO, version, build, true)
 		if err != nil && debug {
 			printError(os.Stderr, err, rootCmd, debug)
 		}

--- a/commands/label/create/label_create.go
+++ b/commands/label/create/label_create.go
@@ -6,8 +6,6 @@ import (
 	"github.com/profclems/glab/pkg/api"
 
 	"github.com/profclems/glab/commands/cmdutils"
-	"github.com/profclems/glab/internal/utils"
-
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
@@ -22,7 +20,6 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -50,7 +47,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(out, "Created label: %s\nWith color: %s\n", label.Name, label.Color)
+			fmt.Fprintf(f.IO.StdOut, "Created label: %s\nWith color: %s\n", label.Name, label.Color)
 
 			return nil
 		},

--- a/commands/label/list/label_list.go
+++ b/commands/label/list/label_list.go
@@ -21,7 +21,6 @@ func NewCmdList(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -49,7 +48,7 @@ func NewCmdList(f *cmdutils.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(out, "Showing label %d of %d on %s\n\n", len(labels), len(labels), repo.FullName())
+			fmt.Fprintf(f.IO.StdOut, "Showing label %d of %d on %s\n\n", len(labels), len(labels), repo.FullName())
 			var labelPrintInfo string
 			for _, label := range labels {
 				labelPrintInfo += label.Name
@@ -58,7 +57,7 @@ func NewCmdList(f *cmdutils.Factory) *cobra.Command {
 				}
 				labelPrintInfo += "\n"
 			}
-			fmt.Fprintln(out, utils.Indent(labelPrintInfo, " "))
+			fmt.Fprintln(f.IO.StdOut, utils.Indent(labelPrintInfo, " "))
 
 			// Cache labels for host
 			//labelNames := make([]string, 0, len(labels))

--- a/commands/mr/approve/mr_approve.go
+++ b/commands/mr/approve/mr_approve.go
@@ -24,7 +24,6 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -49,12 +48,12 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 				opts.SHA = gitlab.String(s)
 			}
 
-			fmt.Fprintf(out, "- Approving Merge Request !%d\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Approving Merge Request !%d\n", mr.IID)
 			_, err = api.ApproveMR(apiClient, repo.FullName(), mr.IID, opts)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(out, utils.GreenCheck(), "Approved")
+			fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Approved")
 
 			return nil
 		},

--- a/commands/mr/approvers/mr_approvers.go
+++ b/commands/mr/approvers/mr_approvers.go
@@ -22,8 +22,6 @@ func NewCmdApprovers(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -34,21 +32,21 @@ func NewCmdApprovers(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out, "\nListing Merge Request !%d eligible approvers\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "\nListing Merge Request !%d eligible approvers\n", mr.IID)
 
 			mrApprovals, err := api.GetMRApprovalState(apiClient, repo.FullName(), mr.IID)
 			if err != nil {
 				return err
 			}
 			if mrApprovals.ApprovalRulesOverwritten {
-				fmt.Fprintln(out, utils.Yellow("Approval rules overwritten"))
+				fmt.Fprintln(f.IO.StdOut, utils.Yellow("Approval rules overwritten"))
 			}
 			for _, rule := range mrApprovals.Rules {
 				table := tableprinter.NewTablePrinter()
 				if rule.Approved {
-					fmt.Fprintln(out, utils.Green(fmt.Sprintf("Rule %q sufficient approvals (%d/%d required):", rule.Name, len(rule.ApprovedBy), rule.ApprovalsRequired)))
+					fmt.Fprintln(f.IO.StdOut, utils.Green(fmt.Sprintf("Rule %q sufficient approvals (%d/%d required):", rule.Name, len(rule.ApprovedBy), rule.ApprovalsRequired)))
 				} else {
-					fmt.Fprintln(out, utils.Yellow(fmt.Sprintf("Rule %q insufficient approvals (%d/%d required):", rule.Name, len(rule.ApprovedBy), rule.ApprovalsRequired)))
+					fmt.Fprintln(f.IO.StdOut, utils.Yellow(fmt.Sprintf("Rule %q insufficient approvals (%d/%d required):", rule.Name, len(rule.ApprovedBy), rule.ApprovalsRequired)))
 				}
 
 				eligibleApprovers := rule.EligibleApprovers
@@ -75,7 +73,7 @@ func NewCmdApprovers(f *cmdutils.Factory) *cobra.Command {
 					approved := "👍"
 					table.AddRow(approver.Name, approver.Username, approved, "")
 				}
-				fmt.Fprintln(out, table)
+				fmt.Fprintln(f.IO.StdOut, table)
 			}
 			return nil
 		},

--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -21,8 +21,6 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -46,13 +44,13 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 			l.StateEvent = gitlab.String("close")
 			arrIds := strings.Split(strings.Trim(mergeID, "[] "), ",")
 			for _, i2 := range arrIds {
-				fmt.Fprintf(out, "- Closing Merge request...")
+				fmt.Fprintf(f.IO.StdOut, "- Closing Merge request...")
 				mr, err := api.UpdateMR(apiClient, repo.FullName(), utils.StringToInt(i2), l)
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(out, "%s Merge request !%s\n", utils.RedCheck(), i2)
-				fmt.Fprintln(out, mrutils.DisplayMR(mr))
+				fmt.Fprintf(f.IO.StdOut, "%s Merge request !%s\n", utils.RedCheck(), i2)
+				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 			}
 
 			return nil

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -20,8 +20,6 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Example: "$ glab delete 123",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -32,13 +30,13 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out, "- Deleting Merge Request !%d\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Deleting Merge Request !%d\n", mr.IID)
 
 			if err = api.DeleteMR(apiClient, repo.FullName(), mr.IID); err != nil {
 				return err
 			}
 
-			fmt.Fprintf(out, "%s Merge request !%d deleted\n", utils.RedCheck(), mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "%s Merge request !%d deleted\n", utils.RedCheck(), mr.IID)
 
 			return nil
 		},

--- a/commands/mr/for/mr_for.go
+++ b/commands/mr/for/mr_for.go
@@ -31,7 +31,6 @@ func NewCmdFor(f *cmdutils.Factory) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -135,7 +134,7 @@ func NewCmdFor(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/issues/mr_issues.go
+++ b/commands/mr/issues/mr_issues.go
@@ -23,7 +23,6 @@ func NewCmdIssues(f *cmdutils.Factory) *cobra.Command {
 		Example: "$ glab mr issues 46",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -48,7 +47,7 @@ func NewCmdIssues(f *cmdutils.Factory) *cobra.Command {
 			title.ListActionType = "search"
 			title.CurrentPageTotal = len(mrIssues)
 
-			fmt.Fprintf(out, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(mrIssues, repo.FullName()))
+			fmt.Fprintf(f.IO.StdOut, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(mrIssues, repo.FullName()))
 			return nil
 		},
 	}

--- a/commands/mr/merge/mr_merge.go
+++ b/commands/mr/merge/mr_merge.go
@@ -26,7 +26,6 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -69,7 +68,7 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 				opts.SHA = gitlab.String(m)
 			}
 
-			fmt.Fprintf(out, "- Merging merge request !%d\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Merging merge request !%d\n", mr.IID)
 
 			mr, err = api.MergeMR(apiClient, repo.FullName(), mr.IID, opts)
 
@@ -77,8 +76,8 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(out, utils.GreenCheck(), "Merged")
-			fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Merged")
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/note/mr_note_create.go
+++ b/commands/mr/note/mr_note_create.go
@@ -22,7 +22,6 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -61,7 +60,7 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out, "%s#note_%d\n", mr.WebURL, noteInfo.ID)
+			fmt.Fprintf(f.IO.StdOut, "%s#note_%d\n", mr.WebURL, noteInfo.ID)
 			return nil
 		},
 	}

--- a/commands/mr/rebase/mr_rebase.go
+++ b/commands/mr/rebase/mr_rebase.go
@@ -21,7 +21,6 @@ func NewCmdRebase(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -33,7 +32,7 @@ func NewCmdRebase(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(out, "- Sending request...")
+			fmt.Fprintln(f.IO.StdOut, "- Sending request...")
 			err = api.RebaseMR(apiClient, repo.FullName(), mr.IID)
 			if err != nil {
 				return err
@@ -41,7 +40,7 @@ func NewCmdRebase(f *cmdutils.Factory) *cobra.Command {
 
 			opts := &gitlab.GetMergeRequestsOptions{}
 			opts.IncludeRebaseInProgress = gitlab.Bool(true)
-			fmt.Fprintln(out, "- Checking rebase status...")
+			fmt.Fprintln(f.IO.StdOut, "- Checking rebase status...")
 			i := 0
 			for {
 				mr, err := api.GetMR(apiClient, repo.FullName(), mr.IID, opts)
@@ -50,14 +49,14 @@ func NewCmdRebase(f *cmdutils.Factory) *cobra.Command {
 				}
 				if mr.RebaseInProgress {
 					if i == 0 {
-						fmt.Fprintln(out, "- Rebase in progress...")
+						fmt.Fprintln(f.IO.StdOut, "- Rebase in progress...")
 					}
 				} else {
 					if mr.MergeError != "" && mr.MergeError != "null" {
-						fmt.Fprintln(utils.ColorableErr(cmd), mr.MergeError)
+						fmt.Fprintln(f.IO.StdErr, mr.MergeError)
 						break
 					}
-					fmt.Fprintln(out, utils.GreenCheck(), "Rebase successful")
+					fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Rebase successful")
 					break
 				}
 				i++

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -20,8 +20,6 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"open"},
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -42,15 +40,15 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 			l := &gitlab.UpdateMergeRequestOptions{}
 			l.StateEvent = gitlab.String("reopen")
 
-			fmt.Fprintf(out, "- Reopening Merge request !%d...\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Reopening Merge request !%d...\n", mr.IID)
 
 			mr, err = api.UpdateMR(apiClient, repo.FullName(), mr.IID, l)
 			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(out, "%s Merge request !%d reopened\n", utils.GreenCheck(), mr.IID)
-			fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintf(f.IO.StdOut, "%s Merge request !%d reopened\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/revoke/mr_revoke.go
+++ b/commands/mr/revoke/mr_revoke.go
@@ -20,7 +20,6 @@ func NewCmdRevoke(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -40,14 +39,14 @@ func NewCmdRevoke(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out, "- Revoking approval for Merge Request #%d...\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Revoking approval for Merge Request #%d...\n", mr.IID)
 
 			err = api.UnapproveMR(apiClient, repo.FullName(), mr.IID)
 			if err != nil {
 				return err
 			}
 
-			fmt.Fprintln(out, utils.GreenCheck(), "Merge Request approval revoked")
+			fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Merge Request approval revoked")
 
 			return nil
 		},

--- a/commands/mr/subscribe/mr_subscribe.go
+++ b/commands/mr/subscribe/mr_subscribe.go
@@ -20,7 +20,6 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -38,15 +37,15 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out, "- Subscribing to merge request !%d\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Subscribing to merge request !%d\n", mr.IID)
 
 			mr, err = api.SubscribeToMR(apiClient, repo.FullName(), mr.IID, nil)
 			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(out, "%s You have successfully subscribed to merge request !%d\n", utils.GreenCheck(), mr.IID)
-			fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintf(f.IO.StdOut, "%s You have successfully subscribed to merge request !%d\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/subscribe/mr_subscribe_test.go
+++ b/commands/mr/subscribe/mr_subscribe_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/profclems/glab/internal/utils"
+
 	"github.com/acarl005/stripansi"
 	"github.com/profclems/glab/commands/cmdtest"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -27,7 +29,12 @@ hosts:
     username: monalisa
     token: OTOKEN
 `, "")()
+
+	io, _, stdout, stderr := utils.IOTest()
 	stubFactory, _ := cmdtest.StubFactoryWithConfig("")
+	stubFactory.IO = io
+	stubFactory.IO.IsaTTY = true
+	stubFactory.IO.IsErrTTY = true
 
 	oldSubscribeMR := api.SubscribeToMR
 	timer, _ := time.Parse(time.RFC3339, "2014-11-12T11:45:26.371Z")
@@ -113,7 +120,7 @@ hosts:
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			output, err := cmdtest.RunCommand(cmd, tc.Issue)
+			_, err := cmdtest.RunCommand(cmd, tc.Issue)
 
 			if tc.wantErr {
 				require.Error(t, err)
@@ -122,10 +129,11 @@ hosts:
 				require.NoError(t, err)
 			}
 
-			out := stripansi.Strip(output.String())
+			out := stripansi.Strip(stdout.String())
 
 			for _, msg := range tc.ExpectedMsg {
 				assert.Contains(t, out, msg)
+				assert.Equal(t, "", stderr.String())
 			}
 		})
 	}

--- a/commands/mr/todo/mr_todo.go
+++ b/commands/mr/todo/mr_todo.go
@@ -21,7 +21,6 @@ func NewCmdTodo(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -38,7 +37,7 @@ func NewCmdTodo(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(out, utils.GreenCheck(), "Done!!")
+			fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Done!!")
 
 			return nil
 		},

--- a/commands/mr/unsubscribe/mr_unsubscribe.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe.go
@@ -20,7 +20,6 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -38,15 +37,15 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(out, "- Unsubscribing from Merge Request !%d\n", mr.IID)
+			fmt.Fprintf(f.IO.StdOut, "- Unsubscribing from Merge Request !%d\n", mr.IID)
 
 			mr, err = api.UnsubscribeFromMR(apiClient, repo.FullName(), mr.IID, nil)
 			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(out, "%s You have successfully unsubscribed from merge request !%d\n", utils.GreenCheck(), mr.IID)
-			fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintf(f.IO.StdOut, "%s You have successfully unsubscribed from merge request !%d\n", utils.GreenCheck(), mr.IID)
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 
 			return nil
 		},

--- a/commands/mr/unsubscribe/mr_unsubscribe_test.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/profclems/glab/internal/utils"
+
 	"github.com/acarl005/stripansi"
 	"github.com/profclems/glab/commands/cmdtest"
 	"github.com/profclems/glab/internal/config"
@@ -26,7 +28,12 @@ hosts:
     username: monalisa
     token: OTOKEN
 `, "")()
+
+	io, _, stdout, stderr := utils.IOTest()
 	stubFactory, _ := cmdtest.StubFactoryWithConfig("")
+	stubFactory.IO = io
+	stubFactory.IO.IsaTTY = true
+	stubFactory.IO.IsErrTTY = true
 
 	oldUnsubscribeMR := api.UnsubscribeFromMR
 	timer, _ := time.Parse(time.RFC3339, "2014-11-12T11:45:26.371Z")
@@ -111,7 +118,7 @@ hosts:
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 
-			output, err := cmdtest.RunCommand(cmd, tc.Issue)
+			_, err := cmdtest.RunCommand(cmd, tc.Issue)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
@@ -119,10 +126,11 @@ hosts:
 				require.NoError(t, err)
 			}
 
-			out := stripansi.Strip(output.String())
+			out := stripansi.Strip(stdout.String())
 
 			for _, msg := range tc.ExpectedMsg {
 				assert.Contains(t, out, msg)
+				assert.Equal(t, "", stderr.String())
 			}
 		})
 	}

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
-	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 
 	"github.com/MakeNowJust/heredoc"
@@ -27,7 +26,6 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -97,7 +95,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(out, mrutils.DisplayMR(mr))
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 			return nil
 		},
 	}

--- a/commands/pipeline/ci/trace/pipeline_ci_trace.go
+++ b/commands/pipeline/ci/trace/pipeline_ci_trace.go
@@ -39,8 +39,6 @@ func TraceCmdFunc(cmd *cobra.Command, args []string, f *cmdutils.Factory) error 
 	var jobID int
 	var err error
 
-	out := utils.ColorableOut(cmd)
-
 	apiClient, err := f.HttpClient()
 	if err != nil {
 		return err
@@ -71,7 +69,7 @@ func TraceCmdFunc(cmd *cobra.Command, args []string, f *cmdutils.Factory) error 
 		l.Page = 1
 		l.PerPage = 1
 
-		fmt.Fprintf(out, "Searching for latest pipeline on %s...\n", branch)
+		fmt.Fprintf(f.IO.StdOut, "Searching for latest pipeline on %s...\n", branch)
 
 		pipes, err := api.GetPipelines(apiClient, l, repo.FullName())
 		if err != nil {
@@ -79,12 +77,12 @@ func TraceCmdFunc(cmd *cobra.Command, args []string, f *cmdutils.Factory) error 
 		}
 
 		if len(pipes) == 0 {
-			fmt.Fprintln(out, "No pipeline running or available on "+branch+"branch")
+			fmt.Fprintln(f.IO.StdOut, "No pipeline running or available on "+branch+"branch")
 			return nil
 		}
 
 		pipeline := pipes[0]
-		fmt.Fprintf(out, "Getting jobs for pipeline %d...\n", pipeline.ID)
+		fmt.Fprintf(f.IO.StdOut, "Getting jobs for pipeline %d...\n", pipeline.ID)
 
 		jobs, err := api.GetPipelineJobs(apiClient, pipeline.ID, repo.FullName())
 		if err != nil {
@@ -126,7 +124,7 @@ func TraceCmdFunc(cmd *cobra.Command, args []string, f *cmdutils.Factory) error 
 		return err
 	}
 
-	err = pipelineutils.RunTrace(apiClient, context.Background(), out, repo.FullName(), job.Pipeline.Sha, job.Name)
+	err = pipelineutils.RunTrace(apiClient, context.Background(), f.IO.StdOut, repo.FullName(), job.Pipeline.Sha, job.Name)
 	if err != nil {
 		return err
 	}

--- a/commands/pipeline/ci/view/pipeline_ci_view.go
+++ b/commands/pipeline/ci/view/pipeline_ci_view.go
@@ -61,7 +61,7 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			defer recoverPanic(a)
 			var err error
 
-			cOut = utils.ColorableOut(cmd)
+			cOut = f.IO.StdOut
 
 			apiClient, err = f.HttpClient()
 			if err != nil {

--- a/commands/pipeline/delete/pipeline_delete.go
+++ b/commands/pipeline/delete/pipeline_delete.go
@@ -28,8 +28,6 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 
 			var err error
 
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -53,7 +51,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 						return err
 					}
 
-					fmt.Fprintln(out, utils.RedCheck(), "Pipeline #"+strconv.Itoa(item.ID)+" Deleted Successfully")
+					fmt.Fprintln(f.IO.StdOut, utils.RedCheck(), "Pipeline #"+strconv.Itoa(item.ID)+" Deleted Successfully")
 				}
 
 			} else {
@@ -61,13 +59,13 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 
 				arrIds := strings.Split(strings.Trim(pipelineID, "[] "), ",")
 				for _, i2 := range arrIds {
-					fmt.Fprintln(out, "Deleting Pipeline #"+i2)
+					fmt.Fprintln(f.IO.StdOut, "Deleting Pipeline #"+i2)
 					err := api.DeletePipeline(apiClient, repo.FullName(), utils.StringToInt(i2))
 					if err != nil {
 						return err
 					}
 
-					fmt.Fprintln(out, utils.RedCheck(), "Pipeline #"+i2+" Deleted Successfully")
+					fmt.Fprintln(f.IO.StdOut, utils.RedCheck(), "Pipeline #"+i2+" Deleted Successfully")
 				}
 				fmt.Println()
 			}

--- a/commands/pipeline/list/pipeline_list.go
+++ b/commands/pipeline/list/pipeline_list.go
@@ -27,8 +27,6 @@ func NewCmdList(f *cmdutils.Factory) *cobra.Command {
 			var err error
 			var titleQualifier string
 
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -70,7 +68,7 @@ func NewCmdList(f *cmdutils.Factory) *cobra.Command {
 			title.Page = l.Page
 			title.CurrentPageTotal = len(pipes)
 
-			fmt.Fprintf(out, "%s\n%s\n", title.Describe(), pipelineutils.DisplayMultiplePipelines(pipes, repo.FullName()))
+			fmt.Fprintf(f.IO.StdOut, "%s\n%s\n", title.Describe(), pipelineutils.DisplayMultiplePipelines(pipes, repo.FullName()))
 			return nil
 		},
 	}

--- a/commands/pipeline/run/pipeline_run.go
+++ b/commands/pipeline/run/pipeline_run.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/git"
-	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 
 	"github.com/MakeNowJust/heredoc"
@@ -48,8 +47,6 @@ func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -84,7 +81,7 @@ func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(out, "Created pipeline (id:", pipe.ID, "), status:", pipe.Status, ", ref:", pipe.Ref, ", weburl: ", pipe.WebURL, ")")
+			fmt.Fprintln(f.IO.StdOut, "Created pipeline (id:", pipe.ID, "), status:", pipe.Status, ", ref:", pipe.Ref, ", weburl: ", pipe.WebURL, ")")
 			return nil
 		},
 	}

--- a/commands/pipeline/status/pipeline_status.go
+++ b/commands/pipeline/status/pipeline_status.go
@@ -32,8 +32,6 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-			out := utils.ColorableOut(cmd)
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -141,7 +139,7 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 				return nil
 			}
 			redCheck := utils.Red("✘")
-			fmt.Fprintf(out, "%s No pipelines running or available on %s branch\n", redCheck, branch)
+			fmt.Fprintf(f.IO.StdOut, "%s No pipelines running or available on %s branch\n", redCheck, branch)
 			return nil
 		},
 	}

--- a/commands/project/archive/repo_archive.go
+++ b/commands/project/archive/repo_archive.go
@@ -8,11 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/profclems/glab/commands/cmdutils"
-	"github.com/profclems/glab/internal/utils"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/dustin/go-humanize"
+	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
@@ -37,8 +35,6 @@ func NewCmdArchive(f *cmdutils.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var name string
 			var err error
-
-			colorableOut := utils.ColorableOut(cmd)
 
 			if len(args) != 0 {
 				err = f.RepoOverride(args[0])
@@ -96,12 +92,12 @@ func NewCmdArchive(f *cmdutils.Factory) *cobra.Command {
 				return fmt.Errorf("failed to write repos: %v", err)
 			}
 
-			fmt.Fprint(colorableOut, "\n")
+			fmt.Fprint(f.IO.StdOut, "\n")
 			_ = out.Close()
 			if err = os.Rename(archiveName+".tmp", archiveName); err != nil {
 				return fmt.Errorf("failed to rename tmp repos: %v", err)
 			}
-			fmt.Fprintln(colorableOut, "Complete...", archiveName)
+			fmt.Fprintln(f.IO.StdOut, "Complete...", archiveName)
 			return nil
 		},
 	}

--- a/commands/project/contributors/repo_contributors.go
+++ b/commands/project/contributors/repo_contributors.go
@@ -30,7 +30,6 @@ func NewCmdContributors(f *cmdutils.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			var err error
-			out := utils.ColorableOut(cmd)
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -54,7 +53,7 @@ func NewCmdContributors(f *cmdutils.Factory) *cobra.Command {
 					utils.Green(string(rune(user.Additions))))
 			}
 
-			fmt.Fprintln(out, usersPrintDetails)
+			fmt.Fprintln(f.IO.StdOut, usersPrintDetails)
 			return err
 		},
 	}

--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -82,7 +82,6 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 		isPath = true
 	}
 
-	out := utils.ColorableOut(cmd)
 	apiClient, err := f.HttpClient()
 	if err != nil {
 		return err
@@ -151,16 +150,9 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 	project, err := api.CreateProject(apiClient, opts)
 
 	greenCheck := utils.Green("✓")
-	isTTY := false
-	if outFile, isFile := out.(*os.File); isFile {
-		isTTY = utils.IsTerminal(outFile)
-		if isTTY {
-			// FIXME: duplicates colorableOut
-			out = utils.NewColorable(outFile)
-		}
-	}
+
 	if err == nil {
-		fmt.Fprintf(out, "%s Created repository %s on GitLab: %s\n", greenCheck, project.NameWithNamespace, project.WebURL)
+		fmt.Fprintf(f.IO.StdOut, "%s Created repository %s on GitLab: %s\n", greenCheck, project.NameWithNamespace, project.WebURL)
 		if isPath {
 			cfg, _ := f.Config()
 			protocol, _ := cfg.Get(repo.RepoHost(), "git_protocol")
@@ -178,9 +170,9 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(out, "%s Added remote %s\n", greenCheck, remote)
+			fmt.Fprintf(f.IO.StdOut, "%s Added remote %s\n", greenCheck, remote)
 
-		} else if isTTY {
+		} else if f.IO.IsaTTY {
 			doSetup, err := utils.Confirm(fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace))
 			if err != nil {
 				return err
@@ -192,7 +184,7 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(out, "%s Initialized repository in './%s/'\n", greenCheck, projectPath)
+				fmt.Fprintf(f.IO.StdOut, "%s Initialized repository in './%s/'\n", greenCheck, projectPath)
 			}
 		}
 	} else {

--- a/commands/project/search/project_search.go
+++ b/commands/project/search/project_search.go
@@ -22,7 +22,7 @@ func NewCmdSearch(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"find", "lookup"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			out := utils.ColorableOut(cmd)
+
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -61,7 +61,7 @@ func NewCmdSearch(f *cmdutils.Factory) *cobra.Command {
 				table.EndRow()
 			}
 
-			fmt.Fprintf(out, "%s\n%s\n", title, table.Render())
+			fmt.Fprintf(f.IO.StdOut, "%s\n%s\n", title, table.Render())
 			return nil
 		},
 	}

--- a/commands/release/list/release_list.go
+++ b/commands/release/list/release_list.go
@@ -60,7 +60,7 @@ func listReleases(cmd *cobra.Command, args []string) error {
 
 		cfg, _ := factory.Config()
 		glamourStyle, _ := cfg.Get(repo.RepoHost(), "glamour_style")
-		fmt.Fprintln(utils.ColorableOut(cmd), releaseutils.DisplayRelease(release, glamourStyle))
+		fmt.Fprintln(factory.IO.StdOut, releaseutils.DisplayRelease(release, glamourStyle))
 	} else {
 		l.PerPage = 30
 
@@ -74,7 +74,7 @@ func listReleases(cmd *cobra.Command, args []string) error {
 		title.Page = 0
 		title.CurrentPageTotal = len(releases)
 
-		fmt.Fprintf(utils.ColorableOut(cmd), "%s\n%s\n", title.Describe(), releaseutils.DisplayAllReleases(releases, repo.FullName()))
+		fmt.Fprintf(factory.IO.StdOut, "%s\n%s\n", title.Describe(), releaseutils.DisplayAllReleases(releases, repo.FullName()))
 	}
 	return nil
 }

--- a/commands/release/list/release_list_test.go
+++ b/commands/release/list/release_list_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/profclems/glab/internal/utils"
+
 	cmdTestUtils "github.com/profclems/glab/commands/cmdtest"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/pkg/api"
@@ -106,7 +108,11 @@ func TestNewCmdReleaseList(t *testing.T) {
 		},
 	}
 
+	io, _, stdout, stderr := utils.IOTest()
 	f := cmdTestUtils.StubFactory("https://gitlab.com/glab-cli/test")
+	f.IO = io
+	f.IO.IsaTTY = true
+	f.IO.IsErrTTY = true
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,7 +120,7 @@ func TestNewCmdReleaseList(t *testing.T) {
 			cmd := NewCmdReleaseList(f)
 			cmdutils.EnableRepoOverride(cmd, f)
 
-			output, err := cmdTestUtils.RunCommand(cmd, tt.args)
+			_, err := cmdTestUtils.RunCommand(cmd, tt.args)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -122,8 +128,8 @@ func TestNewCmdReleaseList(t *testing.T) {
 				require.Nil(t, err)
 			}
 
-			out := stripansi.Strip(output.String())
-			outErr := stripansi.Strip(output.Stderr())
+			out := stripansi.Strip(stdout.String())
+			outErr := stripansi.Strip(stderr.String())
 
 			tt.stdOutFunc(t, out)
 			assert.Contains(t, outErr, tt.stdErr)

--- a/commands/root.go
+++ b/commands/root.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-
 	aliasCmd "github.com/profclems/glab/commands/alias"
 	authCmd "github.com/profclems/glab/commands/auth"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -61,16 +59,6 @@ func NewCmdRoot(f *cmdutils.Factory, version, buildDate string) *cobra.Command {
 			https://github.com/charmbracelet/glamour#styles
 		`),
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				fmt.Printf("Unknown command: %s\n", args[0])
-				return cmd.Usage()
-			} else if ok, _ := cmd.Flags().GetBool("version"); ok {
-				return versionCmd.NewCmdVersion(version, buildDate).RunE(cmd, args)
-			}
-
-			return cmd.Help()
-		},
 	}
 
 	rootCmd.SetOut(f.IO.StdOut)
@@ -86,12 +74,16 @@ func NewCmdRoot(f *cmdutils.Factory, version, buildDate string) *cobra.Command {
 		return &cmdutils.FlagError{Err: err}
 	})
 
+	formattedVersion := versionCmd.Scheme(version, buildDate)
+	rootCmd.SetVersionTemplate(formattedVersion)
+	rootCmd.Version = formattedVersion
+
 	// Child commands
 	rootCmd.AddCommand(aliasCmd.NewCmdAlias(f))
 	rootCmd.AddCommand(configCmd.NewCmdConfig(f))
 	rootCmd.AddCommand(completionCmd.NewCmdCompletion(f.IO))
-	rootCmd.AddCommand(versionCmd.NewCmdVersion(version, buildDate))
-	rootCmd.AddCommand(updateCmd.NewCheckUpdateCmd(version, buildDate))
+	rootCmd.AddCommand(versionCmd.NewCmdVersion(f.IO, version, buildDate))
+	rootCmd.AddCommand(updateCmd.NewCheckUpdateCmd(f.IO, version, buildDate))
 	rootCmd.AddCommand(authCmd.NewCmdAuth(f))
 
 	// the commands below require apiClient and resolved repos

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -36,7 +36,7 @@ func TestRootVersion(t *testing.T) {
 	os.Stdout = old // restoring the real stdout
 	out := <-outC
 
-	assert.Contains(t, out, "glab v1.0.0 (2020-01-01)")
+	assert.Equal(t, "glab version 1.0.0 (2020-01-01)\n", out)
 }
 
 func TestRootNoArg(t *testing.T) {

--- a/commands/update/checkupdate.go
+++ b/commands/update/checkupdate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCheckUpdateCmd(version, build string) *cobra.Command {
+func NewCheckUpdateCmd(s *utils.IOStreams, version, build string) *cobra.Command {
 	// versionCmd represents the version command
 	var cmd = &cobra.Command{
 		Use:     "check-update",
@@ -18,14 +18,14 @@ func NewCheckUpdateCmd(version, build string) *cobra.Command {
 		Long:    ``,
 		Aliases: []string{"update"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return CheckUpdate(cmd, version, build, false)
+			return CheckUpdate(cmd, s, version, build, false)
 		},
 	}
 
 	return cmd
 }
 
-func CheckUpdate(cmd *cobra.Command, version, build string, silentErr bool) error {
+func CheckUpdate(cmd *cobra.Command, s *utils.IOStreams, version, build string, silentErr bool) error {
 	releaseInfo, err := GetUpdateInfo()
 	if err != nil {
 		if silentErr {
@@ -41,10 +41,10 @@ func CheckUpdate(cmd *cobra.Command, version, build string, silentErr bool) erro
 		if silentErr {
 			return nil
 		}
-		fmt.Fprintf(utils.ColorableOut(cmd), "%v %v", utils.GreenCheck(),
+		fmt.Fprintf(s.StdOut, "%v %v", utils.GreenCheck(),
 			utils.Green("You are already using the latest version of glab"))
 	} else {
-		fmt.Fprintf(utils.ColorableOut(cmd), "%s %s → %s\n%s\n",
+		fmt.Fprintf(s.StdOut, "%s %s → %s\n%s\n",
 			utils.Yellow("A new version of glab has been released:"),
 			utils.Red(version), utils.Green(latestVersion),
 			releaseInfo.HTMLUrl)

--- a/commands/version/version.go
+++ b/commands/version/version.go
@@ -2,25 +2,32 @@ package version
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/profclems/glab/internal/utils"
 	"github.com/spf13/cobra"
 )
 
-var VersionOutput = "DEV"
-
-func NewCmdVersion(s *utils.IOStreams, version, build string) *cobra.Command {
-	VersionOutput = fmt.Sprintf("glab %s (%s)", version, build)
+func NewCmdVersion(s *utils.IOStreams, version, buildDate string) *cobra.Command {
 	var versionCmd = &cobra.Command{
 		Use:     "version",
 		Short:   "show glab version information",
 		Long:    ``,
 		Aliases: []string{"v"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintln(s.StdOut, VersionOutput)
+			fmt.Fprint(s.StdOut, Scheme(version, buildDate))
 			return nil
 		},
 	}
-	versionCmd.Root().SetVersionTemplate(VersionOutput)
 	return versionCmd
+}
+
+func Scheme(version, buildDate string) string {
+	version = strings.TrimPrefix(version, "v")
+
+	if buildDate != "" {
+		version = fmt.Sprintf("%s (%s)", version, buildDate)
+	}
+
+	return fmt.Sprintf("glab version %s\n", version)
 }

--- a/commands/version/version.go
+++ b/commands/version/version.go
@@ -7,18 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmdVersion(version, build string) *cobra.Command {
-	versionOutput := fmt.Sprintf("glab %s (%s)", version, build)
+var VersionOutput = "DEV"
+
+func NewCmdVersion(s *utils.IOStreams, version, build string) *cobra.Command {
+	VersionOutput = fmt.Sprintf("glab %s (%s)", version, build)
 	var versionCmd = &cobra.Command{
 		Use:     "version",
 		Short:   "show glab version information",
 		Long:    ``,
 		Aliases: []string{"v"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintln(utils.ColorableOut(cmd), versionOutput)
+			fmt.Fprintln(s.StdOut, VersionOutput)
 			return nil
 		},
 	}
-	versionCmd.Root().SetVersionTemplate(versionOutput)
+	versionCmd.Root().SetVersionTemplate(VersionOutput)
 	return versionCmd
 }

--- a/commands/version/version_test.go
+++ b/commands/version/version_test.go
@@ -1,9 +1,6 @@
 package version
 
 import (
-	"bytes"
-	"io"
-	"os"
 	"testing"
 
 	"github.com/profclems/glab/internal/utils"
@@ -12,26 +9,9 @@ import (
 )
 
 func Test_Version(t *testing.T) {
-	old := os.Stdout // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	ios, _, stdout, stderr := utils.IOTest()
+	assert.Nil(t, NewCmdVersion(ios, "v1.0.0", "2020-01-01").Execute())
 
-	ios, _, _, _ := utils.IOTest()
-
-	NewCmdVersion(ios, "v1.0.0", "2020-01-01").Execute()
-
-	outC := make(chan string)
-	// copy the output in a separate goroutine so printing can't block indefinitely
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	// back to normal state
-	w.Close()
-	os.Stdout = old // restoring the real stdout
-	out := <-outC
-
-	assert.Contains(t, out, "lab version 1.0.0 (2020-01-01)")
+	assert.Equal(t, "glab version 1.0.0 (2020-01-01)\n", stdout.String())
+	assert.Equal(t, "", stderr.String())
 }

--- a/commands/version/version_test.go
+++ b/commands/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"bytes"
+	"github.com/profclems/glab/internal/utils"
 	"io"
 	"os"
 	"testing"
@@ -14,7 +15,9 @@ func Test_Version(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	NewCmdVersion("v1.0.0", "2020-01-01").Execute()
+	ios, _, _, _ := utils.IOTest()
+
+	NewCmdVersion(ios, "v1.0.0", "2020-01-01").Execute()
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely
@@ -29,5 +32,5 @@ func Test_Version(t *testing.T) {
 	os.Stdout = old // restoring the real stdout
 	out := <-outC
 
-	assert.Contains(t, out, "glab v1.0.0 (2020-01-01)")
+	assert.Contains(t, out, "lab version 1.0.0 (2020-01-01)")
 }

--- a/commands/version/version_test.go
+++ b/commands/version/version_test.go
@@ -2,10 +2,11 @@ package version
 
 import (
 	"bytes"
-	"github.com/profclems/glab/internal/utils"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/profclems/glab/internal/utils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/tcnksm/go-gitconfig v0.1.2
 	github.com/xanzy/go-gitlab v0.39.0
 	github.com/yuin/goldmark v1.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/internal/utils/iostreams.go
+++ b/internal/utils/iostreams.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	"github.com/google/shlex"
-	"github.com/mattn/go-isatty"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -138,11 +136,6 @@ func isStdoutTerminal() bool {
 	return _isStdoutTerminal
 }
 
-// IsTerminal reports whether the file descriptor is connected to a terminal
-func IsTerminal(f *os.File) bool {
-	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
-}
-
 func IOTest() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	in := &bytes.Buffer{}
 	out := &bytes.Buffer{}
@@ -152,22 +145,4 @@ func IOTest() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 		StdOut: out,
 		StdErr: errOut,
 	}, in, out, errOut
-}
-
-// TODO: remove after making sure no function uses it
-func ColorableOut(cmd *cobra.Command) io.Writer {
-	out := cmd.OutOrStdout()
-	if outFile, isFile := out.(*os.File); isFile {
-		return NewColorable(outFile)
-	}
-	return out
-}
-
-// TODO: remove
-func ColorableErr(cmd *cobra.Command) io.Writer {
-	err := cmd.ErrOrStderr()
-	if outFile, isFile := err.(*os.File); isFile {
-		return NewColorable(outFile)
-	}
-	return err
 }

--- a/internal/utils/terminal.go
+++ b/internal/utils/terminal.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/mattn/go-isatty"
 	"golang.org/x/crypto/ssh/terminal"
-	"os"
 )
 
 // IsTerminal reports whether the file descriptor is connected to a terminal

--- a/internal/utils/terminal.go
+++ b/internal/utils/terminal.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"golang.org/x/crypto/ssh/terminal"
+	"os"
+)
+
+// IsTerminal reports whether the file descriptor is connected to a terminal
+var IsTerminal = func(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || IsCygwinTerminal(f)
+}
+
+func IsCygwinTerminal(f *os.File) bool {
+	return isatty.IsCygwinTerminal(f.Fd())
+}
+
+var TerminalSize = func(w interface{}) (int, int, error) {
+	if f, isFile := w.(*os.File); isFile {
+		return terminal.GetSize(int(f.Fd()))
+	}
+
+	return 0, 0, fmt.Errorf("%v is not a file", w)
+}


### PR DESCRIPTION
- This PR cleans up the old `utils.ColorableOut` and `utils.ColourableErr` funcs in favour of the iostream package
- Serves as a Pre-work to resolving #300 