### PR TITLE
packaging: create windows installer

### DIFF
--- a/.github/workflows/create_exe.yml
+++ b/.github/workflows/create_exe.yml
@@ -37,18 +37,18 @@ jobs:
           $srcDir = Convert-Path .
           Rename-Item -Path $srcDir/bin/glab -NewName glab.exe
           Copy-Item -Path $srcDir/scripts/setup_windows.iss -Destination $srcDir
-          iscc "setup_windows.iss" /DVersion=1.13.0
+          iscc "setup_windows.iss" /DVersion=1.13.1
 
       - name: Generate Hash
         env:
           GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
         run:
           gh release download -p "checksums.txt"; 
-          echo "$(Get-FileHash ./bin/glab_1.13.0_Windows_x86_64_installer.exe -Algorithm SHA256 | Select-Object "Hash" | ForEach-Object {$_.Hash})  glab_1.13.0_Windows_x86_64_installer.exe" >> checksums.txt
+          echo "$(Get-FileHash ./bin/glab_1.13.1_Windows_x86_64_installer.exe -Algorithm SHA256 | Select-Object "Hash" | ForEach-Object {$_.Hash})  glab_1.13.1_Windows_x86_64_installer.exe" >> checksums.txt
 
       - name: Upload Installer to Release
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
         run: |
-          gh release upload "v1.13.0" ./bin/glab_1.13.0_Windows_x86_64_installer.exe checksums.txt --clobber
+          gh release upload "v1.13.1" ./bin/glab_1.13.1_Windows_x86_64_installer.exe checksums.txt --clobber

--- a/.github/workflows/create_exe.yml
+++ b/.github/workflows/create_exe.yml
@@ -1,0 +1,54 @@
+name: goreleaser
+
+on: [push]
+
+jobs:
+  exe-installer:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Install Chocolatey
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+      - name: Install Build Tools
+        run: |
+          choco install innosetup make
+
+      - name: Build GLab For Windows
+        id: buildwin
+        run: |
+          make build && Get-ChildItem bin
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
+          echo ::set-output name=vtag::${GITHUB_REF#refs/tags/}
+
+      - name: Create Installer
+        run: |
+          $srcDir = Convert-Path .
+          Rename-Item -Path $srcDir/bin/glab -NewName glab.exe
+          Copy-Item -Path $srcDir/scripts/setup_windows.iss -Destination $srcDir
+          iscc "setup_windows.iss" /DVersion=${{steps.buildwin.outputs.tag}}
+
+      - name: Generate Hash
+        env:
+          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
+        run:
+          gh release download -p "checksums.txt"
+          echo "$(Get-FileHash ./bin/glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe -Algorithm SHA256 | Select-Object "Hash" | ForEach-Object {$_.Hash})  glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe" >> checksums.txt
+
+      - name: Upload Installer to Release
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
+        run: |
+          gh release upload "${{ steps.buildwin.outputs.vtag }}" ./bin/glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe checksums.txt --clobber

--- a/.github/workflows/create_exe.yml
+++ b/.github/workflows/create_exe.yml
@@ -37,18 +37,18 @@ jobs:
           $srcDir = Convert-Path .
           Rename-Item -Path $srcDir/bin/glab -NewName glab.exe
           Copy-Item -Path $srcDir/scripts/setup_windows.iss -Destination $srcDir
-          iscc "setup_windows.iss" /DVersion=${{steps.buildwin.outputs.tag}}
+          iscc "setup_windows.iss" /DVersion=1.13.0
 
       - name: Generate Hash
         env:
           GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
         run:
           gh release download -p "checksums.txt"; 
-          echo "$(Get-FileHash ./bin/glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe -Algorithm SHA256 | Select-Object "Hash" | ForEach-Object {$_.Hash})  glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe" >> checksums.txt
+          echo "$(Get-FileHash ./bin/glab_1.13.0_Windows_x86_64_installer.exe -Algorithm SHA256 | Select-Object "Hash" | ForEach-Object {$_.Hash})  glab_1.13.0_Windows_x86_64_installer.exe" >> checksums.txt
 
       - name: Upload Installer to Release
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
         run: |
-          gh release upload "${{ steps.buildwin.outputs.vtag }}" ./bin/glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe checksums.txt --clobber
+          gh release upload "v1.13.0" ./bin/glab_1.13.0_Windows_x86_64_installer.exe checksums.txt --clobber

--- a/.github/workflows/create_exe.yml
+++ b/.github/workflows/create_exe.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
         run:
-          gh release download -p "checksums.txt"
+          gh release download -p "checksums.txt"; 
           echo "$(Get-FileHash ./bin/glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe -Algorithm SHA256 | Select-Object "Hash" | ForEach-Object {$_.Hash})  glab_${{ steps.buildwin.outputs.tag }}_Windows_x86_64_installer.exe" >> checksums.txt
 
       - name: Upload Installer to Release


### PR DESCRIPTION
The release workflow failed due to an error in the `exe installer` step.
This has been fixed but the exe installer artifact is missing in the releases page.

This adds a separate workflow (taken from the `release workflow`) which will create the exe installer.

NB: This will not be merged