### PR TITLE
feat(commands/mr/create): prompt for labels with --autofill

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -397,7 +397,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	mrCreateCmd.Flags().BoolVarP(&opts.RemoveSourceBranch, "remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 	mrCreateCmd.Flags().StringP("head", "H", "", "Select another head repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
-	mrCreateCmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Do not prompt for confirmation to submit the merge request, skip prompts with --autofill")
+	mrCreateCmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Do not prompt for confirmation to submit the merge request, use together with --autofill to skip prompts")
 
 	mrCreateCmd.Flags().StringVarP(&mrCreateTargetProject, "target-project", "", "", "Add target project by id or OWNER/REPO or GROUP/NAMESPACE/REPO")
 	mrCreateCmd.Flags().MarkHidden("target-project")

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -264,14 +264,17 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 						}
 					}
 				}
+			} else if opts.Title == "" {
+				return fmt.Errorf("title can't be blank")
+			}
+
+			if opts.IsInteractive && (opts.Autofill && !opts.Yes || !opts.Autofill) {
 				if len(opts.Labels) == 0 {
 					err = cmdutils.LabelsPrompt(&opts.Labels, labClient, baseRepoRemote)
 					if err != nil {
 						return err
 					}
 				}
-			} else if opts.Title == "" {
-				return fmt.Errorf("title can't be blank")
 			}
 
 			if opts.IsDraft || opts.IsWIP {
@@ -386,7 +389,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	mrCreateCmd.Flags().BoolVarP(&opts.RemoveSourceBranch, "remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 	mrCreateCmd.Flags().StringP("head", "H", "", "Select another head repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
-	mrCreateCmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Do not prompt for confirmation to submit the merge request")
+	mrCreateCmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Do not prompt for confirmation to submit the merge request, skip prompts with --autofill")
 
 	mrCreateCmd.Flags().StringVarP(&mrCreateTargetProject, "target-project", "", "", "Add target project by id or OWNER/REPO or GROUP/NAMESPACE/REPO")
 	mrCreateCmd.Flags().MarkHidden("target-project")


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
Split the `cmdutils.LabelsPrompt` logic into its own block that checks.

1. Is it interactive ?
2. was `--autofill` used but `--yes` not used, OR
3. was `--autofill` not used

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #448 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See screenshots:

**Screenshots (if appropriate):**
![interative-autofill-1](https://user-images.githubusercontent.com/30738253/103322499-d94a5880-4a1c-11eb-88cc-f2a8b92ea235.png)
![interative-autofill-2](https://user-images.githubusercontent.com/30738253/103322500-da7b8580-4a1c-11eb-8b54-94e6b237d3e3.png)
![interative-autofill-3](https://user-images.githubusercontent.com/30738253/103322501-da7b8580-4a1c-11eb-87fa-7d01f94077a6.png)


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
