### PR TITLE
feat: add repo delete command

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -127,7 +127,7 @@ func DescriptionPrompt(response *string, templateContent, editorCommand string) 
 
 func LabelsPrompt(response *string, apiClient *gitlab.Client, repoRemote *glrepo.Remote) (err error) {
 	var addLabels bool
-	err = prompt.Confirm(&addLabels, "Do you want to add labels?")
+	err = prompt.Confirm(&addLabels, "Do you want to add labels?", true)
 	if err != nil {
 		return
 	}

--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -176,7 +176,7 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 
 		} else if f.IO.IsaTTY {
 			var doSetup bool
-			err := prompt.Confirm(&doSetup, fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace))
+			err := prompt.Confirm(&doSetup, fmt.Sprintf("Create a local project directory for %s?", project.NameWithNamespace), true)
 			if err != nil {
 				return err
 			}

--- a/commands/project/delete/delete.go
+++ b/commands/project/delete/delete.go
@@ -2,6 +2,8 @@ package delete
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/glrepo"
@@ -10,23 +12,22 @@ import (
 	"github.com/profclems/glab/pkg/prompt"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
-	"strings"
 )
 
 type DeleteOpts struct {
 	ForceDelete bool
-	RepoName	string
-	Args		[]string
+	RepoName    string
+	Args        []string
 
-	IO *utils.IOStreams
-	Lab func() (*gitlab.Client, error)
+	IO       *utils.IOStreams
+	Lab      func() (*gitlab.Client, error)
 	BaseRepo func() (glrepo.Interface, error)
 }
 
 func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 	var opts = &DeleteOpts{
-		IO: f.IO,
-		Lab: f.HttpClient,
+		IO:       f.IO,
+		Lab:      f.HttpClient,
 		BaseRepo: f.BaseRepo,
 	}
 

