### PR TITLE
fix(mr): Readd ability to close multiple MRs

### DIFF
--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -17,6 +17,7 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 		Use:   "close [<id> | <branch>]",
 		Short: `Close merge requests`,
 		Long:  ``,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			apiClient, err := f.HttpClient()

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -16,6 +16,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Use:     "delete [<id> | <branch>]",
 		Short:   `Delete merge requests`,
 		Long:    ``,
+		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"del"},
 		Example: "$ glab delete 123",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -17,7 +17,6 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Short:   `Delete merge requests`,
 		Long:    ``,
 		Aliases: []string{"del"},
-		Args:    cobra.MaximumNArgs(1),
 		Example: "$ glab delete 123",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient, err := f.HttpClient()
@@ -25,18 +24,18 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args)
 			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(f.IO.StdOut, "- Deleting Merge Request !%d\n", mr.IID)
-
-			if err = api.DeleteMR(apiClient, repo.FullName(), mr.IID); err != nil {
-				return err
+			for _, mr := range mrs {
+				fmt.Fprintf(f.IO.StdOut, "- Deleting Merge Request !%d\n", mr.IID)
+				if err = api.DeleteMR(apiClient, repo.FullName(), mr.IID); err != nil {
+					return err
+				}
+				fmt.Fprintf(f.IO.StdOut, "%s Merge request !%d deleted\n", utils.RedCheck(), mr.IID)
 			}
-
-			fmt.Fprintf(f.IO.StdOut, "%s Merge request !%d deleted\n", utils.RedCheck(), mr.IID)
 
 			return nil
 		},

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -1,6 +1,7 @@
 package mrutils
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/profclems/glab/pkg/api"
 	"github.com/profclems/glab/pkg/tableprinter"
 	"github.com/xanzy/go-gitlab"
+	"golang.org/x/sync/errgroup"
 )
 
 type MRCheckErrOptions struct {
@@ -149,6 +151,54 @@ func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrep
 	}
 
 	return mr, baseRepo, nil
+}
+
+func MRsFromArgs(f *cmdutils.Factory, args []string) ([]*gitlab.MergeRequest, glrepo.Interface, error) {
+	if len(args) <= 1 {
+		mrID, baseRepo, err := MRFromArgs(f, args)
+		if err != nil {
+			return nil, nil, err
+		}
+		return []*gitlab.MergeRequest{mrID}, baseRepo, err
+	}
+
+	apiClient, err := f.HttpClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	baseRepo, err := f.BaseRepo()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	errGroup, _ := errgroup.WithContext(context.Background())
+	mrs := make([]*gitlab.MergeRequest, len(args))
+	for i, arg := range args {
+		i, arg := i, arg
+		errGroup.Go(func() error {
+			mrID, err := strconv.Atoi(arg)
+			if err != nil {
+				return err
+			}
+			if mrID == 0 {
+				return fmt.Errorf("invalid merge request ID provided")
+			}
+			// fetching multiple MRs does not return many major params in the payload
+			// so we fetch again using the single mr endpoint
+			mr, err := api.GetMR(apiClient, baseRepo.FullName(), mrID, &gitlab.GetMergeRequestsOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get merge request %d: %w", mrID, err)
+			}
+			mrs[i] = mr
+			return nil
+		})
+	}
+	if err := errGroup.Wait(); err != nil {
+		return nil, nil, err
+	}
+	return mrs, baseRepo, nil
+
 }
 
 func GetOpenMRForBranch(apiClient *gitlab.Client, baseRepo glrepo.Interface, currentBranch string) (*gitlab.MergeRequest, error) {

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/glrepo"
@@ -155,11 +156,18 @@ func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrep
 
 func MRsFromArgs(f *cmdutils.Factory, args []string) ([]*gitlab.MergeRequest, glrepo.Interface, error) {
 	if len(args) <= 1 {
-		mrID, baseRepo, err := MRFromArgs(f, args)
-		if err != nil {
-			return nil, nil, err
+		var arrIDs []string
+		if len(args) == 1 {
+			arrIDs = strings.Split(args[0], ",")
 		}
-		return []*gitlab.MergeRequest{mrID}, baseRepo, err
+		if len(arrIDs) <= 1 {
+			mr, baseRepo, err := MRFromArgs(f, args)
+			if err != nil {
+				return nil, nil, err
+			}
+			return []*gitlab.MergeRequest{mr}, baseRepo, err
+		}
+		args = arrIDs
 	}
 
 	apiClient, err := f.HttpClient()

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -17,6 +17,7 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 		Use:     "reopen [<id> | <branch>]",
 		Short:   `Reopen merge requests`,
 		Long:    ``,
+		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"open"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient, err := f.HttpClient()

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/yuin/goldmark v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/go.sum
+++ b/go.sum
@@ -385,6 +385,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTm
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

**Description**
Ability to remove multiple MRs was there but it had gone missing when
implementing `MRFromArgs`.

Added a function for concurrently fetching multiple merge requests from
branches that, falsback to the `MRFromArgs` if the argument count is
lower then 1. This is because the MRFromArgs, contains some specific
logic for handling cases where there are no arguments or user provided
0 in arguments.

Added this functionality to deal with more then one MR to `delete` and `reopen`. 
I opted to not implement this functionality to `merge` command since, if there merge multiple MRs one might create merge conflicts to others and block the merging.  

**Related Issue**
Fixes #301


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
