### PR TITLE
fix(commands/issue/create): remotes error on issue create

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -138,7 +138,10 @@ func LabelsPrompt(response *[]string, apiClient *gitlab.Client, repoRemote *glre
 		return
 	}
 	if addLabels {
-		labelOptions, _ := git.Config("remote." + repoRemote.Name + ".glab-cached-labels")
+		var labelOptions string
+		if repoRemote.Name != "" {
+			labelOptions, _ = git.Config("remote." + repoRemote.Name + ".glab-cached-labels")
+		}
 		if labelOptions == "" {
 			lOpts := &gitlab.ListLabelsOptions{}
 			lOpts.PerPage = 100
@@ -150,7 +153,7 @@ func LabelsPrompt(response *[]string, apiClient *gitlab.Client, repoRemote *glre
 					}
 					labelOptions += label.Name
 				}
-				if labelOptions != "" {
+				if labelOptions != "" && repoRemote.Name != "" {
 					// silently fails if not a git repo
 					_ = git.SetConfig(repoRemote.Name, "glab-cached-labels", labelOptions)
 				}
@@ -278,12 +281,12 @@ func IDsFromUsers(users []*gitlab.User) []int {
 	return ids
 }
 
-func ParseMilestone(apiClient *gitlab.Client, repoRemote *glrepo.Remote, milestoneTitle string) (int, error) {
+func ParseMilestone(apiClient *gitlab.Client, repo glrepo.Interface, milestoneTitle string) (int, error) {
 	if milestoneID, err := strconv.Atoi(milestoneTitle); err == nil {
 		return milestoneID, nil
 	}
 
-	milestone, err := api.MilestoneByTitle(apiClient, repoRemote.FullName(), milestoneTitle)
+	milestone, err := api.MilestoneByTitle(apiClient, repo.FullName(), milestoneTitle)
 	if err != nil {
 		return 0, err
 	}

--- a/commands/issue/create/issue_create_test.go
+++ b/commands/issue/create/issue_create_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func Test_IssueCreate(t *testing.T) {
+	cmdtest.CopyTestRepo(t, "issue_create")
 	ask, teardown := prompt.InitAskStubber()
 	defer teardown()
 

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -170,7 +170,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 			}
 
 			if opts.MilestoneFlag != "" {
-				opts.MileStone, err = cmdutils.ParseMilestone(labClient, baseRepoRemote, opts.MilestoneFlag)
+				opts.MileStone, err = cmdutils.ParseMilestone(labClient, baseRepo, opts.MilestoneFlag)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
When an issue is created for a different repo which has no remote
in the current working git directory, it results in a `remote not found` error.
This happens because `cmdutils.LabelsPrompt` needs the remote name to cache the labels
in .git/config.

To fix that, we avoid caching the labels if there are no matching remotes.

Folow up to #446 