### PR TITLE
feat(commands/issue/update): use plural only when appropriate

### DIFF
--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -67,11 +67,17 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				l.Description = gitlab.String(m)
 			}
 			if m, _ := cmd.Flags().GetStringArray("label"); len(m) != 0 {
-				actions = append(actions, fmt.Sprintf("added labels %s", strings.Join(m, " ")))
+				actions = append(actions, fmt.Sprintf("added %s %s",
+					utils.Pluralize(len(m), "label"),
+					strings.Join(m, " ")),
+				)
 				l.AddLabels = gitlab.Labels(m)
 			}
 			if m, _ := cmd.Flags().GetStringArray("unlabel"); len(m) != 0 {
-				actions = append(actions, fmt.Sprintf("removed labels %s", strings.Join(m, " ")))
+				actions = append(actions, fmt.Sprintf("removed %s %s",
+					utils.Pluralize(len(m), "label"),
+					strings.Join(m, " ")),
+				)
 				l.RemoveLabels = gitlab.Labels(m)
 			}
 			if m, _ := cmd.Flags().GetBool("public"); m {


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
use `utils.Pluralize` where we can

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
