### PR TITLE
fix(cmd/mr/merge): don't print Default to true as Cobra already does

### DIFF
--- a/commands/mr/merge/mr_merge.go
+++ b/commands/mr/merge/mr_merge.go
@@ -85,7 +85,7 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 
 	mrMergeCmd.Flags().StringP("sha", "", "", "Merge Commit sha")
 	mrMergeCmd.Flags().BoolP("remove-source-branch", "d", false, "Remove source branch on merge")
-	mrMergeCmd.Flags().BoolP("when-pipeline-succeeds", "", true, "Merge only when pipeline succeeds. Default to true")
+	mrMergeCmd.Flags().BoolP("when-pipeline-succeeds", "", true, "Merge only when pipeline succeeds")
 	mrMergeCmd.Flags().StringP("message", "m", "", "Custom merge commit message")
 	mrMergeCmd.Flags().StringP("squash-message", "", "", "Custom Squash commit message")
 	mrMergeCmd.Flags().BoolP("squash", "s", false, "Squash commits on merge")


### PR DESCRIPTION
**Description**
`gitlab mr merge --help` has double default, one auto-generated from the cobra package by looking at the default value given to the flag function and another written by glab


<!--- Describe your changes in detail -->

**Related Issue**
#382 

**How Has This Been Tested?**
make && ./bin/glab mr merge --help | grep default

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
