### PR TITLE
feat: provide submit options for `mr create` and `issue create`

### DIFF
--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -3,6 +3,12 @@ package create
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/profclems/glab/internal/config"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/internal/utils"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -26,10 +32,25 @@ type CreateOpts struct {
 	NoEditor       bool
 	IsConfidential bool
 	IsInteractive  bool
+	OpenInWeb      bool
+
+	IO         *utils.IOStreams
+	BaseRepo   func() (glrepo.Interface, error)
+	HTTPClient func() (*gitlab.Client, error)
+	Remotes    func() (glrepo.Remotes, error)
+	Config     func() (config.Config, error)
+
+	BaseProject *gitlab.Project
 }
 
 func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
-	opts := &CreateOpts{}
+	opts := &CreateOpts{
+		IO:         f.IO,
+		BaseRepo:   f.BaseRepo,
+		HTTPClient: f.HttpClient,
+		Remotes:    f.Remotes,
+		Config:     f.Config,
+	}
 	var issueCreateCmd = &cobra.Command{
 		Use:     "create [flags]",
 		Short:   `Create an issue`,
@@ -37,7 +58,17 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"new"},
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			issueCreateOpts := &gitlab.CreateIssueOptions{}
+			var err error
+
+			apiClient, err := opts.HTTPClient()
+			if err != nil {
+				return err
+			}
+
+			repo, err := opts.BaseRepo()
+			if err != nil {
+				return err
+			}
 
 			hasTitle := cmd.Flags().Changed("title")
 			hasDescription := cmd.Flags().Changed("description")
@@ -45,147 +76,251 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			// disable interactive mode if title and description are explicitly defined
 			opts.IsInteractive = !(hasTitle && hasDescription)
 
-			if opts.IsInteractive && !f.IO.PromptEnabled() {
+			if opts.IsInteractive && !opts.IO.PromptEnabled() {
 				return &cmdutils.FlagError{Err: errors.New("--title and --description required for non-interactive mode")}
 			}
 
-			apiClient, err := f.HttpClient()
+			opts.BaseProject, err = api.GetProject(apiClient, repo.FullName())
 			if err != nil {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
-			if err != nil {
-				return err
+			if !opts.BaseProject.IssuesEnabled {
+				fmt.Fprintf(opts.IO.StdErr, "Issues are disabled for %q\n", opts.BaseProject.PathWithNamespace)
+				return cmdutils.SilentError
 			}
 
-			var templateName string
-			var templateContents string
-
-			if opts.IsInteractive {
-				if opts.Description == "" {
-					if editor, _ := cmd.Flags().GetBool("no-editor"); editor {
-						err = prompt.AskMultiline(&opts.Description, "Description:", "")
-						if err != nil {
-							return err
-						}
-					} else {
-
-						templateResponse := struct {
-							Index int
-						}{}
-						templateNames, err := cmdutils.ListGitLabTemplates(cmdutils.IssueTemplate)
-						if err != nil {
-							return fmt.Errorf("error getting templates: %w", err)
-						}
-
-						templateNames = append(templateNames, "Open a blank Issue")
-
-						selectQs := []*survey.Question{
-							{
-								Name: "index",
-								Prompt: &survey.Select{
-									Message: "Choose a template",
-									Options: templateNames,
-								},
-							},
-						}
-
-						if err := prompt.Ask(selectQs, &templateResponse); err != nil {
-							return fmt.Errorf("could not prompt: %w", err)
-						}
-						if templateResponse.Index != len(templateNames) {
-							templateName = templateNames[templateResponse.Index]
-							templateContents, err = cmdutils.LoadGitLabTemplate(cmdutils.IssueTemplate, templateName)
-							if err != nil {
-								return fmt.Errorf("failed to get template contents: %w", err)
-							}
-						}
-					}
-				}
-				if opts.Title == "" {
-					err = prompt.AskQuestionWithInput(&opts.Title, "Title", "", true)
-					if err != nil {
-						return err
-					}
-				}
-				if opts.Description == "" {
-					if opts.NoEditor {
-						err = prompt.AskMultiline(&opts.Description, "Description:", "")
-						if err != nil {
-							return err
-						}
-					} else {
-						editor, err := cmdutils.GetEditor(f.Config)
-						if err != nil {
-							return err
-						}
-						err = cmdutils.DescriptionPrompt(&opts.Description, templateContents, editor)
-						if err != nil {
-							return err
-						}
-					}
-				}
-				if len(opts.Labels) == 0 {
-					remotes, err := f.Remotes()
-					if err != nil {
-						return err
-					}
-					repoRemote, err := remotes.FindByRepo(repo.RepoOwner(), repo.RepoName())
-					if err != nil {
-						return err
-					}
-					err = cmdutils.LabelsPrompt(&opts.Labels, apiClient, repoRemote)
-					if err != nil {
-						return err
-					}
-				}
-			} else {
-				if opts.Title == "" {
-					return fmt.Errorf("title can't be blank")
-				}
-			}
-
-			issueCreateOpts.Title = gitlab.String(opts.Title)
-			issueCreateOpts.Labels = opts.Labels
-			issueCreateOpts.Description = &opts.Description
-			if opts.IsConfidential {
-				issueCreateOpts.Confidential = gitlab.Bool(opts.IsConfidential)
-			}
-			if opts.Weight != -1 {
-				issueCreateOpts.Weight = gitlab.Int(opts.Weight)
-			}
-			if opts.LinkedMR != -1 {
-				issueCreateOpts.MergeRequestToResolveDiscussionsOf = gitlab.Int(opts.LinkedMR)
-			}
-			if opts.MileStone != -1 {
-				issueCreateOpts.MilestoneID = gitlab.Int(opts.MileStone)
-			}
-			if len(opts.Assignees) > 0 {
-				users, err := api.UsersByNames(apiClient, opts.Assignees)
-				if err != nil {
-					return err
-				}
-				issueCreateOpts.AssigneeIDs = cmdutils.IDsFromUsers(users)
-			}
-			fmt.Fprintln(f.IO.StdErr, "\n- Creating issue in", repo.FullName())
-			issue, err := api.CreateIssue(apiClient, repo.FullName(), issueCreateOpts)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(issue))
-			return nil
+			return createRun(opts)
 		},
 	}
 	issueCreateCmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Supply a title for issue")
 	issueCreateCmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Supply a description for issue")
 	issueCreateCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Add label by name. Multiple labels should be comma separated")
 	issueCreateCmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", []string{}, "Assign issue to people by their `usernames`")