--- a/commands/project/delete/delete.go
+++ b/commands/project/delete/delete.go
@@ -1,0 +1,115 @@
+package delete
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/profclems/glab/pkg/prompt"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+	"strings"
+)
+
+type DeleteOpts struct {
+	ForceDelete bool
+	RepoName	string
+	Args		[]string
+
+	IO *utils.IOStreams
+	Lab func() (*gitlab.Client, error)
+	BaseRepo func() (glrepo.Interface, error)
+}
+
+func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
+	var opts = &DeleteOpts{
+		IO: f.IO,
+		Lab: f.HttpClient,
+		BaseRepo: f.BaseRepo,
+	}
+
+	var projectCreateCmd = &cobra.Command{
+		Use:   "delete [<NAMESPACE>/]<NAME>",
+		Short: `Delete an existing repository on GitLab`,
+		Long:  `Delete an existing repository on GitLab`,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Args = args
+			return deleteRun(opts)
+		},
+		Example: heredoc.Doc(`
+		# delete a personal repo
+		$ glab repo delete dotfiles
+
+		# delete a repo in GitLab group or another repo you have write access
+		$ glab repo delete mygroup/dotfiles
+
+		$ glab repo delete myorg/mynamespace/dotfiles
+	  `),
+	}
+
+	projectCreateCmd.Flags().BoolVarP(&opts.ForceDelete, "yes", "y", false, "Skip the confirmation prompt and immediately delete the repository.")
+
+	return projectCreateCmd
+}
+
+func deleteRun(opts *DeleteOpts) error {
+	labClient, err := opts.Lab()
+	if err != nil {
+		return err
+	}
+
+	baseRepo, baseRepoErr := opts.BaseRepo() // don't handle error yet
+	if len(opts.Args) == 1 {
+		opts.RepoName = opts.Args[0]
+
+		if !strings.ContainsRune(opts.RepoName, '/') {
+			namespace := ""
+			if baseRepoErr == nil {
+				namespace = baseRepo.RepoOwner()
+			} else {
+				currentUser, err := api.CurrentUser(labClient)
+				if err != nil {
+					return err
+				}
+				namespace = currentUser.Username
+			}
+			opts.RepoName = fmt.Sprintf("%s/%s", namespace, opts.RepoName)
+		}
+	} else {
+		if baseRepoErr != nil {
+			return baseRepoErr
+		}
+		opts.RepoName = baseRepo.FullName()
+	}
+
+	if !opts.ForceDelete && !opts.IO.PromptEnabled() {
+		return &cmdutils.FlagError{Err: fmt.Errorf("--yes or -y flag is required when not running interactively")}
+	}
+
+	if !opts.ForceDelete && opts.IO.PromptEnabled() {
+		fmt.Fprintf(opts.IO.StdErr, "This action will permanently delete %s immediately, including its repositories and all content: issues, merge requests.\n\n", opts.RepoName)
+		err = prompt.Confirm(&opts.ForceDelete, fmt.Sprintf("Are you ABSOLUTELY SURE you wish to delete %s", opts.RepoName), false)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.ForceDelete {
+		if opts.IO.IsErrTTY && opts.IO.IsaTTY {
+			fmt.Fprintf(opts.IO.StdErr, "- Deleting project %s\n", opts.RepoName)
+		}
+		resp, err := api.DeleteProject(labClient, opts.RepoName)
+		if err != nil && resp == nil {
+			return err
+		}
+		if resp.StatusCode == 401 {
+			return fmt.Errorf("you are not authorized to delete %s.\nPlease edit your token used for glab and make sure it has `api` and `write_repository` scopes enabled", opts.RepoName)
+		}
+		return err
+	}
+	fmt.Fprintln(opts.IO.StdErr, "aborted by user")
+	return nil
+}

--- a/commands/project/repo.go
+++ b/commands/project/repo.go
@@ -6,6 +6,7 @@ import (
 	repoCmdClone "github.com/profclems/glab/commands/project/clone"
 	repoCmdContributors "github.com/profclems/glab/commands/project/contributors"
 	repoCmdCreate "github.com/profclems/glab/commands/project/create"
+	repoCmdDelete "github.com/profclems/glab/commands/project/delete"
 	repoCmdSearch "github.com/profclems/glab/commands/project/search"
 
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ func NewCmdRepo(f *cmdutils.Factory) *cobra.Command {
 	repoCmd.AddCommand(repoCmdClone.NewCmdClone(f))
 	repoCmd.AddCommand(repoCmdContributors.NewCmdContributors(f))
 	repoCmd.AddCommand(repoCmdCreate.NewCmdCreate(f))
+	repoCmd.AddCommand(repoCmdDelete.NewCmdDelete(f))
 	repoCmd.AddCommand(repoCmdSearch.NewCmdSearch(f))
 
 	return repoCmd

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -53,10 +53,10 @@ var Ask = func(qs []*survey.Question, response interface{}, opts ...survey.AskOp
 	return survey.Ask(qs, response, opts...)
 }
 
-var Confirm = func(result *bool, prompt string) error {
+var Confirm = func(result *bool, prompt string, defaultVal bool) error {
 	p := &survey.Confirm{
 		Message: prompt,
-		Default: true,
+		Default: defaultVal,
 	}
 	return survey.AskOne(p, result)
 }

--- a/pkg/prompt/stubber.go
+++ b/pkg/prompt/stubber.go
@@ -10,7 +10,7 @@ import (
 
 func StubConfirm(result bool) func() {
 	orig := Confirm
-	Confirm = func(r *bool, _ string) error {
+	Confirm = func(r *bool, _ string, _ bool) error {
 		*r = result
 		return nil
 	}


### PR DESCRIPTION
This PR adds the `repo delete` command

Follows the implementation stated in https://github.com/profclems/glab/issues/318#issuecomment-729809919 but uses `--yes | -y` flag instead of `--force | -f` flag to skip the confirmation prompt. 

Resolves #318 