### PR TITLE
fix(ci view): Return error if no pipeline found

### DIFF
--- a/commands/pipeline/ci/view/pipeline_ci_view.go
+++ b/commands/pipeline/ci/view/pipeline_ci_view.go
@@ -92,6 +92,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 			CommitSHA = commit.ID
+			if commit.LastPipeline == nil {
+				return fmt.Errorf("Can't find pipeline for commit : %s", CommitSHA)
+			}
 			root := tview.NewPages()
 			root.SetBorderPadding(1, 1, 2, 2).SetBorder(true).SetTitle(fmt.Sprintf(" Pipeline #%d triggered %s by %s ", commit.LastPipeline.ID, utils.TimeToPrettyTimeAgo(*commit.AuthoredDate), commit.AuthorName))
 


### PR DESCRIPTION
**Description**
In cases where we can't find a pipeline for the commit supplied, we just
gotta return error, because otherwise it would trigger a nil pointer
exception.
**Related Issue**
Fixes #225 

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
Fixes nil pointer reference panic when trying to view CI jobs when they don't exist for a commit.

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
Before ![image](https://user-images.githubusercontent.com/14844365/100474236-dd671b80-30e8-11eb-8d57-f6f229897bdb.png)
After 
![image](https://user-images.githubusercontent.com/14844365/100474338-0b4c6000-30e9-11eb-8139-76125bea1c58.png)


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
