### PR TITLE
(chore): Clean up releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,14 +8,13 @@ before:
     - go mod tidy
     
 builds:
-  - main: ./cmd/glab
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.build={{time "2006-01-02"}}
   - <<: &build_defaults
-      binary: bin/glab
       main: ./cmd/glab
+      binary: bin/glab
+      env:
+        - CGO_ENABLED=0
+      ldflags:
+        - -s -w -X main.version={{.Version}} -X main.build={{time "2006-01-02"}}
     id: macos
     goos: [darwin]
     goarch: [amd64]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,31 +30,26 @@ builds:
     goarch: [386, amd64]
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    allow_different_binary_count: true
-
   - id: nix
     builds: [macos, linux]
     <<: &archive_defaults
       name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    wrap_in_directory: false
-    allow_different_binary_count: true
-    replacements:
+      wrap_in_directory: false
+    format: tar.gz
+    replacements: 
       darwin: macOS
       linux: Linux
-    format: tar.gz
+      <<: &arch_replacemens
+        386: i386
+        amd64: x86_64
 
   - id: windows
     builds: [windows]
     <<: *archive_defaults
-    wrap_in_directory: false
-    allow_different_binary_count: true
     format: zip
+    replacements: 
+      windows: Windows
+      <<: *arch_replacemens
 
 scoop:
   url_template: "http://github.com/profclems/glab/releases/download/{{ .Tag }}/{{ .ArtifactName }}"


### PR DESCRIPTION
**Description**
This fixes the little mess with releases.
There were multiple binaries in releases and duplicate releases [example](https://github.com/profclems/glab/releases/tag/v1.12.1)
**Related Issue**
#62

**How Has This Been Tested?**
Running `make rt` now creates a dist folder that looks like this :
```sh
▶ tree dist 
dist
├── checksums.txt
├── config.yaml
├── glab.rb
├── glab_v1.12.1_Linux_i386.deb
├── glab_v1.12.1_Linux_i386.rpm
├── glab_v1.12.1_Linux_i386.tar.gz
├── glab_v1.12.1_Linux_x86_64.deb
├── glab_v1.12.1_Linux_x86_64.rpm
├── glab_v1.12.1_Linux_x86_64.tar.gz
├── glab_v1.12.1_macOS_x86_64.tar.gz
├── glab_v1.12.1_Windows_i386.zip
├── glab_v1.12.1_Windows_x86_64.zip
├── linux_linux_386
│   └── bin
│       └── glab
├── linux_linux_amd64
│   └── bin
│       └── glab
├── macos_darwin_amd64
│   └── bin
│       └── glab
├── windows_windows_386
│   └── bin
│       └── glab.exe
└── windows_windows_amd64
    └── bin
        └── glab.exe
```
compared to trunks :
```sh
▶ tree dist 
dist
├── checksums.txt
├── config.yaml
├── glab_darwin_amd64
│   └── glab
├── glab_linux_386
│   └── glab
├── glab_linux_amd64
│   └── glab
├── glab.rb
├── glab_v1.12.1_Darwin_x86_64.tar.gz
├── glab_v1.12.1_Linux_386.tar.gz
├── glab_v1.12.1_Linux_amd64.tar.gz
├── glab_v1.12.1_Linux_i386.deb
├── glab_v1.12.1_Linux_i386.rpm
├── glab_v1.12.1_Linux_i386.tar.gz
├── glab_v1.12.1_Linux_x86_64.deb
├── glab_v1.12.1_Linux_x86_64.rpm
├── glab_v1.12.1_Linux_x86_64.tar.gz
├── glab_v1.12.1_macOS_amd64.tar.gz
├── glab_v1.12.1_windows_386.zip
├── glab_v1.12.1_windows_amd64.zip
├── glab_v1.12.1_Windows_i386.tar.gz
├── glab_v1.12.1_Windows_x86_64.tar.gz
├── linux_linux_386
│   └── bin
│       └── glab
├── linux_linux_amd64
│   └── bin
│       └── glab
├── macos_darwin_amd64
│   └── bin
│       └── glab
├── windows_windows_386
│   └── bin
│       └── glab.exe
└── windows_windows_amd64
    └── bin
        └── glab.exe
```
