### PR TITLE
deprecate `glab config init` in favour of `glab auth login`

### DIFF
--- a/commands/config/config.go
+++ b/commands/config/config.go
@@ -146,6 +146,7 @@ Examples:
 			return configInit(f)
 		},
 	}
+	configInitCmd.Deprecated = "use `glab auth login` which is secure and has additional options."
 	return configInitCmd
 }
 


### PR DESCRIPTION
Add deprecation notice to `glab config init` command.

`glab auth login` has additional optional to read token from stdin and it provides a safer way of authenticating `glab` with GitLab tokens.

Check out https://github.com/profclems/glab#authentication

Resolves #311