### PR TITLE
feat: add labels multiselect to issue create and mr create

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -2,13 +2,14 @@ package cmdutils
 
 import (
 	"fmt"
-	"github.com/profclems/glab/internal/glrepo"
-	"github.com/profclems/glab/pkg/api"
-	"github.com/xanzy/go-gitlab"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/xanzy/go-gitlab"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/profclems/glab/pkg/prompt"

--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -2,6 +2,9 @@ package cmdutils
 
 import (
 	"fmt"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/xanzy/go-gitlab"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -114,6 +117,53 @@ func DescriptionPrompt(response *string, templateContent, editorCommand string) 
 	err := prompt.Ask(qs, response)
 	if err != nil {
 		return err
+	}
+	if *response == "" {
+		*response = defaultBody
+	}
+	return nil
+}
+
+func LabelsPrompt(response *string, apiClient *gitlab.Client, repoRemote *glrepo.Remote) (err error) {
+	var addLabels bool
+	err = prompt.Confirm(&addLabels, "Do you want to add labels?")
+	if err != nil {
+		return
+	}
+	if addLabels {
+		labelOptions, _ := git.Config("remote." + repoRemote.Name + ".glab-cached-labels")
+		if labelOptions == "" {
+			lOpts := &gitlab.ListLabelsOptions{}
+			lOpts.PerPage = 100
+			labels, err := api.ListLabels(apiClient, repoRemote.FullName(), lOpts)
+			if err == nil && labels != nil {
+				for i, label := range labels {
+					if i > 0 {
+						labelOptions += ","
+					}
+					labelOptions += label.Name
+				}
+				if labelOptions != "" {
+					// silently fails if not a git repo
+					_ = git.SetConfig(repoRemote.Name, "glab-cached-labels", labelOptions)
+				}
+			}
+		}
+		if labelOptions != "" {
+			var selectedLabels []string
+			err = prompt.MultiSelect(&selectedLabels, "Select Labels", strings.Split(labelOptions, ","))
+			if err != nil {
+				return err
+			}
+			if len(selectedLabels) > 0 {
+				*response = strings.Join(selectedLabels, ",")
+			}
+		} else {
+			err = prompt.AskQuestionWithInput(response, "Label(s) [Comma Separated]", "", false)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -129,7 +129,15 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 					}
 				}
 				if opts.Labels == "" {
-					err = prompt.AskQuestionWithInput(&opts.Labels, "Label(s) [Comma Separated]", "", false)
+					remotes, err := f.Remotes()
+					if err != nil {
+						return err
+					}
+					repoRemote, err := remotes.FindByRepo(repo.RepoOwner(), repo.RepoName())
+					if err != nil {
+						return err
+					}
+					err = cmdutils.LabelsPrompt(&opts.Labels, apiClient, repoRemote)
 					if err != nil {
 						return err
 					}

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -194,7 +194,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 					}
 				}
 				if opts.Labels == "" {
-					err = prompt.AskQuestionWithInput(&opts.Labels, "Label(s) [Comma Separated]", "", false)
+					err = cmdutils.LabelsPrompt(&opts.Labels, apiClient, repoRemote)
 					if err != nil {
 						return err
 					}

--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -176,7 +176,7 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 
 		} else if f.IO.IsaTTY {
 			var doSetup bool
-			err := prompt.Confirm(fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace), &doSetup)
+			err := prompt.Confirm(&doSetup, fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace))
 			if err != nil {
 				return err
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -469,7 +469,11 @@ func AddRemote(name, u string) (*Remote, error) {
 }
 
 func SetRemoteResolution(name, resolution string) error {
-	addCmd := exec.Command("git", "config", "--add", fmt.Sprintf("remote.%s.glab-resolved", name), resolution)
+	return SetConfig(name, "glab-resolved", resolution)
+}
+
+func SetConfig(remote, key, value string) error {
+	addCmd := exec.Command("git", "config", "--add", fmt.Sprintf("remote.%s.%s", remote, key), value)
 	return run.PrepareCmd(addCmd).Run()
 }
 

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -53,7 +53,7 @@ var Ask = func(qs []*survey.Question, response interface{}, opts ...survey.AskOp
 	return survey.Ask(qs, response, opts...)
 }
 
-var Confirm = func(prompt string, result *bool) error {
+var Confirm = func(result *bool, prompt string) error {
 	p := &survey.Confirm{
 		Message: prompt,
 		Default: true,

--- a/pkg/prompt/stubber.go
+++ b/pkg/prompt/stubber.go
@@ -10,7 +10,7 @@ import (
 
 func StubConfirm(result bool) func() {
 	orig := Confirm
-	Confirm = func(_ string, r *bool) error {
+	Confirm = func(r *bool, _ string) error {
 		*r = result
 		return nil
 	}


### PR DESCRIPTION
This PR adds a new cool feature to the `issue create` and `mr create` commands:

The user is prompted whether to add labels and if the user selects confirms, `glab` gets the list of labels for the project and saves in the local git config, and prompts the user to select the labels to apply.

![labels](https://user-images.githubusercontent.com/41906128/100595452-d27fd700-32f2-11eb-9f2a-da29d140e843.gif)
