### PR TITLE
Fix(pipeline) Don't close writer before done

### DIFF
--- a/commands/pipeline/status/pipeline_status.go
+++ b/commands/pipeline/status/pipeline_status.go
@@ -71,6 +71,7 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 
 				// start listening for updates and render
 				writer.Start()
+				defer writer.Stop()
 				for isRunning {
 					jobs, err := api.GetPipelineJobs(apiClient, runningPipeline.ID, repo.FullName())
 					if err != nil {
@@ -127,7 +128,6 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 							isRunning = false
 						}
 					}
-					writer.Stop()
 
 					if retry == "View Logs" {
 						// ToDo: bad idea to call another sub-command. should be fixed to avoid cyclo imports


### PR DESCRIPTION
**Description**

We were calling `writer.Stop` in a infinite loop, that would update the
UI, but we closed the writer after the first iteration, so it failed.

**Related Issue**
Fixes #325

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
