### PR TITLE
Rework BaseRepo from internal.glrepo.resolver

### DIFF
--- a/internal/glrepo/resolver.go
+++ b/internal/glrepo/resolver.go
@@ -117,12 +117,12 @@ func (r *ResolvedRemotes) BaseRepo(prompt bool) (Interface, error) {
 		}
 	}
 
-	for _, repo := range r.network {
-		if repo.ForkedFromProject != nil {
-			fProject, _ := api.GetProject(r.apiClient, repo.ForkedFromProject.PathWithNamespace)
+	for i := range r.network {
+		if r.network[i].ForkedFromProject != nil {
+			fProject, _ := api.GetProject(r.apiClient, r.network[i].ForkedFromProject.PathWithNamespace)
 			add(fProject)
 		}
-		add(&repo)
+		add(&r.network[i])
 	}
 
 	if len(repoNames) == 0 {

--- a/internal/glrepo/resolver.go
+++ b/internal/glrepo/resolver.go
@@ -3,6 +3,7 @@ package glrepo
 import (
 	"errors"
 	"sort"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/profclems/glab/internal/git"
@@ -66,7 +67,7 @@ func (r *ResolvedRemotes) BaseRepo(prompt bool) (Interface, error) {
 	for _, r := range r.remotes {
 		if r.Resolved == "base" {
 			return r, nil
-		} else if r.Resolved != "" {
+		} else if strings.HasPrefix(r.Resolved, "base:") {
 			repo, err := FromFullName(r.Resolved)
 			if err != nil {
 				return nil, err

--- a/internal/glrepo/resolver.go
+++ b/internal/glrepo/resolver.go
@@ -107,12 +107,7 @@ func (r *ResolvedRemotes) BaseRepo(prompt bool) (Interface, error) {
 	add := func(r *gitlab.Project) {
 		fn, _ := FullNameFromURL(r.HTTPURLToRepo)
 		if _, ok := repoMap[fn]; !ok {
-			// This is run inside a for-loop, create a local copy and use its address
-			// instead of the one given to us, otherwise the value in repoMap will be
-			// overwriten in the next iteration of the loop
-			// See: #395, #384
-			localCopy := *r
-			repoMap[fn] = &localCopy
+			repoMap[fn] = r
 			repoNames = append(repoNames, fn)
 		}
 	}

--- a/internal/glrepo/resolver.go
+++ b/internal/glrepo/resolver.go
@@ -148,6 +148,7 @@ func (r *ResolvedRemotes) BaseRepo(prompt bool) (Interface, error) {
 	if remote == nil {
 		remote = r.remotes[0]
 		resolution, _ = FullNameFromURL(selectedRepo.HTTPURLToRepo)
+		resolution = "base:" + resolution
 	}
 
 	// cache the result to git config


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This reworks BaseRepo to support certain features:

- Be stricter about cached resolutions, only use `base` or the first with the prefix `base:` (instead of any other resolution)

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
No issue was open for this but it is ripped of #410 to be easier to reason about

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested as part of #410 

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
