### PR TITLE
add support for interactively attaching milestones

### DIFF
--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -188,7 +188,7 @@ func createRun(opts *CreateOpts) error {
 				}
 			}
 		}
-		if len(opts.Labels) == 0 {
+		if len(opts.Labels) == 0 || opts.MileStone == 0 {
 			remotes, err := opts.Remotes()
 			if err != nil {
 				return err
@@ -197,9 +197,17 @@ func createRun(opts *CreateOpts) error {
 			if err != nil {
 				return err
 			}
-			err = cmdutils.LabelsPrompt(&opts.Labels, apiClient, repoRemote)
-			if err != nil {
-				return err
+			if len(opts.Labels) == 0 {
+				err = cmdutils.LabelsPrompt(&opts.Labels, apiClient, repoRemote)
+				if err != nil {
+					return err
+				}
+			}
+			if opts.MileStone == 0 {
+				err = cmdutils.MilestonesPrompt(&opts.MileStone, apiClient, repoRemote, opts.IO)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	} else if opts.Title == "" {

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -270,6 +270,12 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 						return err
 					}
 				}
+				if opts.MileStone == 0 {
+					err = cmdutils.MilestonesPrompt(&opts.MileStone, labClient, baseRepoRemote, opts.IO)
+					if err != nil {
+						return err
+					}
+				}
 			} else if opts.Title == "" {
 				return fmt.Errorf("title can't be blank")
 			}

--- a/pkg/api/milestone.go
+++ b/pkg/api/milestone.go
@@ -1,0 +1,19 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+var ListMilestones = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	if opts.PerPage == 0 {
+		opts.PerPage = DefaultListLimit
+	}
+
+	milestone, _, err := client.Milestones.ListMilestones(projectID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return milestone, nil
+}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This adds:

- Minor support in `pkg/api/milestone.go` (that can be expanded with more stuff as required)
- Helper function like `cmdutils.LabelsPrompt` but for Milestones instead
- Make `mr create` and `issue create` use the the helper function above to interactively attach milestones

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Partial fix to #439 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Still undergoing testing

**Screenshots (if appropriate):**
![milestone-1](https://user-images.githubusercontent.com/30738253/103320796-920c9980-4a15-11eb-8993-60347c7024e1.png)
![milestone-2](https://user-images.githubusercontent.com/30738253/103320799-92a53000-4a15-11eb-8de4-f6626af8803a.png)
![milestone-3](https://user-images.githubusercontent.com/30738253/103320801-93d65d00-4a15-11eb-9417-741c4ba2161f.png)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