-	issueCreateCmd.Flags().IntVarP(&opts.MileStone, "milestone", "m", -1, "The global ID of a milestone to assign issue")
+	issueCreateCmd.Flags().IntVarP(&opts.MileStone, "milestone", "m", 0, "The global ID of a milestone to assign issue")
 	issueCreateCmd.Flags().BoolVarP(&opts.IsConfidential, "confidential", "c", false, "Set an issue to be confidential. Default is false")
-	issueCreateCmd.Flags().IntVarP(&opts.LinkedMR, "linked-mr", "", -1, "The IID of a merge request in which to resolve all issues")
-	issueCreateCmd.Flags().IntVarP(&opts.Weight, "weight", "w", -1, "The weight of the issue. Valid values are greater than or equal to 0.")
+	issueCreateCmd.Flags().IntVarP(&opts.LinkedMR, "linked-mr", "", 0, "The IID of a merge request in which to resolve all issues")
+	issueCreateCmd.Flags().IntVarP(&opts.Weight, "weight", "w", 0, "The weight of the issue. Valid values are greater than or equal to 0.")
 	issueCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 
 	return issueCreateCmd
+}
+
+func createRun(opts *CreateOpts) error {
+	apiClient, err := opts.HTTPClient()
+	if err != nil {
+		return err
+	}
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	var templateName string
+	var templateContents string
+
+	issueCreateOpts := &gitlab.CreateIssueOptions{}
+
+	if opts.IsInteractive {
+		if opts.Description == "" {
+			if opts.NoEditor {
+				err = prompt.AskMultiline(&opts.Description, "Description:", "")
+				if err != nil {
+					return err
+				}
+			} else {
+
+				templateResponse := struct {
+					Index int
+				}{}
+				templateNames, err := cmdutils.ListGitLabTemplates(cmdutils.IssueTemplate)
+				if err != nil {
+					return fmt.Errorf("error getting templates: %w", err)
+				}
+
+				templateNames = append(templateNames, "Open a blank Issue")
+
+				selectQs := []*survey.Question{
+					{
+						Name: "index",
+						Prompt: &survey.Select{
+							Message: "Choose a template",
+							Options: templateNames,
+						},
+					},
+				}
+
+				if err := prompt.Ask(selectQs, &templateResponse); err != nil {
+					return fmt.Errorf("could not prompt: %w", err)
+				}
+				if templateResponse.Index != len(templateNames) {
+					templateName = templateNames[templateResponse.Index]
+					templateContents, err = cmdutils.LoadGitLabTemplate(cmdutils.IssueTemplate, templateName)
+					if err != nil {
+						return fmt.Errorf("failed to get template contents: %w", err)
+					}
+				}
+			}
+		}
+		if opts.Title == "" {
+			err = prompt.AskQuestionWithInput(&opts.Title, "Title", "", true)
+			if err != nil {
+				return err
+			}
+		}
+		if opts.Description == "" {
+			if opts.NoEditor {
+				err = prompt.AskMultiline(&opts.Description, "Description:", "")
+				if err != nil {
+					return err
+				}
+			} else {
+				editor, err := cmdutils.GetEditor(opts.Config)
+				if err != nil {
+					return err
+				}
+				err = cmdutils.DescriptionPrompt(&opts.Description, templateContents, editor)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if len(opts.Labels) == 0 {
+			remotes, err := opts.Remotes()
+			if err != nil {
+				return err
+			}
+			repoRemote, err := remotes.FindByRepo(repo.RepoOwner(), repo.RepoName())
+			if err != nil {
+				return err
+			}
+			err = cmdutils.LabelsPrompt(&opts.Labels, apiClient, repoRemote)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		if opts.Title == "" {
+			return fmt.Errorf("title can't be blank")
+		}
+	}
+
+	var action cmdutils.Action
+
+	// submit without prompting for non interactive mode
+	if !opts.IsInteractive {
+		action = cmdutils.SubmitAction
+	}
+
+	if action == 0 {
+		action, err = cmdutils.ConfirmSubmission(true)
+		if err != nil {
+			return fmt.Errorf("unable to confirm: %w", err)
+		}
+	}
+
+	if action == cmdutils.CancelAction {
+		fmt.Fprintln(opts.IO.StdErr, "Discarded.")
+		return nil
+	}
+
+	if action == cmdutils.PreviewAction {
+		return previewIssue(opts)
+	}
+
+	if action == cmdutils.SubmitAction {
+		issueCreateOpts.Title = gitlab.String(opts.Title)
+		issueCreateOpts.Labels = opts.Labels
+		issueCreateOpts.Description = &opts.Description
+		if opts.IsConfidential {
+			issueCreateOpts.Confidential = gitlab.Bool(opts.IsConfidential)
+		}
+		if opts.Weight != 0 {
+			issueCreateOpts.Weight = gitlab.Int(opts.Weight)
+		}
+		if opts.LinkedMR != 0 {
+			issueCreateOpts.MergeRequestToResolveDiscussionsOf = gitlab.Int(opts.LinkedMR)
+		}
+		if opts.MileStone != 0 {
+			issueCreateOpts.MilestoneID = gitlab.Int(opts.MileStone)
+		}
+		if len(opts.Assignees) > 0 {
+			users, err := api.UsersByNames(apiClient, opts.Assignees)
+			if err != nil {
+				return err
+			}
+			issueCreateOpts.AssigneeIDs = cmdutils.IDsFromUsers(users)
+		}
+		fmt.Fprintln(opts.IO.StdErr, "\n- Creating issue in", repo.FullName())
+		issue, err := api.CreateIssue(apiClient, repo.FullName(), issueCreateOpts)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(opts.IO.StdOut, issueutils.DisplayIssue(issue))
+		return nil
+	}
+
+	return errors.New("expected to cancel, preview in browser, or submit")
+}
+
+func previewIssue(opts *CreateOpts) error {
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	openURL, err := generateIssueWebURL(opts, repo)
+	if err != nil {
+		return err
+	}
+
+	if opts.IO.IsOutputTTY() {
+		fmt.Fprintf(opts.IO.StdErr, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
+	}
+	browser, _ := cfg.Get(repo.RepoHost(), "browser")
+	return utils.OpenInBrowser(openURL, browser)
+}
+
+func generateIssueWebURL(opts *CreateOpts, repo glrepo.Interface) (string, error) {
+	description := opts.Description
+
+	if len(opts.Labels) > 0 {
+		// this uses the slash commands to add labels to the description
+		// See https://docs.gitlab.com/ee/user/project/quick_actions.html
+		// See also https://gitlab.com/gitlab-org/gitlab-foss/-/issues/19731#note_32550046
+		description += fmt.Sprintf("\n/label ~%s", strings.Join(opts.Labels, " ~"))
+	}
+	if len(opts.Assignees) > 0 {
+		// this uses the slash commands to add assignees to the description
+		description += fmt.Sprintf("\n/assign %s", strings.Join(opts.Assignees, ", "))
+	}
+	if opts.MileStone != 0 {
+		// this uses the slash commands to add milestone to the description
+		description += fmt.Sprintf("\n/milestone %%%d", opts.MileStone)
+	}
+	if opts.Weight != 0 {
+		// this uses the slash commands to add weight to the description
+		description += fmt.Sprintf("\n/weight %%%d", opts.Weight)
+	}
+	if opts.IsConfidential {
+		// this uses the slash commands to add confidential to the description
+		description += "\n/confidential"
+	}
+
+	u, err := url.Parse(opts.BaseProject.WebURL)
+	if err != nil {
+		return "", err
+	}
+	u.Path += "/-/issues/new"
+	u.RawQuery = fmt.Sprintf(
+		"utf8=✓&issue[title]=%s&issue[description]=%s",
+		opts.Title,
+		description)
+	return u.String(), nil
 }

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -200,10 +200,8 @@ func createRun(opts *CreateOpts) error {
 				return err
 			}
 		}
-	} else {
-		if opts.Title == "" {
-			return fmt.Errorf("title can't be blank")
-		}
+	} else if opts.Title == "" {
+		return fmt.Errorf("title can't be blank")
 	}
 
 	var action cmdutils.Action

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -16,7 +16,7 @@ import (
 type CreateOpts struct {
 	Title       string
 	Description string
-	Labels      string
+	Labels      []string
 	Assignees   []string
 
 	Weight    int
@@ -126,7 +126,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 						}
 					}
 				}
-				if opts.Labels == "" {
+				if len(opts.Labels) == 0 {
 					remotes, err := f.Remotes()
 					if err != nil {
 						return err
@@ -147,7 +147,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			}
 
 			issueCreateOpts.Title = gitlab.String(opts.Title)
-			issueCreateOpts.Labels = gitlab.Labels{opts.Labels}
+			issueCreateOpts.Labels = opts.Labels
 			issueCreateOpts.Description = &opts.Description
 			if opts.IsConfidential {
 				issueCreateOpts.Confidential = gitlab.Bool(opts.IsConfidential)
@@ -179,7 +179,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	}
 	issueCreateCmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Supply a title for issue")
 	issueCreateCmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Supply a description for issue")
-	issueCreateCmd.Flags().StringVarP(&opts.Labels, "label", "l", "", "Add label by name. Multiple labels should be comma separated")
+	issueCreateCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Add label by name. Multiple labels should be comma separated")
 	issueCreateCmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", []string{}, "Assign issue to people by their `usernames`")
 	issueCreateCmd.Flags().IntVarP(&opts.MileStone, "milestone", "m", -1, "The global ID of a milestone to assign issue")
 	issueCreateCmd.Flags().BoolVarP(&opts.IsConfidential, "confidential", "c", false, "Set an issue to be confidential. Default is false")

--- a/commands/issue/create/issue_create_test.go
+++ b/commands/issue/create/issue_create_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/profclems/glab/pkg/prompt"
+
 	"github.com/profclems/glab/internal/utils"
 
 	"github.com/acarl005/stripansi"
@@ -16,6 +18,16 @@ import (
 )
 
 func Test_IssueCreate(t *testing.T) {
+	ask, teardown := prompt.InitAskStubber()
+	defer teardown()
+
+	ask.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "confirmation",
+			Value: 0,
+		},
+	})
+
 	oldCreateIssue := api.CreateIssue
 	timer, _ := time.Parse(time.RFC3339, "2014-11-12T11:45:26.371Z")
 	api.CreateIssue = func(client *gitlab.Client, projectID interface{}, opts *gitlab.CreateIssueOptions) (*gitlab.Issue, error) {


### PR DESCRIPTION
Provide submit options to allow users either submit the MR via the CLI or continue in browser or cancel.

If 'preview in browser' is selected, it opens up a browser window with a prefilled title, description and
other mr or issue options.

Note on Prefilling issue with url query parameters: https://gitlab.com/gitlab-org/gitlab-foss/-/issues/19731#note_32449479
and slash commands: https://gitlab.com/gitlab-org/gitlab-foss/-/issues/19731#note_32550046

Resolves #329
