### PR TITLE
chore(ci/test): switch test job from GitLab CI to GitHub action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push, pull_request]
+on: [push, pull_request_target]
 jobs:
   build:
     strategy:
@@ -37,3 +37,36 @@ jobs:
 
       - name: Build
         run: go build -v ./cmd/glab
+
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup SSH Key
+        run: |
+          mkdir ~/.ssh && chmod 700 ~/.ssh
+          echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+          echo -e "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCc54ULcDSmuQBMaM52dqxNMETAlwn01AF79vJb6Nw3SzkNKEMY1pBttM1U8wz7dHpVteAQGCU2AH+T2UhswZWPIzcMfVwB+1RgcIkHW184V5FX1xxqo4Xx6CC6LTSq3md/EmXfQR7gAwaKQHy6txxYpEprlhw+EWICgD5znUMprRRbcsb2FoAdsodMWSl5aRIyC1rA06SKKwqN09o4mgNhv49McyzDnUCGmSTc0oQpygPadDRqW46iCkMdiJa1fuP9pSGkAuTaQayILbDenAM3cV7LqsIm7tOXLPW5fQm9FB91ftRLXxk1Mp6lMYqNc5eGoR4ATzHn7M/VHbBaqVlp profclems@ProfClems" > ~/.ssh/id_rsa.pub
+          echo -e "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn\nNhAAAAAwEAAQAAAQEAnOeFC3A0prkATGjOdnasTTBEwJcJ9NQBe/byW+jcN0s5DShDGNaQ\nbbTNVPMM+3R6VbXgEBglNgB/k9lIbMGVjyM3DH1cAftUYHCJB1tfOFeRV9ccaqOF8eggui\n00qt5nfxJl30Ee4AMGikB8urccWKRKa5YcPhFiAoA+c51DKa0UW3LG9haAHbKHTFkpeWkS\nMgtawNOkiisKjdPaOJoDYb+PTHMsw51Ahpkk3NKEKcoD2nQ0aluOogpDHYiWtX7j/aUhpA\nLk2kGsiC2w3pwDN3Fey6rCJu7Tlyz1uX0JvRQfdX7US18ZNTKepTGKjXOXhqEeAE8x5+zP\n1R2wWqlZaQAAA8j2Yikl9mIpJQAAAAdzc2gtcnNhAAABAQCc54ULcDSmuQBMaM52dqxNME\nTAlwn01AF79vJb6Nw3SzkNKEMY1pBttM1U8wz7dHpVteAQGCU2AH+T2UhswZWPIzcMfVwB\n+1RgcIkHW184V5FX1xxqo4Xx6CC6LTSq3md/EmXfQR7gAwaKQHy6txxYpEprlhw+EWICgD\n5znUMprRRbcsb2FoAdsodMWSl5aRIyC1rA06SKKwqN09o4mgNhv49McyzDnUCGmSTc0oQp\nygPadDRqW46iCkMdiJa1fuP9pSGkAuTaQayILbDenAM3cV7LqsIm7tOXLPW5fQm9FB91ft\nRLXxk1Mp6lMYqNc5eGoR4ATzHn7M/VHbBaqVlpAAAAAwEAAQAAAQAJvxv1nO+4V4+cL3p7\nw11qog/zQq6cpbq935YofWuIh8Swe4rHdTSdi/ihSUPKLu8WeejENyvAkgFaxsmH7/KBZL\nebsAHSIbGZGAR7D4L3tgDSSwt52FSOtVOrHPnDj3MwYo0vdBUd5zI1zlGxK4S4QORakIWK\nmXvUGfFHL0KnyP6uH3Z/j8hQaAE8TIVrGM6PyLes3NWFTlXIakrV8jiJc5bxVnhzDcIKdf\n9JUYGO3DUCQI+pdkCfMNptbBuGwqHjruruGYMfh+mx7FrnpjbJ3y2TG01pcXBeCRIJNm2/\n4htjlAxdz2Zxa8JL437s56Jf4ZtDOYt367dhTMRBleoxAAAAgDo0de+4nNSVb/H3aGo5Y0\nLg/q/npYUNVSvZ9R0GfRY0qDbNCaKeqbyJDkReRn5R/KKT9+Gx0/zqXGNi1ubnGtxqCCmC\nYHDys0PSw6yAEDZ3JOeYWEIO7ntH0DKdErcEUj+FqatdIpoZZO48XZDSXzO1+B1n2y+AML\nfyMggdFXIBAAAAgQDMnIFss9kLpnqC5QOAiDO+jsnHwNHENBgQKE9/jM6gagaK3T4TDkJl\nPszXRDE11LSBCxahL5rxwWDog1vG67tnbfznjhGm8Fd+mEs6omuQ5pA0o6Qx40xtkfn3vi\nj4NLkpo5rYg0DTtciDgGeibtt1oT1EhKZ59ystGdFgSGWxtQAAAIEAxE+xPCLHzqEUUlxI\nSJC6+e2hUT/9s64OwmH9pCrQ8+96G9TtbR9NFD1LSArnLXvl6ooYODw0QDjLdgCUQj63r7\nqOV9QjWKL6xD1atN37WFbrIpem8pFOJWinYrQtddANSBd5tp5QsDkI58ovqhdDuYoVfL1y\nmEfWvucOVlZraWUAAAATcHJvZmNsZW1zQFByb2ZDbGVtcw==\n-----END OPENSSH PRIVATE KEY-----" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa*
+          eval `ssh-agent -s`
+          ssh-add ~/.ssh/id_rsa
+
+      - name: Go Get
+        run: go get -t -v ./...
+
+      - name: Run tests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          make test
+          bash <(curl -s https://codecov.io/bash)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,9 +12,6 @@ workflow:
     - if: '$CI_COMMIT_BRANCH =~ /^[\d-]+-stable$/'
     #
 
-stages:
-  - test
-
 default:
   image: golang:1.15
 
@@ -40,31 +37,3 @@ code_navigation:
   artifacts:
     reports:
       lsif: dump.lsif
-
-.test:
-  variables:
-    GOPATH: "/builds/go"
-    GIT_CLONE_PATH: $GOPATH/src/github.com/profclems/glab
-    GITLAB_TOKEN: "qRC87Xg9Wd46RhB8J8sp"
-    CODECOV_TOKEN: "1597edbc-8760-42c1-ab79-c192ad151717"
-  before_script:
-    # Add a non-sensitive ssh key for test to work.
-    - mkdir ~/.ssh && chmod 700 ~/.ssh
-    - echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-    - echo -e "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCc54ULcDSmuQBMaM52dqxNMETAlwn01AF79vJb6Nw3SzkNKEMY1pBttM1U8wz7dHpVteAQGCU2AH+T2UhswZWPIzcMfVwB+1RgcIkHW184V5FX1xxqo4Xx6CC6LTSq3md/EmXfQR7gAwaKQHy6txxYpEprlhw+EWICgD5znUMprRRbcsb2FoAdsodMWSl5aRIyC1rA06SKKwqN09o4mgNhv49McyzDnUCGmSTc0oQpygPadDRqW46iCkMdiJa1fuP9pSGkAuTaQayILbDenAM3cV7LqsIm7tOXLPW5fQm9FB91ftRLXxk1Mp6lMYqNc5eGoR4ATzHn7M/VHbBaqVlp profclems@ProfClems" > ~/.ssh/id_rsa.pub
-    - echo -e "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn\nNhAAAAAwEAAQAAAQEAnOeFC3A0prkATGjOdnasTTBEwJcJ9NQBe/byW+jcN0s5DShDGNaQ\nbbTNVPMM+3R6VbXgEBglNgB/k9lIbMGVjyM3DH1cAftUYHCJB1tfOFeRV9ccaqOF8eggui\n00qt5nfxJl30Ee4AMGikB8urccWKRKa5YcPhFiAoA+c51DKa0UW3LG9haAHbKHTFkpeWkS\nMgtawNOkiisKjdPaOJoDYb+PTHMsw51Ahpkk3NKEKcoD2nQ0aluOogpDHYiWtX7j/aUhpA\nLk2kGsiC2w3pwDN3Fey6rCJu7Tlyz1uX0JvRQfdX7US18ZNTKepTGKjXOXhqEeAE8x5+zP\n1R2wWqlZaQAAA8j2Yikl9mIpJQAAAAdzc2gtcnNhAAABAQCc54ULcDSmuQBMaM52dqxNME\nTAlwn01AF79vJb6Nw3SzkNKEMY1pBttM1U8wz7dHpVteAQGCU2AH+T2UhswZWPIzcMfVwB\n+1RgcIkHW184V5FX1xxqo4Xx6CC6LTSq3md/EmXfQR7gAwaKQHy6txxYpEprlhw+EWICgD\n5znUMprRRbcsb2FoAdsodMWSl5aRIyC1rA06SKKwqN09o4mgNhv49McyzDnUCGmSTc0oQp\nygPadDRqW46iCkMdiJa1fuP9pSGkAuTaQayILbDenAM3cV7LqsIm7tOXLPW5fQm9FB91ft\nRLXxk1Mp6lMYqNc5eGoR4ATzHn7M/VHbBaqVlpAAAAAwEAAQAAAQAJvxv1nO+4V4+cL3p7\nw11qog/zQq6cpbq935YofWuIh8Swe4rHdTSdi/ihSUPKLu8WeejENyvAkgFaxsmH7/KBZL\nebsAHSIbGZGAR7D4L3tgDSSwt52FSOtVOrHPnDj3MwYo0vdBUd5zI1zlGxK4S4QORakIWK\nmXvUGfFHL0KnyP6uH3Z/j8hQaAE8TIVrGM6PyLes3NWFTlXIakrV8jiJc5bxVnhzDcIKdf\n9JUYGO3DUCQI+pdkCfMNptbBuGwqHjruruGYMfh+mx7FrnpjbJ3y2TG01pcXBeCRIJNm2/\n4htjlAxdz2Zxa8JL437s56Jf4ZtDOYt367dhTMRBleoxAAAAgDo0de+4nNSVb/H3aGo5Y0\nLg/q/npYUNVSvZ9R0GfRY0qDbNCaKeqbyJDkReRn5R/KKT9+Gx0/zqXGNi1ubnGtxqCCmC\nYHDys0PSw6yAEDZ3JOeYWEIO7ntH0DKdErcEUj+FqatdIpoZZO48XZDSXzO1+B1n2y+AML\nfyMggdFXIBAAAAgQDMnIFss9kLpnqC5QOAiDO+jsnHwNHENBgQKE9/jM6gagaK3T4TDkJl\nPszXRDE11LSBCxahL5rxwWDog1vG67tnbfznjhGm8Fd+mEs6omuQ5pA0o6Qx40xtkfn3vi\nj4NLkpo5rYg0DTtciDgGeibtt1oT1EhKZ59ystGdFgSGWxtQAAAIEAxE+xPCLHzqEUUlxI\nSJC6+e2hUT/9s64OwmH9pCrQ8+96G9TtbR9NFD1LSArnLXvl6ooYODw0QDjLdgCUQj63r7\nqOV9QjWKL6xD1atN37WFbrIpem8pFOJWinYrQtddANSBd5tp5QsDkI58ovqhdDuYoVfL1y\nmEfWvucOVlZraWUAAAATcHJvZmNsZW1zQFByb2ZDbGVtcw==\n-----END OPENSSH PRIVATE KEY-----" > ~/.ssh/id_rsa
-    - chmod 600 ~/.ssh/id_rsa*
-    - eval `ssh-agent -s`
-    - ssh-add ~/.ssh/id_rsa
-  script:
-    - go version
-    - export PATH=$GOPATH/bin:$PATH
-    - go get -t -v ./...
-    - make test
-  after_script:
-    - bash <(curl -s https://codecov.io/bash)
-
-test:
-  stage: test
-  extends: .test
-  image: golang:1.15

--- a/commands/cmdtest/helper.go
+++ b/commands/cmdtest/helper.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/profclems/glab/internal/git"
+
 	"github.com/google/shlex"
 	"github.com/otiai10/copy"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -32,7 +34,18 @@ type fatalLogger interface {
 }
 
 func init() {
-	projectPath, _ = os.Getwd()
+	path := &bytes.Buffer{}
+	// get root dir via git
+	gitCmd := git.GitCommand("rev-parse", "--show-toplevel")
+	gitCmd.Stdout = path
+	err := gitCmd.Run()
+	if err != nil {
+		log.Fatalln("Failed to get root directory: ", err)
+	}
+	projectPath = strings.TrimSuffix(path.String(), "\n")
+	if !strings.HasSuffix(projectPath, "/") {
+		projectPath += "/"
+	}
 }
 
 func InitTest(m *testing.M, suffix string) {

--- a/commands/cmdtest/helper.go
+++ b/commands/cmdtest/helper.go
@@ -32,8 +32,7 @@ type fatalLogger interface {
 }
 
 func init() {
-	path, _ := os.Getwd()
-	projectPath = strings.SplitN(path, "/glab/", 2)[0] + "/glab/"
+	projectPath, _ = os.Getwd()
 }
 
 func InitTest(m *testing.M, suffix string) {


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
Currently, GitLab CI does not run on forks per the discussion here https://gitlab.com/gitlab-org/gitlab/-/issues/5667.
However, `glab` needs the GitLab CI to run on forks in order to run tests.
Since this is not possible, we remove the test job from the GitLab CI to gitHub action.

GitHub action provides pull_request_target event which is not limited to secrets and runs on forks.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Chore (Related to CI or Packaging to platforms)
