### PR TITLE
feat(cmd/mr/merge): show different message when merging after pipeline success

### DIFF
--- a/commands/mr/merge/mr_merge.go
+++ b/commands/mr/merge/mr_merge.go
@@ -76,7 +76,11 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Merged")
+			if m, _ := cmd.Flags().GetBool("when-pipeline-succeeds"); m {
+				fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Will merge when pipeline succeeds")
+			} else {
+				fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Merged")
+			}
 			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(mr))
 
 			return nil


### PR DESCRIPTION
**Description**
Checks if when-pipeline-succeeds is set and prints a more appropriate message

**Related Issue**
Resolves #386 

**How Has This Been Tested?**
Tested against gitlab.alpinelinux.org

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
