### PR TITLE
docs(readme): use official scoop main bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ winget install glab
 
 #### Scoop
 ```sh
-scoop bucket add profclems-bucket https://github.com/profclems/scoop-bucket.git
 scoop install glab
 ```
 Updating:


### PR DESCRIPTION
Finally what I have been waiting for has been merged. 
`glab` is now in the scoop main bucket https://github.com/ScoopInstaller/Main/pull/1640.

**Related Issue**
None

**How Has This Been Tested?**

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Chore (Related to CI or Packaging to platforms)
