### PR TITLE
Add testing for MilestonePrompt()

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -200,10 +200,7 @@ func MilestonesPrompt(response *int, apiClient *gitlab.Client, repoRemote *glrep
 	}
 
 	var selectedMilestone string
-	err = prompt.AskOne(&survey.Select{
-		Message: "Select Milestone",
-		Options: milestoneOptions,
-	}, &selectedMilestone)
+	err = prompt.Select(&selectedMilestone, "milestone", "Select Milestone", milestoneOptions)
 	if err != nil {
 		return err
 	}

--- a/commands/cmdutils/cmdutils_test.go
+++ b/commands/cmdutils/cmdutils_test.go
@@ -769,3 +769,73 @@ func TestMilestonesPromptFailures(t *testing.T) {
 	}
 	assert.Equal(t, "api.ListMilestones() failed", err.Error())
 }
+
+func Test_IDsFromUsers(t *testing.T) {
+	testCases := []struct {
+		name  string
+		users []*gitlab.User // Mock of the gitlab.User object
+		IDs   []int          // IDs we expect from the users
+	}{
+		{
+			name: "no users",
+		},
+		{
+			name: "one user",
+			users: []*gitlab.User{
+				{
+					ID: 1,
+				},
+			},
+			IDs: []int{1},
+		},
+		{
+			name: "multiple users",
+			users: []*gitlab.User{
+				{
+					ID: 3,
+				},
+				{
+					ID: 6,
+				},
+				{
+					ID: 2,
+				},
+				{
+					ID: 51,
+				},
+				{
+					ID: 32,
+				},
+				{
+					ID: 87,
+				},
+				{
+					ID: 210,
+				},
+				{
+					ID: 6493,
+				},
+				{
+					ID: 50132,
+				},
+			},
+			IDs: []int{
+				50132,
+				6493,
+				210,
+				87,
+				32,
+				51,
+				2,
+				3,
+				6,
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			got := IDsFromUsers(tC.users)
+			assert.ElementsMatch(t, got, tC.IDs)
+		})
+	}
+}

--- a/commands/cmdutils/cmdutils_test.go
+++ b/commands/cmdutils/cmdutils_test.go
@@ -228,8 +228,7 @@ func Test_UsersFromReplaces(t *testing.T) {
 				return tC.users, nil
 			}
 			var gotAction []string
-			apiClient := gitlab.Client{} // Empty Client, it won't be used, just to satisfy the function signature
-			gotIDs, gotAction, err := ua.UsersFromReplaces(&apiClient, gotAction)
+			gotIDs, gotAction, err := ua.UsersFromReplaces(&gitlab.Client{}, gotAction)
 			if err != nil {
 				t.Errorf("UsersFromReplaces() unexpected error = %s", err)
 			}
@@ -458,8 +457,7 @@ func Test_UsersFromAddRemove(t *testing.T) {
 				return tC.users, nil
 			}
 			var gotAction []string
-			apiClient := gitlab.Client{} // Empty Client, it won't be used, just to satisfy the function signature
-			gotIDs, gotAction, err := tC.ua.UsersFromAddRemove(tC.issue, tC.merge, &apiClient, gotAction)
+			gotIDs, gotAction, err := tC.ua.UsersFromAddRemove(tC.issue, tC.merge, &gitlab.Client{}, gotAction)
 			if err != nil {
 				if tC.wantErr != "" && tC.wantErr != err.Error() {
 					t.Errorf("UsersFromAddRemove() expected error = %s, got = %s", tC.wantErr, err)

--- a/internal/glrepo/resolver_test.go
+++ b/internal/glrepo/resolver_test.go
@@ -1,0 +1,88 @@
+package glrepo
+
+import (
+	"testing"
+
+	"github.com/profclems/glab/internal/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_RemoteForRepo(t *testing.T) {
+	r := &ResolvedRemotes{
+		remotes: Remotes{
+			&Remote{
+				Remote: &git.Remote{
+					Name: "upstream",
+				},
+				Repo: NewWithHost("profclems", "glab", "gitlab.com"),
+			},
+			&Remote{
+				Remote: &git.Remote{
+					Name: "origin",
+				},
+				Repo: NewWithHost("maxice8", "glab", "gitlab.com"),
+			},
+		},
+	}
+	testCases := []struct {
+		name    string
+		input   Interface
+		output  *Remote // Expected remote if there is a match
+		wantErr string  // Expected error
+	}{
+		{
+			name:  "match upstream",
+			input: NewWithHost("profclems", "glab", "gitlab.com"),
+			output: &Remote{
+				Remote: &git.Remote{
+					Name: "upstream",
+				},
+				Repo: NewWithHost("profclems", "glab", "gitlab.com"),
+			},
+		},
+		{
+			name:  "match origin",
+			input: NewWithHost("maxice8", "glab", "gitlab.com"),
+			output: &Remote{
+				Remote: &git.Remote{
+					Name: "origin",
+				},
+				Repo: NewWithHost("maxice8", "glab", "gitlab.com"),
+			},
+		},
+		{
+			name:    "no match via Hostname",
+			input:   NewWithHost("profclems", "glab", "gitlab.extradomain.com"),
+			wantErr: "not found",
+		},
+		{
+			name:    "no match via Username",
+			input:   NewWithHost("noexist", "glab", "gitlab.com"),
+			wantErr: "not found",
+		},
+		{
+			name:    "no match via Name",
+			input:   NewWithHost("profclems", "maxice8", "gitlab.com"),
+			wantErr: "not found",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			got, err := r.RemoteForRepo(tC.input)
+			if tC.wantErr == "" && err != nil {
+				t.Errorf("RemoteForRepo() unexpected error = %s", err)
+			}
+			if tC.wantErr != "" {
+				if tC.wantErr != err.Error() {
+					t.Errorf("RemoteForRepo() expected error = %s, got = %s", tC.wantErr, err)
+				}
+			} else {
+				// Make sure both return all the exact same thing
+				assert.Equal(t, got.Name, tC.output.Name)
+				assert.Equal(t, got.Remote.Name, tC.output.Remote.Name)
+				assert.Equal(t, got.Repo.FullName(), tC.output.Repo.FullName())
+				assert.Equal(t, got.Repo.RepoHost(), tC.output.Repo.RepoHost())
+			}
+		})
+	}
+}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -60,6 +60,23 @@ func AskMultiline(response interface{}, name, question string, defaultVal string
 	return nil
 }
 
+func Select(response interface{}, name string, question string, options []string, opts ...survey.AskOpt) error {
+	prompt := []*survey.Question{
+		{
+			Name: name,
+			Prompt: &survey.Select{
+				Message: question,
+				Options: options,
+			},
+		},
+	}
+	err := Ask(prompt, response, opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 var AskOne = survey.AskOne
 
 var Ask = survey.Ask


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
- feat(pkg/prompt): add `Select()` to select a single option
- refactor(commands/cmdutils): use the new prompt.Select()
- test(command/cmdutils): add tests for MilestonePrompt()

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create Merge Request with path where `cmdutils.MilestonePrompt()` is invoked
