### PR TITLE
fix: respect repo override

### DIFF
--- a/commands/ci/trace/trace.go
+++ b/commands/ci/trace/trace.go
@@ -32,9 +32,7 @@ type TraceOpts struct {
 
 func NewCmdTrace(f *cmdutils.Factory, runE func(traceOpts *TraceOpts) error) *cobra.Command {
 	opts := &TraceOpts{
-		BaseRepo:   f.BaseRepo,
-		HTTPClient: f.HttpClient,
-		IO:         f.IO,
+		IO: f.IO,
 	}
 	var pipelineCITraceCmd = &cobra.Command{
 		Use:   "trace [<job-id>] [flags]",
@@ -48,6 +46,14 @@ func NewCmdTrace(f *cmdutils.Factory, runE func(traceOpts *TraceOpts) error) *co
 	`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
+
+			// support `-R, --repo` override
+			//
+			// NOTE: it is important to assign the BaseRepo and HTTPClient in RunE because
+			// they are overridden in a PersistentRun hook (when `-R, --repo` is specified)
+			// which runs before RunE is executed
+			opts.BaseRepo = f.BaseRepo
+			opts.HTTPClient = f.HttpClient
 
 			if len(args) != 0 {
 				opts.JobID = utils.StringToInt(args[0])

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -48,11 +48,9 @@ type CreateOpts struct {
 
 func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	opts := &CreateOpts{
-		IO:         f.IO,
-		BaseRepo:   f.BaseRepo,
-		HTTPClient: f.HttpClient,
-		Remotes:    f.Remotes,
-		Config:     f.Config,
+		IO:      f.IO,
+		Remotes: f.Remotes,
+		Config:  f.Config,
 	}
 	var issueCreateCmd = &cobra.Command{
 		Use:     "create [flags]",
@@ -62,6 +60,14 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
+
+			// support `-R, --repo` override
+			//
+			// NOTE: it is important to assign the BaseRepo and HTTPClient in RunE because
+			// they are overridden in a PersistentRun hook (when `-R, --repo` is specified)
+			// which runs before RunE is executed
+			opts.BaseRepo = f.BaseRepo
+			opts.HTTPClient = f.HttpClient
 
 			apiClient, err := opts.HTTPClient()
 			if err != nil {

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -67,9 +67,7 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		IO:       f.IO,
 		Branch:   f.Branch,
 		Remotes:  f.Remotes,
-		Lab:      f.HttpClient,
 		Config:   f.Config,
-		BaseRepo: f.BaseRepo,
 		HeadRepo: resolvedHeadRepo(f),
 	}
 
@@ -90,6 +88,14 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
+
+			// support `-R, --repo` override
+			//
+			// NOTE: it is important to assign the BaseRepo and HTTPClient in RunE because
+			// they are overridden in a PersistentRun hook (when `-R, --repo` is specified)
+			// which runs before RunE is executed
+			opts.BaseRepo = f.BaseRepo
+			opts.Lab = f.HttpClient
 
 			out := opts.IO.StdOut
 			mrCreateOpts := &gitlab.CreateMergeRequestOptions{}


### PR DESCRIPTION
The repo override was not respected by the following commands
- `issue create`
- `mr create`
- `ci trace`

This was due the the BaseRepo and HTTPClient being assigned too early
before the PersistentPrerun function is executed

Resolves #455
