### PR TITLE
Add template support to mr create and issue create workflow

### DIFF
--- a/.gitlab/issue_templates/Bug.md
+++ b/.gitlab/issue_templates/Bug.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+**Description**
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+
+**Expected Behavior**
+<!--- Tell us what should happen -->
+
+**Actual Behavior**
+<!--- Tell us what happens instead -->
+
+**Possible Fix**
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+**Steps to Reproduce**
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+**Context**
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+
+**Your Environment**
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Operating System and version:

--- a/.gitlab/issue_templates/Feature Request.md
+++ b/.gitlab/issue_templates/Feature Request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,0 +1,36 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+**Description**
+<!--- Describe your changes in detail -->
+
+**Related Issue**
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+**Motivation and Context**
+<!--- Why is this change required? What problem does it solve? -->
+
+**How Has This Been Tested?**
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+**Screenshots (if appropriate):**
+
+**Types of changes**
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+**Checklist:**
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -1,1 +1,80 @@
 package cmdutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/profclems/glab/internal/config"
+
+	"github.com/profclems/glab/internal/git"
+)
+
+const (
+	IssueTemplate        = "issue_templates"
+	MergeRequestTemplate = "merge_request_templates"
+)
+
+// LoadGitLabTemplate finds and loads the GitLab template from the working git directory
+// Follows the format officially supported by GitLab
+// https://docs.gitlab.com/ee/user/project/description_templates.html#setting-a-default-template-for-issues-and-merge-requests.
+//
+// TODO: load from remote repository if repo is overriden by -R flag
+func LoadGitLabTemplate(tmplType, tmplName string) (string, error) {
+	wdir, err := git.ToplevelDir()
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasSuffix(tmplName, ".md") {
+		tmplName = tmplName + ".md"
+	}
+
+	tmplFile := filepath.Join(wdir, ".gitlab", tmplType, tmplName)
+	f, err := os.Open(tmplFile)
+	if os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+
+	tmpl, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(tmpl)), nil
+}
+
+func ListGitLabTemplates(tmplType string) ([]string, error) {
+	wdir, err := git.ToplevelDir()
+	tmplFolder := filepath.Join(wdir, ".gitlab", tmplType)
+	var files []string
+	f, err := os.Open(tmplFolder)
+	if err != nil {
+		return files, err
+	}
+	fileNames, err := f.Readdirnames(-1)
+	defer f.Close()
+	if err != nil {
+		return files, err
+	}
+
+	for _, file := range fileNames {
+		files = append(files, strings.TrimSuffix(file, ".md"))
+	}
+	return files, nil
+}
+
+func GetEditor(cf func() (config.Config, error)) (string, error) {
+	cfg, err := cf()
+	if err != nil {
+		return "", fmt.Errorf("could not read config: %w", err)
+	}
+	// will search in the order glab_editor, visual, editor first from the env before the config file
+	editorCommand, _ := cfg.Get("", "editor")
+
+	return editorCommand, nil
+}

--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/profclems/glab/pkg/prompt"
+	"github.com/profclems/glab/pkg/surveyext"
+
 	"github.com/profclems/glab/internal/config"
 
 	"github.com/profclems/glab/internal/git"
@@ -77,4 +81,39 @@ func GetEditor(cf func() (config.Config, error)) (string, error) {
 	editorCommand, _ := cfg.Get("", "editor")
 
 	return editorCommand, nil
+}
+
+func DescriptionPrompt(response *string, templateContent, editorCommand string) error {
+	defaultBody := *response
+	if templateContent != "" {
+		if defaultBody != "" {
+			// prevent excessive newlines between default body and template
+			defaultBody = strings.TrimRight(defaultBody, "\n")
+			defaultBody += "\n\n"
+		}
+		defaultBody += templateContent
+	}
+
+	qs := []*survey.Question{
+		{
+			Name: "Description",
+			Prompt: &surveyext.GLabEditor{
+				BlankAllowed:  true,
+				EditorCommand: editorCommand,
+				Editor: &survey.Editor{
+					Message:       "Description",
+					FileName:      "*.md",
+					Default:       defaultBody,
+					HideDefault:   true,
+					AppendDefault: true,
+				},
+			},
+		},
+	}
+
+	err := prompt.Ask(qs, response)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/commands/issue/board/create/issue_board_create.go
+++ b/commands/issue/board/create/issue_board_create.go
@@ -3,6 +3,8 @@ package create
 import (
 	"fmt"
 
+	"github.com/profclems/glab/pkg/prompt"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
@@ -37,7 +39,10 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			}
 
 			if boardName == "" {
-				boardName = utils.AskQuestionWithInput("Board Name:", "", true)
+				err = prompt.AskQuestionWithInput(&boardName, "Board Name:", "", true)
+				if err != nil {
+					return err
+				}
 			}
 
 			opts := &gitlab.CreateIssueBoardOptions{

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -164,7 +164,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 				}
 				issueCreateOpts.AssigneeIDs = assigneeIDs
 			}
