### PR TITLE
glab-resolved = {base|head} support

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -47,6 +47,7 @@ type CreateOpts struct {
 	Lab      func() (*gitlab.Client, error)
 	Config   func() (config.Config, error)
 	BaseRepo func() (glrepo.Interface, error)
+	HeadRepo func() (glrepo.Interface, error)
 
 	BaseProject   *gitlab.Project
 	TargetProject *gitlab.Project
@@ -62,6 +63,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		Lab:      f.HttpClient,
 		Config:   f.Config,
 		BaseRepo: f.BaseRepo,
+		HeadRepo: resolvedHeadRepo(f),
 	}
 
 	var mrCreateCmd = &cobra.Command{

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/profclems/glab/internal/config"
@@ -72,6 +73,15 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		Long:    ``,
 		Aliases: []string{"new"},
 		Args:    cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			repoOverride, _ := cmd.Flags().GetString("head")
+			if repoFromEnv := os.Getenv("GITLAB_HEAD_REPO"); repoOverride == "" && repoFromEnv != "" {
+				repoOverride = repoFromEnv
+			}
+			if repoOverride != "" {
+				_ = headRepoOverride(opts, repoOverride)
+			}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
@@ -349,6 +359,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	mrCreateCmd.Flags().BoolVarP(&opts.AllowCollaboration, "allow-collaboration", "", false, "Allow commits from other members")
 	mrCreateCmd.Flags().BoolVarP(&opts.RemoveSourceBranch, "remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
+	mrCreateCmd.Flags().StringP("head", "H", "", "Select another head repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
 
 	return mrCreateCmd
 }

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -509,3 +509,33 @@ func generateMRCompareURL(opts *CreateOpts, repo glrepo.Interface) (string, erro
 		targetProjectID)
 	return u.String(), nil
 }
+
+func resolvedHeadRepo(f *cmdutils.Factory) func() (glrepo.Interface, error) {
+	return func() (glrepo.Interface, error) {
+		httpClient, err := f.HttpClient()
+		if err != nil {
+			return nil, err
+		}
+		remotes, err := f.Remotes()
+		if err != nil {
+			return nil, err
+		}
+		repoContext, err := glrepo.ResolveRemotesToRepos(remotes, httpClient, "")
+		if err != nil {
+			return nil, err
+		}
+		headRepo, err := repoContext.HeadRepo(true)
+		if err != nil {
+			return nil, err
+		}
+
+		return headRepo, nil
+	}
+}
+
+func headRepoOverride(opts *CreateOpts, repo string) error {
+	opts.HeadRepo = func() (glrepo.Interface, error) {
+		return glrepo.FromFullName(repo)
+	}
+	return nil
+}

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -141,15 +141,19 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			repoRemote, err := remotes.FindByRepo(headRepo.RepoOwner(), headRepo.RepoName())
+			headRepoRemote, err := remotes.FindByRepo(headRepo.RepoOwner(), headRepo.RepoName())
+			if err != nil {
+				return err
+			}
+			baseRepoRemote, err := remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName())
 			if err != nil {
 				return err
 			}
 
 			if opts.TargetBranch == "" {
-				opts.TargetBranch, _ = git.GetDefaultBranch(repoRemote.PushURL.String())
+				opts.TargetBranch, _ = git.GetDefaultBranch(baseRepoRemote.PushURL.String())
 			}
-			opts.TargetTrackingBranch = fmt.Sprintf("%s/%s", repoRemote.Name, opts.TargetBranch)
+			opts.TargetTrackingBranch = fmt.Sprintf("%s/%s", baseRepoRemote.Name, opts.TargetBranch)
 
 			if opts.CreateSourceBranch && opts.SourceBranch == "" {
 				opts.SourceBranch = utils.ReplaceNonAlphaNumericChars(opts.Title, "-")
@@ -243,7 +247,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 					}
 				}
 				if len(opts.Labels) == 0 {
-					err = cmdutils.LabelsPrompt(&opts.Labels, labClient, repoRemote)
+					err = cmdutils.LabelsPrompt(&opts.Labels, labClient, baseRepoRemote)
 					if err != nil {
 						return err
 					}
@@ -319,7 +323,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 				return nil
 			}
 
-			if err := handlePush(opts, repoRemote); err != nil {
+			if err := handlePush(opts, headRepoRemote); err != nil {
 				return err
 			}
 

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -173,7 +173,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 				if err = mrBodyAndTitle(opts); err != nil {
 					return err
 				}
-				_, err = api.GetCommit(labClient, headRepo.FullName(), opts.TargetBranch)
+				_, err = api.GetCommit(labClient, baseRepo.FullName(), opts.TargetBranch)
 				if err != nil {
 					return fmt.Errorf("target branch %s does not exist on remote. Specify target branch with --target-branch flag",
 						opts.TargetBranch)

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -362,13 +362,16 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	mrCreateCmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", []string{}, "Assign merge request to people by their `usernames`")
 	mrCreateCmd.Flags().StringVarP(&opts.SourceBranch, "source-branch", "s", "", "The Branch you are creating the merge request. Default is the current branch.")
 	mrCreateCmd.Flags().StringVarP(&opts.TargetBranch, "target-branch", "b", "", "The target or base branch into which you want your code merged")
-	mrCreateCmd.Flags().StringVarP(&mrCreateTargetProject, "target-project", "", "", "Add target project by id or OWNER/REPO or GROUP/NAMESPACE/REPO")
 	mrCreateCmd.Flags().BoolVarP(&opts.CreateSourceBranch, "create-source-branch", "", false, "Create source branch if it does not exist")
 	mrCreateCmd.Flags().IntVarP(&opts.MileStone, "milestone", "m", 0, "add milestone by <id> for merge request")
 	mrCreateCmd.Flags().BoolVarP(&opts.AllowCollaboration, "allow-collaboration", "", false, "Allow commits from other members")
 	mrCreateCmd.Flags().BoolVarP(&opts.RemoveSourceBranch, "remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 	mrCreateCmd.Flags().StringP("head", "H", "", "Select another head repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
+
+	mrCreateCmd.Flags().StringVarP(&mrCreateTargetProject, "target-project", "", "", "Add target project by id or OWNER/REPO or GROUP/NAMESPACE/REPO")
+	mrCreateCmd.Flags().MarkHidden("target-project")
+	mrCreateCmd.Flags().MarkDeprecated("target-project", "Use --repo instead")
 
 	return mrCreateCmd
 }


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This is a big one:

- Create HeadRepo in internal/glrepo, works the same as `BaseRepo` but checks `glab-resolved = head` and
  also picks the first forked repo instead of just the first repo
- vendor functions used for `glab-resolved = base` into create_mr and make them work for `glab-resolved = head`
- deprecate `--target-project` as users can just use `--repo` instead

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #406 #393 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Alpine

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)

**TODO**

- Need to re-introduce the alternate code for resolution but make it prefix with `base:` and `head:`