### PR TITLE
fix: set tracking branch only if not set

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -395,12 +395,14 @@ func handlePush(opts *CreateOpts, remote *glrepo.Remote) error {
 			}
 			fmt.Fprintf(opts.IO.StdErr, "\nwarning: you have %s\n", utils.Pluralize(c, "uncommitted change"))
 		}
-		if trackingRef := determineTrackingBranch(remotes, opts.SourceBranch); trackingRef != nil {
-			if r, err := remotes.FindByName(trackingRef.RemoteName); err == nil {
-				sourceRemote = r
+		err := git.Push(sourceRemote.Name, fmt.Sprintf("HEAD:%s", sourceBranch), opts.IO.StdOut, opts.IO.StdErr)
+		if err == nil {
+			if trackingRef := determineTrackingBranch(remotes, opts.SourceBranch); trackingRef == nil {
+				// No remote is set so set it
+				_ = git.SetUpstream(sourceRemote.Name, sourceBranch, opts.IO.StdOut, opts.IO.StdErr)
 			}
 		}
-		return git.Push(sourceRemote.Name, fmt.Sprintf("HEAD:%s", sourceBranch), opts.IO.StdOut, opts.IO.StdErr)
+		return err
 	}
 
 	return nil

--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -167,8 +167,7 @@ func TestNewCmdCreate_autofill(t *testing.T) {
 		out := stripansi.Strip(stdout.String())
 		outErr := stripansi.Strip(stderr.String())
 
-		assert.Equal(t, `Branch 'mr-autofill-test-br' set up to track remote branch 'mr-autofill-test-br' from 'origin'.
-!1 docs: add some changes to txt file (mr-autofill-test-br)
+		assert.Equal(t, `!1 docs: add some changes to txt file (mr-autofill-test-br)
  https://gitlab.com/glab-cli/test/-/merge_requests/1
 
 `, out)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -208,12 +208,20 @@ func CommitBody(sha string) (string, error) {
 	return string(output), nil
 }
 
-// Push publishes a git ref to a remote and sets up upstream configuration
+// Push publishes a git ref to a remote
 func Push(remote string, ref string, cmdOut, cmdErr io.Writer) error {
-	pushCmd := GitCommand("push", "--set-upstream", remote, ref)
+	pushCmd := GitCommand("push", remote, ref)
 	pushCmd.Stdout = cmdOut
 	pushCmd.Stderr = cmdErr
 	return run.PrepareCmd(pushCmd).Run()
+}
+
+// SetUpstream sets the upstream (tracking) of a branch
+func SetUpstream(remote string, branch string, cmdOut, cmdErr io.Writer) error {
+	setCmd := GitCommand("branch", "--set-upstream-to", fmt.Sprintf("%s/%s", remote, branch))
+	setCmd.Stdout = cmdOut
+	setCmd.Stderr = cmdErr
+	return run.PrepareCmd(setCmd).Run()
 }
 
 type BranchConfig struct {


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
Split `git.SetUpstream` out of `git.Push`, the latter no longer runs with `--set-upstream` as to avoid overriding the tracking branch set by the user. Instead we set it with `git.SetUpstream` if none is set

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #406 


**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Creating MRs on gitlab.alpinelinux.org, it doesn't override my tracking branches but more testing would be nice before merging.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