-			fmt.Fprintln(f.IO.StdErr, "- Creating issue in", repo.FullName())
+			fmt.Fprintln(f.IO.StdErr, "\n- Creating issue in", repo.FullName())
 			issue, err := api.CreateIssue(apiClient, repo.FullName(), issueCreateOpts)
 			if err != nil {
 				return err

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/profclems/glab/pkg/prompt"
+
 	"github.com/profclems/glab/pkg/api"
 
 	"github.com/profclems/glab/commands/cmdutils"
@@ -46,13 +48,19 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			if title, _ := cmd.Flags().GetString("title"); title != "" {
 				issueTitle = title
 			} else {
-				issueTitle = utils.AskQuestionWithInput("Title", "", true)
+				err = prompt.AskQuestionWithInput(&issueTitle, "Title", "", true)
+				if err != nil {
+					return err
+				}
 			}
 			if description, _ := cmd.Flags().GetString("description"); description != "" {
 				issueDescription = description
 			} else {
 				if editor, _ := cmd.Flags().GetBool("no-editor"); editor {
-					issueDescription = utils.AskQuestionMultiline("Description:", "")
+					err = prompt.AskMultiline(&issueDescription, "Description:", "")
+					if err != nil {
+						return err
+					}
 				} else {
 					issueDescription = utils.Editor(utils.EditorOptions{
 						Label:    "Description:",
@@ -67,9 +75,16 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 				labelsEntry := cachedLabels
 				if labelsEntry != "" {
 					labels := strings.Split(labelsEntry, ",")
-					issueLabel = strings.Join(utils.AskQuestionWithMultiSelect("Label(s)", labels), ",")
+					err = prompt.MultiSelect(&labels, "Label(s)", labels)
+					if err != nil {
+						return err
+					}
+					issueLabel = strings.Join(labels, ",")
 				} else {
-					issueLabel = utils.AskQuestionWithInput("Label(s) [Comma Separated]", "", false)
+					err = prompt.AskQuestionWithInput(&issueLabel, "Label(s) [Comma Separated]", "", false)
+					if err != nil {
+						return err
+					}
 				}
 			}
 			l.Title = gitlab.String(issueTitle)

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -1,22 +1,37 @@
 package create
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/profclems/glab/pkg/prompt"
-
-	"github.com/profclems/glab/pkg/api"
-
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/issue/issueutils"
 	"github.com/profclems/glab/internal/utils"
-
+	"github.com/profclems/glab/pkg/api"
+	"github.com/profclems/glab/pkg/prompt"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
 
+type CreateOpts struct {
+	Title       string
+	Description string
+	Labels      string
+	Assignees   string
+
+	Weight    int
+	MileStone int
+	LinkedMR  int
+
+	NoEditor       bool
+	IsConfidential bool
+	IsInteractive  bool
+}
+
 func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
+	opts := &CreateOpts{}
 	var issueCreateCmd = &cobra.Command{
 		Use:     "create [flags]",
 		Short:   `Create an issue`,
@@ -24,13 +39,17 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"new"},
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			l := &gitlab.CreateIssueOptions{}
-			var (
-				issueTitle       string
-				issueLabel       string
-				issueDescription string
-				err              error
-			)
+			issueCreateOpts := &gitlab.CreateIssueOptions{}
+
+			hasTitle := cmd.Flags().Changed("title")
+			hasDescription := cmd.Flags().Changed("description")
+
+			// disable interactive mode if title and description are explicitly defined
+			opts.IsInteractive = !(hasTitle && hasDescription)
+
+			if opts.IsInteractive && !f.IO.PromptEnabled() {
+				return &cmdutils.FlagError{Err: errors.New("--title and --description required for non-interactive mode")}
+			}
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -42,78 +61,111 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			cfg, _ := f.Config()
-			cachedLabels, _ := cfg.Get(repo.RepoHost(), "project_labels")
+			var templateName string
+			var templateContents string
 
-			if title, _ := cmd.Flags().GetString("title"); title != "" {
-				issueTitle = title
-			} else {
-				err = prompt.AskQuestionWithInput(&issueTitle, "Title", "", true)
-				if err != nil {
-					return err
-				}
-			}
-			if description, _ := cmd.Flags().GetString("description"); description != "" {
-				issueDescription = description
-			} else {
-				if editor, _ := cmd.Flags().GetBool("no-editor"); editor {
-					err = prompt.AskMultiline(&issueDescription, "Description:", "")
-					if err != nil {
-						return err
-					}
-				} else {
-					issueDescription = utils.Editor(utils.EditorOptions{
-						Label:    "Description:",
-						Help:     "Enter the issue description. ",
-						FileName: "*_ISSUE_EDITMSG.md",
-					})
-				}
-			}
-			if label, _ := cmd.Flags().GetString("label"); label != "" {
-				issueLabel = strings.Trim(label, "[] ")
-			} else {
-				labelsEntry := cachedLabels
-				if labelsEntry != "" {
-					labels := strings.Split(labelsEntry, ",")
-					err = prompt.MultiSelect(&labels, "Label(s)", labels)
-					if err != nil {
-						return err
-					}
-					issueLabel = strings.Join(labels, ",")
-				} else {
-					err = prompt.AskQuestionWithInput(&issueLabel, "Label(s) [Comma Separated]", "", false)
-					if err != nil {
-						return err
-					}
-				}
-			}
-			l.Title = gitlab.String(issueTitle)
-			l.Labels = gitlab.Labels{issueLabel}
-			l.Description = &issueDescription
-			if confidential, _ := cmd.Flags().GetBool("confidential"); confidential {
-				l.Confidential = gitlab.Bool(confidential)
-			}
-			if weight, _ := cmd.Flags().GetInt("weight"); weight != -1 {
-				l.Weight = gitlab.Int(weight)
-			}
-			if a, _ := cmd.Flags().GetInt("linked-mr"); a != -1 {
-				l.MergeRequestToResolveDiscussionsOf = gitlab.Int(a)
-			}
-			if a, _ := cmd.Flags().GetInt("milestone"); a != -1 {
-				l.MilestoneID = gitlab.Int(a)
-			}
-			if a, _ := cmd.Flags().GetString("assignee"); a != "" {
-				assignID := a
-				arrIds := strings.Split(strings.Trim(assignID, "[] "), ",")
-				var t2 []int
+			if opts.IsInteractive {
+				if opts.Description == "" {
+					if editor, _ := cmd.Flags().GetBool("no-editor"); editor {
+						err = prompt.AskMultiline(&opts.Description, "Description:", "")
+						if err != nil {
+							return err
+						}
+					} else {
 
-				for _, i := range arrIds {
-					j := utils.StringToInt(i)
-					t2 = append(t2, j)
+						templateResponse := struct {
+							Index int
+						}{}
+						templateNames, err := cmdutils.ListGitLabTemplates(cmdutils.IssueTemplate)
+						if err != nil {
+							return fmt.Errorf("error getting templates: %w", err)
+						}
+
+						templateNames = append(templateNames, "Open a blank merge request")
+
+						selectQs := []*survey.Question{
+							{
+								Name: "index",
+								Prompt: &survey.Select{
+									Message: "Choose a template",
+									Options: templateNames,
+								},
+							},
+						}
+
+						if err := prompt.Ask(selectQs, &templateResponse); err != nil {
+							return fmt.Errorf("could not prompt: %w", err)
+						}
+						if templateResponse.Index != len(templateNames) {
+							templateName = templateNames[templateResponse.Index]
+							templateContents, err = cmdutils.LoadGitLabTemplate(cmdutils.IssueTemplate, templateName)
+							if err != nil {
+								return fmt.Errorf("failed to get template contents: %w", err)
+							}
+						}
+					}
 				}
-				l.AssigneeIDs = t2
+				if opts.Title == "" {
+					err = prompt.AskQuestionWithInput(&opts.Title, "Title", "", true)
+					if err != nil {
+						return err
+					}
+				}
+				if opts.Description == "" {
+					if opts.NoEditor {
+						err = prompt.AskMultiline(&opts.Description, "Description:", "")
+						if err != nil {
+							return err
+						}
+					} else {
+						editor, err := cmdutils.GetEditor(f.Config)
+						if err != nil {
+							return err
+						}
+						err = cmdutils.DescriptionPrompt(&opts.Description, templateContents, editor)
+						if err != nil {
+							return err
+						}
+					}
+				}
+				if opts.Labels == "" {
+					err = prompt.AskQuestionWithInput(&opts.Labels, "Label(s) [Comma Separated]", "", false)
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				if opts.Title == "" {
+					return fmt.Errorf("title can't be blank")
+				}
 			}
-			issue, err := api.CreateIssue(apiClient, repo.FullName(), l)
+
+			issueCreateOpts.Title = gitlab.String(opts.Title)
+			issueCreateOpts.Labels = gitlab.Labels{opts.Labels}
+			issueCreateOpts.Description = &opts.Description
+			if opts.IsConfidential {
+				issueCreateOpts.Confidential = gitlab.Bool(opts.IsConfidential)
+			}
+			if opts.Weight != -1 {
+				issueCreateOpts.Weight = gitlab.Int(opts.Weight)
+			}
+			if opts.LinkedMR != -1 {
+				issueCreateOpts.MergeRequestToResolveDiscussionsOf = gitlab.Int(opts.LinkedMR)
+			}
+			if opts.MileStone != -1 {
+				issueCreateOpts.MilestoneID = gitlab.Int(opts.MileStone)
+			}
+			if opts.Assignees != "" {
+				arrIds := strings.Split(strings.Trim(opts.Assignees, "[] "), ",")
+				var assigneeIDs []int
+
+				for _, id := range arrIds {
+					assigneeIDs = append(assigneeIDs, utils.StringToInt(id))
+				}
+				issueCreateOpts.AssigneeIDs = assigneeIDs
+			}
+			fmt.Fprintln(f.IO.StdErr, "- Creating issue in", repo.FullName())
+			issue, err := api.CreateIssue(apiClient, repo.FullName(), issueCreateOpts)
 			if err != nil {
 				return err
 			}
@@ -121,15 +173,15 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
-	issueCreateCmd.Flags().StringP("title", "t", "", "Supply a title for issue")
-	issueCreateCmd.Flags().StringP("description", "d", "", "Supply a description for issue")
-	issueCreateCmd.Flags().StringP("label", "l", "", "Add label by name. Multiple labels should be comma separated")
-	issueCreateCmd.Flags().StringP("assignee", "a", "", "Assign issue to people by their ID. Multiple values should be comma separated ")
-	issueCreateCmd.Flags().IntP("milestone", "m", -1, "The global ID of a milestone to assign issue")
-	issueCreateCmd.Flags().BoolP("confidential", "c", false, "Set an issue to be confidential. Default is false")
-	issueCreateCmd.Flags().IntP("linked-mr", "", -1, "The IID of a merge request in which to resolve all issues")
-	issueCreateCmd.Flags().IntP("weight", "w", -1, "The weight of the issue. Valid values are greater than or equal to 0.")
-	issueCreateCmd.Flags().BoolP("no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
+	issueCreateCmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Supply a title for issue")
+	issueCreateCmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Supply a description for issue")
+	issueCreateCmd.Flags().StringVarP(&opts.Labels, "label", "l", "", "Add label by name. Multiple labels should be comma separated")
+	issueCreateCmd.Flags().StringVarP(&opts.Assignees, "assignee", "a", "", "Assign issue to people by their ID. Multiple values should be comma separated ")
+	issueCreateCmd.Flags().IntVarP(&opts.MileStone, "milestone", "m", -1, "The global ID of a milestone to assign issue")
+	issueCreateCmd.Flags().BoolVarP(&opts.IsConfidential, "confidential", "c", false, "Set an issue to be confidential. Default is false")
+	issueCreateCmd.Flags().IntVarP(&opts.LinkedMR, "linked-mr", "", -1, "The IID of a merge request in which to resolve all issues")
+	issueCreateCmd.Flags().IntVarP(&opts.Weight, "weight", "w", -1, "The weight of the issue. Valid values are greater than or equal to 0.")
+	issueCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 
 	return issueCreateCmd
 }

--- a/commands/issue/create/issue_create_test.go
+++ b/commands/issue/create/issue_create_test.go
@@ -71,7 +71,7 @@ func Test_IssueCreate(t *testing.T) {
 	outErr := stripansi.Strip(stderr.String())
 	expectedOut := fmt.Sprintf("#1 myissuetitle (%s)", utils.TimeToPrettyTimeAgo(timer))
 	cmdtest.Eq(t, cmdtest.FirstLine([]byte(out)), expectedOut)
-	cmdtest.Eq(t, outErr, "")
+	cmdtest.Eq(t, outErr, "\n- Creating issue in glab-cli/test\n")
 	assert.Contains(t, out, "https://gitlab.com/glab-cli/test/-/issues/1")
 
 	api.CreateIssue = oldCreateIssue

--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -82,6 +82,7 @@ func TestMrCmd(t *testing.T) {
 		"--milestone", "1",
 		"--assignee", "testuser",
 		"-R", "glab-cli/test",
+		"-s", "test-cli",
 	}
 
 	cli := strings.Join(cliStr, " ")
@@ -98,8 +99,11 @@ func TestMrCmd(t *testing.T) {
 	stderr.Reset()
 
 	assert.Contains(t, cmdtest.FirstLine([]byte(out)), `!1 myMRtitle`)
-	cmdtest.Eq(t, outErr, "")
+	// TODO: fix creating mr for default branch
+	cmdtest.Eq(t, outErr, "\nCreating merge request for test-cli into master in glab-cli/test\n\n")
 	assert.Contains(t, out, "https://gitlab.com/glab-cli/test/-/merge_requests/1")
+	stdout.Reset()
+	stderr.Reset()
 }
 
 func TestNewCmdCreate_autofill(t *testing.T) {
@@ -128,8 +132,22 @@ func TestNewCmdCreate_autofill(t *testing.T) {
 		outErr := stripansi.Strip(stderr.String())
 
 		assert.Contains(t, out, `!1 Update somefile.txt`)
-		cmdtest.Eq(t, outErr, "")
+		cmdtest.Eq(t, outErr, "\nwarning: you have 2 uncommitted changes\n\nCreating merge request for test-cli into master in glab-cli/test\n\n")
 		assert.Contains(t, out, "https://gitlab.com/glab-cli/test/-/merge_requests/1")
-
+		stdout.Reset()
+		stderr.Reset()
 	})
+}
+
+func TestMRCreate_nontty_insufficient_flags(t *testing.T) {
+	stubFactory.IO.SetPrompt("true")
+	cmd = NewCmdCreate(stubFactory)
+	_, err := cmdtest.RunCommand(cmd, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	assert.Equal(t, "--title or --fill required for non-interactive mode", err.Error())
+
+	assert.Equal(t, "", stdout.String())
 }

--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -132,7 +132,7 @@ func TestNewCmdCreate_autofill(t *testing.T) {
 		outErr := stripansi.Strip(stderr.String())
 
 		assert.Contains(t, out, `!1 Update somefile.txt`)
-		cmdtest.Eq(t, outErr, "\nwarning: you have 2 uncommitted changes\n\nCreating merge request for test-cli into master in glab-cli/test\n\n")
+		assert.Contains(t, outErr, "\nCreating merge request for test-cli into master in glab-cli/test\n\n")
 		assert.Contains(t, out, "https://gitlab.com/glab-cli/test/-/merge_requests/1")
 		stdout.Reset()
 		stderr.Reset()

--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/profclems/glab/pkg/prompt"
+
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/pkg/api"
 
@@ -173,7 +175,8 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 			fmt.Fprintf(f.IO.StdOut, "%s Added remote %s\n", greenCheck, remote)
 
 		} else if f.IO.IsaTTY {
-			doSetup, err := utils.Confirm(fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace))
+			var doSetup bool
+			err := prompt.Confirm(fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace), &doSetup)
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,9 @@ require (
 	github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gdamore/tcell v1.4.0
-	github.com/google/go-querystring v1.0.0
 	github.com/google/renameio v0.1.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gosuri/uilive v0.0.4
-	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/hashicorp/go-version v1.2.1
 	github.com/jarcoal/httpmock v1.0.6
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/charmbracelet/glamour v0.2.0 h1:mTgaiNiumpqTZp3qVM6DH9UB0NlbY17wejoMf1kM8Pg=
-github.com/charmbracelet/glamour v0.2.0/go.mod h1:UA27Kwj3QHialP74iU6C+Gpc8Y7IOAKupeKMLLBURWM=
+github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684 h1:YMyvXRstOQc7n6eneHfudVMbARSCmZ7EZGjtTkkeB3A=
 github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684/go.mod h1:UA27Kwj3QHialP74iU6C+Gpc8Y7IOAKupeKMLLBURWM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -334,8 +333,6 @@ golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -498,8 +495,6 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,14 @@
 package config
 
 import (
-	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/prompt"
 )
 
 // PromptAndSetEnv : prompts user for value and returns default value if empty
 func Prompt(question, defaultVal string) (envVal string, err error) {
-	envVal = utils.AskQuestionWithInput(question, defaultVal, false)
+	err = prompt.AskQuestionWithInput(&envVal, question, defaultVal, false)
+	if err != nil {
+		return
+	}
 	return
 }

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -646,6 +646,8 @@ func ConfigKeyEquivalence(key string) string {
 		return "no_prompt"
 	case "git_remote_url_var", "git_remote_alias", "remote_alias", "remote_nickname", "git_remote_nickname":
 		return "remote_alias"
+	case "editor", "visual", "glab_editor":
+		return "editor"
 	default:
 		return key
 	}
@@ -662,6 +664,8 @@ func EnvKeyEquivalence(key string) []string {
 		return []string{"GITLAB_TOKEN", "OAUTH_TOKEN"}
 	case "no_prompt":
 		return []string{"NO_PROMPT", "PROMPT_DISABLED"}
+	case "editor", "visual", "glab_editor":
+		return []string{"GLAB_EDITOR", "VISUAL", "EDITOR"}
 	case "remote_alias":
 		return []string{"GIT_REMOTE_URL_VAR", "GIT_REMOTE_ALIAS", "REMOTE_ALIAS", "REMOTE_NICKNAME", "GIT_REMOTE_NICKNAME"}
 	default:

--- a/internal/utils/manip.go
+++ b/internal/utils/manip.go
@@ -6,68 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/profclems/glab/pkg/prompt"
+
 	"github.com/AlecAivazis/survey/v2"
 )
-
-func AskQuestionWithInput(question, defaultVal string, isRequired bool) string {
-	str := ""
-	prompt := &survey.Input{
-		Message: question,
-	}
-	var err error
-	if isRequired {
-		err = survey.AskOne(prompt, &str, survey.WithValidator(survey.Required))
-	} else {
-		err = survey.AskOne(prompt, &str)
-	}
-	if err != nil {
-		log.Fatal(err)
-	}
-	str = strings.TrimSuffix(str, "\n")
-	if str == "" && defaultVal != "" {
-		return defaultVal
-	}
-	return str
-}
-
-// Confirm prompts user for a confirmation and returns a bool value
-func Confirm(question string) (confirmed bool, err error) {
-	confirmed = false
-	prompt := &survey.Confirm{
-		Message: question,
-	}
-	err = survey.AskOne(prompt, &confirmed)
-	return
-}
-
-func AskQuestionWithMultiSelect(question string, options []string) []string {
-	labels := []string{}
-	prompt := &survey.MultiSelect{
-		Message: question,
-		Options: options,
-	}
-	err := survey.AskOne(prompt, &labels)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return labels
-}
-
-func AskQuestionMultiline(question string, defaultVal string) string {
-	str := ""
-	prompt := &survey.Multiline{
-		Message: question,
-	}
-	err := survey.AskOne(prompt, &str)
-	if err != nil {
-		log.Fatal(err)
-	}
-	str = strings.TrimSuffix(str, "\n")
-	if str == "" && defaultVal != "" {
-		return defaultVal
-	}
-	return str
-}
 
 type EditorOptions struct {
 	FileName      string
@@ -80,7 +22,7 @@ type EditorOptions struct {
 
 func Editor(opts EditorOptions) string {
 	var container string
-	prompt := &survey.Editor{
+	editor := &survey.Editor{
 		Renderer:      survey.Renderer{},
 		Message:       opts.Label,
 		Default:       opts.Default,
@@ -89,7 +31,7 @@ func Editor(opts EditorOptions) string {
 		AppendDefault: opts.AppendDefault,
 		FileName:      opts.FileName,
 	}
-	err := survey.AskOne(prompt, &container)
+	err := prompt.AskOne(editor, &container)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,10 +40,7 @@ func Editor(opts EditorOptions) string {
 
 // ReplaceNonAlphaNumericChars : Replaces non alpha-numeric values with provided char/string
 func ReplaceNonAlphaNumericChars(words, replaceWith string) string {
-	reg, err := regexp.Compile("[^A-Za-z0-9]+")
-	if err != nil {
-		log.Fatal(err)
-	}
+	reg := regexp.MustCompile("[^A-Za-z0-9]+")
 	newStr := reg.ReplaceAllString(strings.Trim(words, " "), replaceWith)
 	return newStr
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -1,0 +1,62 @@
+package prompt
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+)
+
+func AskQuestionWithInput(response interface{}, question, defaultVal string, isRequired bool) error {
+	prompt := &survey.Input{
+		Message: question,
+		Default: defaultVal,
+	}
+	var err error
+	if isRequired {
+		err = survey.AskOne(prompt, response, survey.WithValidator(survey.Required))
+	} else {
+		err = survey.AskOne(prompt, response)
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func MultiSelect(response interface{}, question string, options []string, opts ...survey.AskOpt) error {
+	prompt := &survey.MultiSelect{
+		Message: question,
+		Options: options,
+	}
+	err := AskOne(prompt, response, opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func AskMultiline(response interface{}, question string, defaultVal string) error {
+	prompt := &survey.Multiline{
+		Message: question,
+		Default: defaultVal,
+	}
+	err := survey.AskOne(prompt, response)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var AskOne = func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+	return survey.AskOne(p, response, opts...)
+}
+
+var Ask = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+	return survey.Ask(qs, response, opts...)
+}
+
+var Confirm = func(prompt string, result *bool) error {
+	p := &survey.Confirm{
+		Message: prompt,
+		Default: true,
+	}
+	return survey.AskOne(p, result)
+}

--- a/pkg/prompt/stubber.go
+++ b/pkg/prompt/stubber.go
@@ -1,0 +1,113 @@
+package prompt
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+)
+
+func StubConfirm(result bool) func() {
+	orig := Confirm
+	Confirm = func(_ string, r *bool) error {
+		*r = result
+		return nil
+	}
+	return func() {
+		Confirm = orig
+	}
+}
+
+type AskStubber struct {
+	Asks     [][]*survey.Question
+	AskOnes  []*survey.Prompt
+	Count    int
+	OneCount int
+	Stubs    [][]*QuestionStub
+	StubOnes []*PromptStub
+}
+
+func InitAskStubber() (*AskStubber, func()) {
+	origAsk := Ask
+	origAskOne := AskOne
+	as := AskStubber{}
+
+	AskOne = func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+		as.AskOnes = append(as.AskOnes, &p)
+		count := as.OneCount
+		as.OneCount += 1
+		if count >= len(as.StubOnes) {
+			panic(fmt.Sprintf("more asks than stubs. most recent call: %v", p))
+		}
+		stubbedPrompt := as.StubOnes[count]
+		if stubbedPrompt.Default {
+			// TODO this is failing for basic AskOne invocations with a string result.
+			defaultValue := reflect.ValueOf(p).Elem().FieldByName("Default")
+			_ = core.WriteAnswer(response, "", defaultValue)
+		} else {
+			_ = core.WriteAnswer(response, "", stubbedPrompt.Value)
+		}
+
+		return nil
+	}
+
+	Ask = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+		as.Asks = append(as.Asks, qs)
+		count := as.Count
+		as.Count += 1
+		if count >= len(as.Stubs) {
+			panic(fmt.Sprintf("more asks than stubs. most recent call: %#v", qs))
+		}
+
+		// actually set response
+		stubbedQuestions := as.Stubs[count]
+		for i, sq := range stubbedQuestions {
+			q := qs[i]
+			if q.Name != sq.Name {
+				panic(fmt.Sprintf("stubbed question mismatch: %s != %s", q.Name, sq.Name))
+			}
+			if sq.Default {
+				defaultValue := reflect.ValueOf(q.Prompt).Elem().FieldByName("Default")
+				_ = core.WriteAnswer(response, q.Name, defaultValue)
+			} else {
+				_ = core.WriteAnswer(response, q.Name, sq.Value)
+			}
+		}
+
+		return nil
+	}
+	teardown := func() {
+		Ask = origAsk
+		AskOne = origAskOne
+	}
+	return &as, teardown
+}
+
+type PromptStub struct {
+	Value   interface{}
+	Default bool
+}
+
+type QuestionStub struct {
+	Name    string
+	Value   interface{}
+	Default bool
+}
+
+func (as *AskStubber) StubOne(value interface{}) {
+	as.StubOnes = append(as.StubOnes, &PromptStub{
+		Value: value,
+	})
+}
+
+func (as *AskStubber) StubOneDefault() {
+	as.StubOnes = append(as.StubOnes, &PromptStub{
+		Default: true,
+	})
+}
+
+func (as *AskStubber) Stub(stubbedQuestions []*QuestionStub) {
+	// A call to .Ask takes a list of questions; a stub is then a list of questions in the same order.
+	as.Stubs = append(as.Stubs, stubbedQuestions)
+}

--- a/pkg/surveyext/surveyext.go
+++ b/pkg/surveyext/surveyext.go
@@ -1,0 +1,240 @@
+// this is a wrapper for https://github.com/AlecAivazis/survey package but with
+// additional extensions and customizations for glab
+// adapted from https://github.com/cli/cli/blob/trunk/pkg/surveyext/editor.go
+package surveyext
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/kballard/go-shellquote"
+	"github.com/profclems/glab/pkg/execext"
+)
+
+var (
+	bom           = []byte{0xef, 0xbb, 0xbf}
+	defaultEditor = "nano" // EXTENDED to switch from vim as a default editor
+	editorSkipKey = 's'
+	editorOpenKey = 'e'
+)
+
+type showable interface {
+	Show()
+}
+
+func init() {
+	if runtime.GOOS == "windows" {
+		defaultEditor = "notepad"
+	} else if g := os.Getenv("GIT_EDITOR"); g != "" {
+		defaultEditor = g
+	} else if v := os.Getenv("VISUAL"); v != "" {
+		defaultEditor = v
+	} else if e := os.Getenv("EDITOR"); e != "" {
+		defaultEditor = e
+	}
+}
+
+// EXTENDED to enable different prompting behavior
+type GLabEditor struct {
+	*survey.Editor
+	EditorCommand string
+	BlankAllowed  bool
+}
+
+func (e *GLabEditor) editorCommand() string {
+	if e.EditorCommand == "" {
+		return defaultEditor
+	}
+
+	return e.EditorCommand
+}
+
+// EXTENDED to change prompt text
+var EditorQuestionTemplate = `
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
+  {{- if and .Default (not .HideDefault)}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+	{{- color "cyan"}}[(e) or Enter to launch {{ .EditorCommand }}{{- if .BlankAllowed }}, (s) or Esc to skip{{ end }}] {{color "reset"}}
+{{- end}}`
+
+// EXTENDED to pass editor name (to use in prompt)
+type EditorTemplateData struct {
+	survey.Editor
+	EditorCommand string
+	BlankAllowed  bool
+	Answer        string
+	ShowAnswer    bool
+	ShowHelp      bool
+	Config        *survey.PromptConfig
+}
+
+// EXTENDED to augment prompt text and keypress handling
+func (e *GLabEditor) prompt(initialValue string, config *survey.PromptConfig) (interface{}, error) {
+	err := e.Render(
+		EditorQuestionTemplate,
+		// EXTENDED to support printing editor in prompt and BlankAllowed
+		EditorTemplateData{
+			Editor:        *e.Editor,
+			BlankAllowed:  e.BlankAllowed,
+			EditorCommand: filepath.Base(e.editorCommand()),
+			Config:        config,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// start reading runes from the standard in
+	rr := e.NewRuneReader()
+	_ = rr.SetTermMode()
+	defer func() { _ = rr.RestoreTermMode() }()
+
+	cursor := e.NewCursor()
+	cursor.Hide()
+	defer cursor.Show()
+
+	for {
+		// EXTENDED to handle the Enter or e to edit / s or Esc to skip behavior + BlankAllowed
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == editorOpenKey || r == '\r' || r == '\n' {
+			break
+		}
+		if r == editorSkipKey || r == terminal.KeyEscape {
+			if e.BlankAllowed {
+				return "", nil
+			} else {
+				continue
+			}
+		}
+		if r == terminal.KeyInterrupt {
+			return "", terminal.InterruptErr
+		}
+		if r == terminal.KeyEndTransmission {
+			break
+		}
+		if string(r) == config.HelpInput && e.Help != "" {
+			err = e.Render(
+				EditorQuestionTemplate,
+				EditorTemplateData{
+					// EXTENDED to support printing editor in prompt, BlankAllowed
+					Editor:        *e.Editor,
+					BlankAllowed:  e.BlankAllowed,
+					EditorCommand: filepath.Base(e.editorCommand()),
+					ShowHelp:      true,
+					Config:        config,
+				},
+			)
+			if err != nil {
+				return "", err
+			}
+		}
+		continue
+	}
+
+	stdio := e.Stdio()
+	text, err := Edit(e.editorCommand(), e.FileName, initialValue, stdio.In, stdio.Out, stdio.Err, cursor)
+	if err != nil {
+		return "", err
+	}
+
+	// check length, return default value on empty
+	if len(text) == 0 && !e.AppendDefault {
+		return e.Default, nil
+	}
+
+	return text, nil
+}
+
+// EXTENDED This is straight copypasta from survey to get our overridden prompt called.;
+func (e *GLabEditor) Prompt(config *survey.PromptConfig) (interface{}, error) {
+	initialValue := ""
+	if e.Default != "" && e.AppendDefault {
+		initialValue = e.Default
+	}
+	return e.prompt(initialValue, config)
+}
+
+func Edit(editorCommand, fn, initialValue string, stdin io.Reader, stdout io.Writer, stderr io.Writer, cursor showable) (string, error) {
+	// prepare the temp file
+	pattern := fn
+	if pattern == "" {
+		pattern = "survey*.txt"
+	}
+	f, err := ioutil.TempFile("", pattern)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(f.Name())
+
+	// write utf8 BOM header
+	// The reason why we do this is because notepad.exe on Windows determines the
+	// encoding of an "empty" text file by the locale, for example, GBK in China,
+	// while golang string only handles utf8 well. However, a text file with utf8
+	// BOM header is not considered "empty" on Windows, and the encoding will then
+	// be determined utf8 by notepad.exe, instead of GBK or other encodings.
+	if _, err := f.Write(bom); err != nil {
+		return "", err
+	}
+
+	// write initial value
+	if _, err := f.WriteString(initialValue); err != nil {
+		return "", err
+	}
+
+	// close the fd to prevent the editor unable to save file
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+
+	if editorCommand == "" {
+		editorCommand = defaultEditor
+	}
+	args, err := shellquote.Split(editorCommand)
+	if err != nil {
+		return "", err
+	}
+	args = append(args, f.Name())
+
+	editorExe, err := execext.LookPath(args[0])
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command(editorExe, args[1:]...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if cursor != nil {
+		cursor.Show()
+	}
+
+	// open the editor
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	// raw is a BOM-unstripped UTF8 byte slice
+	raw, err := ioutil.ReadFile(f.Name())
+	if err != nil {
+		return "", err
+	}
+
+	// strip BOM header
+	return string(bytes.TrimPrefix(raw, bom)), nil
+}


### PR DESCRIPTION
**Description**
This PR adds template support to the `mr create` and `issue create` commands.

Follows the format officially supported by GitLab (https://docs.gitlab.com/ee/user/project/description_templates.html#setting-a-default-template-for-issues-and-merge-requests)

The templates are fetched from the working directory.
Issue templates: `.gitlab/issue_templates/*`
Merge request templates: `.gitlab/merge_request_templates/*`

Survey is extended to help work on #329 

**Related Issue**
Resolves #330 

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested on glab's test [repo](https://gitlab.com/glab-cli/test).

I will add tests in a separate PR

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
