### PR TITLE
fix(cmd/mr/create): avoid resetting tracking branch if set 

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -3,10 +3,11 @@ package create
 import (
 	"errors"
 	"fmt"
-	"github.com/profclems/glab/internal/config"
-	"github.com/profclems/glab/internal/glrepo"
 	"strconv"
 	"strings"
+
+	"github.com/profclems/glab/internal/config"
+	"github.com/profclems/glab/internal/glrepo"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/profclems/glab/commands/cmdutils"

--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -3,12 +3,13 @@ package create
 import (
 	"bytes"
 	"fmt"
-	"github.com/profclems/glab/internal/git"
-	"github.com/profclems/glab/internal/glrepo"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/profclems/glab/internal/git"
+	"github.com/profclems/glab/internal/glrepo"
 
 	"github.com/google/shlex"
 	"github.com/profclems/glab/test"

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -208,10 +209,10 @@ func CommitBody(sha string) (string, error) {
 }
 
 // Push publishes a git ref to a remote and sets up upstream configuration
-func Push(remote string, ref string) error {
+func Push(remote string, ref string, cmdOut, cmdErr io.Writer) error {
 	pushCmd := GitCommand("push", "--set-upstream", remote, ref)
-	pushCmd.Stdout = os.Stdout
-	pushCmd.Stderr = os.Stderr
+	pushCmd.Stdout = cmdOut
+	pushCmd.Stderr = cmdErr
 	return run.PrepareCmd(pushCmd).Run()
 }
 


### PR DESCRIPTION
`glab` does `git push` using the remote that the base repo (`glab-resolved`) points to.
In order to solves this, we determine the tracking branch preset and use it or resort to
that of the base repo.

Resolves #406