### PR TITLE
Allow comma-separated labels for `issue update`

### DIFF
--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -66,11 +66,11 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				actions = append(actions, "updated description")
 				l.Description = gitlab.String(m)
 			}
-			if m, _ := cmd.Flags().GetStringArray("label"); len(m) != 0 {
+			if m, _ := cmd.Flags().GetStringSlice("label"); len(m) != 0 {
 				actions = append(actions, fmt.Sprintf("added labels %s", strings.Join(m, " ")))
 				l.AddLabels = gitlab.Labels(m)
 			}
-			if m, _ := cmd.Flags().GetStringArray("unlabel"); len(m) != 0 {
+			if m, _ := cmd.Flags().GetStringSlice("unlabel"); len(m) != 0 {
 				actions = append(actions, fmt.Sprintf("removed labels %s", strings.Join(m, " ")))
 				l.RemoveLabels = gitlab.Labels(m)
 			}
@@ -117,8 +117,8 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	issueUpdateCmd.Flags().BoolP("lock-discussion", "", false, "Lock discussion on issue")
 	issueUpdateCmd.Flags().BoolP("unlock-discussion", "", false, "Unlock discussion on issue")
 	issueUpdateCmd.Flags().StringP("description", "d", "", "Issue description")
-	issueUpdateCmd.Flags().StringArrayP("label", "l", []string{}, "add labels")
-	issueUpdateCmd.Flags().StringArrayP("unlabel", "u", []string{}, "remove labels")
+	issueUpdateCmd.Flags().StringSliceP("label", "l", []string{}, "add labels")
+	issueUpdateCmd.Flags().StringSliceP("unlabel", "u", []string{}, "remove labels")
 	issueUpdateCmd.Flags().BoolP("public", "p", false, "Make issue public")
 	issueUpdateCmd.Flags().BoolP("confidential", "c", false, "Make issue confidential")
 	issueUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -95,11 +95,11 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				l.Description = gitlab.String(m)
 			}
 
-			if m, _ := cmd.Flags().GetStringArray("label"); len(m) != 0 {
+			if m, _ := cmd.Flags().GetStringSlice("label"); len(m) != 0 {
 				actions = append(actions, fmt.Sprintf("added labels %s", strings.Join(m, " ")))
 				l.AddLabels = gitlab.Labels(m)
 			}
-			if m, _ := cmd.Flags().GetStringArray("unlabel"); len(m) != 0 {
+			if m, _ := cmd.Flags().GetStringSlice("unlabel"); len(m) != 0 {
 				actions = append(actions, fmt.Sprintf("removed labels %s", strings.Join(m, " ")))
 				l.RemoveLabels = gitlab.Labels(m)
 			}


### PR DESCRIPTION
**Description**
Use StringSliceP instead of StringArrayP to support both comma-separated values
and multiple usages.
https://pkg.go.dev/github.com/spf13/pflag@v1.0.5#StringArray
https://pkg.go.dev/github.com/spf13/pflag@v1.0.5#StringSlice


**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
