### PR TITLE
fix(internal/glrepo/resolver): don't use pointers to gitlab.Project{}

### DIFF
--- a/internal/glrepo/resolver.go
+++ b/internal/glrepo/resolver.go
@@ -93,7 +93,12 @@ func (r *ResolvedRemotes) BaseRepo(prompt bool) (Interface, error) {
 	add := func(r *gitlab.Project) {
 		fn, _ := FullNameFromURL(r.HTTPURLToRepo)
 		if _, ok := repoMap[fn]; !ok {
-			repoMap[fn] = r
+			// This is run inside a for-loop, create a local copy and use its address
+			// instead of the one given to us, otherwise the value in repoMap will be
+			// overwriten in the next iteration of the loop
+			// See: #395, #384
+			localCopy := *r
+			repoMap[fn] = &localCopy
 			repoNames = append(repoNames, fn)
 		}
 	}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->

Using pointers trigger a very interesting bug, imagine this case:

Remotes:
- origin (git@gitlab.alpinelinux.org:Leo/aports.git)
- upstream (git@gitlab.alpinelinux.org:alpine/aports.git)

More important information:
- Leo/aports is a fork of alpine/aports.

What happens ?

This piece of code runs, in this case r.network has the info from the 2
remotes.

```go
for _, repo := range r.network {
    if repo.ForkedFromProject != nil {
        fProject, _ := api.GetProject(r.apiClient, repo.ForkedFromProject.PathWithNamespace)
        add(fProject)
    }
    add(&repo)
}
```

Here is the add function that will be referenced:

```go
add := func(r *gitlab.Project) {
    fn, _ := FullNameFromURL(r.HTTPURLToRepo)
    if _, ok := repoMap[fn]; !ok {
        repoMap[fn] = r
        repoNames = append(repoNames, fn)
    }
}
```

1. upstream (alpine/aports) is checked
2. it is not a fork so just pass &repo to the add function which adds
   it to repoMap[alpine/aports] which will point to the reference
   (due to &repo) and repoNames
3. origin (Leo/aports) is checked
4. origin (Leo/aports) is a fork!, check for what it is forked from (alpine/aports)
5. pass the fork origin to add, which does nothing because we already
   added repoMap[alpine/aports] and repoNames from the upstream remote
6. pass &repo to the add function which adds it to repoMap[Leo/aports]
   and repoNames

both repoMap[alpine/aports] and repoMap[Leo/aports] now point to the
same address, and the later one (Leo/aports), overwrote the earlier one
(alpine/aports)!

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #385

**How Has This Been Tested?**
Tested it against the usecase presented in #385
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
