### PR TITLE
fix: git directory independent commands

### DIFF
--- a/commands/auth/login/login.go
+++ b/commands/auth/login/login.go
@@ -154,7 +154,7 @@ func loginRun() error {
 	existingToken, _, _ := cfg.GetWithSource(hostname, "token")
 
 	if existingToken != "" && opts.Interactive {
-		apiClient, err := cmdutils.HttpClientFunc(hostname, cfg)
+		apiClient, err := cmdutils.HttpClientFunc(hostname, cfg, false)
 		if err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ func loginRun() error {
 		fmt.Fprintf(opts.IO.StdErr, "%s Configured git protocol\n", utils.GreenCheck())
 	}
 
-	apiClient, err := cmdutils.HttpClientFunc(hostname, cfg)
+	apiClient, err := cmdutils.HttpClientFunc(hostname, cfg, false)
 	if err != nil {
 		return err
 	}

--- a/commands/project/clone/repo_clone.go
+++ b/commands/project/clone/repo_clone.go
@@ -60,9 +60,9 @@ func NewCmdClone(f *cmdutils.Factory) *cobra.Command {
 			skipTlsVerify, _ := strconv.ParseBool(tlsVerify)
 			caCert, _ := cfg.Get(host, "ca_cert")
 			if caCert != "" {
-				apiClient, _ = api.InitWithCustomCA(host, token, caCert)
+				apiClient, _ = api.InitWithCustomCA(host, token, caCert, false)
 			} else {
-				apiClient, _ = api.Init(host, token, skipTlsVerify)
+				apiClient, _ = api.Init(host, token, skipTlsVerify, false)
 			}
 
 			repo := args[0]

--- a/internal/glinstance/host.go
+++ b/internal/glinstance/host.go
@@ -1,6 +1,7 @@
 package glinstance
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -56,7 +57,7 @@ func StripHostProtocol(h string) (hostname, protocol string) {
 	return
 }
 
-// APIEndpoint returns the API endpoint prefix for a GitLab instance :)
+// APIEndpoint returns the REST API endpoint prefix for a GitLab instance :)
 func APIEndpoint(hostname, protocol string) string {
 	if protocol == "" {
 		protocol = "https"
@@ -65,4 +66,30 @@ func APIEndpoint(hostname, protocol string) string {
 		return fmt.Sprintf("%s://%s/api/v4/", protocol, hostname)
 	}
 	return "https://gitlab.com/api/v4/"
+}
+
+// GraphQLEndpoint returns the GraphQL API endpoint prefix for a GitLab instance :)
+func GraphQLEndpoint(hostname, protocol string) string {
+	if protocol == "" {
+		protocol = "https"
+	}
+	if IsSelfHosted(hostname) {
+		return fmt.Sprintf("%s://%s/api/graphql/", protocol, hostname)
+	}
+	return "https://gitlab.com/api/graphql/"
+}
+
+func HostnameValidator(v interface{}) error {
+	hostname, valid := v.(string)
+	if !valid {
+		return errors.New("hostname is not a string")
+	}
+
+	if len(strings.TrimSpace(hostname)) < 1 {
+		return errors.New("a value is required")
+	}
+	if strings.ContainsRune(hostname, '/') || strings.ContainsRune(hostname, ':') {
+		return errors.New("invalid hostname")
+	}
+	return nil
 }

--- a/internal/glrepo/remote.go
+++ b/internal/glrepo/remote.go
@@ -59,6 +59,14 @@ type Remote struct {
 	Repo Interface
 }
 
+func (r Remote) RepoNamespace() string {
+	return r.Repo.RepoNamespace()
+}
+
+func (r Remote) RepoGroup() string {
+	return r.Repo.RepoGroup()
+}
+
 func (r Remote) FullName() string {
 	return r.Repo.FullName()
 }

--- a/internal/utils/iostreams.go
+++ b/internal/utils/iostreams.go
@@ -49,7 +49,7 @@ func InitIOStream() *IOStreams {
 		ioStream.IsInTTY = IsTerminal(stdin)
 	}
 
-	_isColorEnabled = isColorEnabled() && stdoutIsTTY
+	_isColorEnabled = isColorEnabled() && stdoutIsTTY && stderrIsTTY
 
 	return ioStream
 }
@@ -59,6 +59,10 @@ func (s *IOStreams) PromptEnabled() bool {
 		return false
 	}
 	return s.IsInTTY && s.IsaTTY
+}
+
+func (s *IOStreams) ColorEnabled() bool {
+	return isColorEnabled() && s.IsaTTY && s.IsErrTTY
 }
 
 func (s *IOStreams) SetPrompt(promptDisabled string) {


### PR DESCRIPTION
This commit fixes issues with glab requiring commands that are git-independent to be run in a git repository.
Commands like repo clone, repo archive, etc should be able to run outside git repos

Fixes #198