### PR TITLE
fix(ci): Remove OrderBy field from pipeline list options

### DIFF
--- a/commands/pipeline/ci/trace/pipeline_ci_trace.go
+++ b/commands/pipeline/ci/trace/pipeline_ci_trace.go
@@ -61,9 +61,8 @@ func TraceCmdFunc(cmd *cobra.Command, args []string, f *cmdutils.Factory) error 
 		jobID = utils.StringToInt(args[0])
 	} else {
 		l := &gitlab.ListProjectPipelinesOptions{
-			Ref:     gitlab.String(branch),
-			OrderBy: gitlab.String("updated_at"),
-			Sort:    gitlab.String("desc"),
+			Ref:  gitlab.String(branch),
+			Sort: gitlab.String("desc"),
 		}
 
 		l.Page = 1

--- a/commands/pipeline/status/pipeline_status.go
+++ b/commands/pipeline/status/pipeline_status.go
@@ -52,9 +52,8 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 				}
 			}
 			l := &gitlab.ListProjectPipelinesOptions{
-				Ref:     gitlab.String(branch),
-				OrderBy: gitlab.String("updated_at"),
-				Sort:    gitlab.String("desc"),
+				Ref:  gitlab.String(branch),
+				Sort: gitlab.String("desc"),
 			}
 			l.Page = 1
 			l.PerPage = 1

--- a/pkg/api/pipeline.go
+++ b/pkg/api/pipeline.go
@@ -182,9 +182,8 @@ var GetPipelineFromBranch = func(client *gitlab.Client, ref, repo string) ([]*gi
 		}
 	}
 	l := &gitlab.ListProjectPipelinesOptions{
-		Ref:     gitlab.String(ref),
-		OrderBy: gitlab.String("updated_at"),
-		Sort:    gitlab.String("desc"),
+		Ref:  gitlab.String(ref),
+		Sort: gitlab.String("desc"),
 	}
 	l.Page = 1
 	l.PerPage = 1


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

**Description**
This field is not supported in GitLab 11.11. This doesn't allow this
command to be run against this version of GitLab.

Since this ordering is not that important easiest is just to remove it.

See: https://docs.gitlab.com/11.11/ee/api/pipelines.html#list-project-pipelines

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #335

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
