### PR TITLE
feat(cmd/issue/update): add --public and --confidential flags

### DIFF
--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/profclems/glab/commands/cmdutils"
@@ -55,6 +56,16 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				l.RemoveLabels = gitlab.Labels(m)
 			}
 
+			if cmd.Flags().Changed("confidential") && cmd.Flags().Changed("public") {
+				return &cmdutils.FlagError{Err: errors.New("--public and --confidential can't be used together")}
+			}
+			if m, _ := cmd.Flags().GetBool("public"); m {
+				l.Confidential = gitlab.Bool(false)
+			}
+			if m, _ := cmd.Flags().GetBool("confidential"); m {
+				l.Confidential = gitlab.Bool(true)
+			}
+
 			fmt.Fprintf(out, "- Updating issue #%d\n", issueID)
 
 			issue, err := api.UpdateIssue(apiClient, repo.FullName(), issueID, l)
@@ -74,6 +85,8 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	issueUpdateCmd.Flags().StringP("description", "d", "", "Issue description")
 	issueUpdateCmd.Flags().StringArrayP("label", "l", []string{}, "add labels")
 	issueUpdateCmd.Flags().StringArrayP("unlabel", "u", []string{}, "remove labels")
+	issueUpdateCmd.Flags().BoolP("public", "p", false, "Make issue public")
+	issueUpdateCmd.Flags().BoolP("confidential", "c", false, "Make issue confidential")
 
 	return issueUpdateCmd
 }


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->

they allow making an issue public or confidential, as documented by
GitLab here[1] and in their API[2] (see confidential field)

[1]: https://docs.gitlab.com/ee/user/project/issues/confidential_issues.html
[2]: https://docs.gitlab.com/ee/api/issues.html#edit-issue

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #395 

**How Has This Been Tested?**
Tested against the usecase presented in #395 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
