### PR TITLE
feat: Interactive assignee

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -220,6 +220,23 @@ func MilestonesPrompt(response *int, apiClient *gitlab.Client, repoRemote *glrep
 	return nil
 }
 
+func AssigneesPrompt(response *[]string) (err error) {
+	var addAssignees bool
+	err = prompt.Confirm(&addAssignees, "Do you wish to assign users?", true)
+	if err != nil {
+		return err
+	}
+	if addAssignees {
+		var responseString string
+		err = prompt.AskQuestionWithInput(&responseString, "Username(s) [Comma Separated]", "", false)
+		if err != nil {
+			return err
+		}
+		*response = strings.Split(responseString, ",")
+	}
+	return nil
+}
+
 type Action int
 
 const (

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -214,12 +214,17 @@ func createRun(opts *CreateOpts) error {
 					return err
 				}
 			}
-
 			if opts.MileStone == 0 {
 				err = cmdutils.MilestonesPrompt(&opts.MileStone, apiClient, repoRemote, opts.IO)
 				if err != nil {
 					return err
 				}
+			}
+		}
+		if len(opts.Assignees) == 0 {
+			err = cmdutils.AssigneesPrompt(&opts.Assignees)
+			if err != nil {
+				return err
 			}
 		}
 

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -283,6 +283,12 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 						return err
 					}
 				}
+				if len(opts.Assignees) == 0 {
+					err = cmdutils.AssigneesPrompt(&opts.Assignees)
+					if err != nil {
+						return err
+					}
+				}
 				if opts.MileStone == 0 {
 					err = cmdutils.MilestonesPrompt(&opts.MileStone, labClient, baseRepoRemote, opts.IO)
 					if err != nil {


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
Add Interactive prompt for assigning users, unfortunately users can range from the hundreds in small instances (`gitlab.alpinelinux.org`) to hundreds of thousands in large instances (`gitlab.com`), so it is not feasible to fetch all of them and present the user with a nice multi-prompt

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Part of #439 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a user while creating a merge request and while creating an issue on `gitlab.alpinelinux.org`

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
