### PR TITLE
Resolver testing

### DIFF
--- a/commands/cmdutils/cmdutils_test.go
+++ b/commands/cmdutils/cmdutils_test.go
@@ -600,6 +600,22 @@ func Test_PickMetadata(t *testing.T) {
 			assert.ElementsMatch(t, got, tC.expected)
 		})
 	}
+
+	t.Run("Prompt fails", func(t *testing.T) {
+		as, restoreAsk := prompt.InitAskStubber()
+		defer restoreAsk()
+
+		as.Stub([]*prompt.QuestionStub{
+			{
+				Name:  "metadata",
+				Value: errors.New("meant to fail"),
+			},
+		})
+
+		got, err := PickMetadata()
+		assert.Nil(t, got)
+		assert.EqualError(t, err, "could not prompt: meant to fail")
+	})
 }
 
 func Test_AssigneesPrompt(t *testing.T) {
@@ -642,6 +658,23 @@ func Test_AssigneesPrompt(t *testing.T) {
 			assert.ElementsMatch(t, got, tC.output)
 		})
 	}
+
+	t.Run("Prompt fails", func(t *testing.T) {
+		as, restoreAsk := prompt.InitAskStubber()
+		defer restoreAsk()
+
+		as.Stub([]*prompt.QuestionStub{
+			{
+				Name:  "assignee",
+				Value: errors.New("meant to fail"),
+			},
+		})
+
+		var got []string
+		err := AssigneesPrompt(&got)
+		assert.Empty(t, got)
+		assert.EqualError(t, err, "meant to fail")
+	})
 }
 
 func Test_MilestonesPrompt(t *testing.T) {
@@ -711,6 +744,25 @@ func Test_MilestonesPrompt(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Prompt fails", func(t *testing.T) {
+		as, restoreAsk := prompt.InitAskStubber()
+		defer restoreAsk()
+
+		as.Stub([]*prompt.QuestionStub{
+			{
+				Name:  "milestone",
+				Value: errors.New("meant to fail"),
+			},
+		})
+
+		var got int
+		var io utils.IOStreams
+
+		err := MilestonesPrompt(&got, &gitlab.Client{}, repoRemote, &io)
+		assert.Empty(t, got)
+		assert.EqualError(t, err, "meant to fail")
+	})
 }
 
 func Test_MilestonesPromptNoPrompts(t *testing.T) {

--- a/internal/glrepo/resolver.go
+++ b/internal/glrepo/resolver.go
@@ -116,10 +116,6 @@ func (r *ResolvedRemotes) BaseRepo(interactive bool) (Interface, error) {
 		add(&r.network[i])
 	}
 
-	if len(repoNames) == 0 {
-		return r.remotes[0], nil
-	}
-
 	baseName := repoNames[0]
 	if len(repoNames) > 1 {
 		err := prompt.Select(
@@ -191,10 +187,6 @@ func (r *ResolvedRemotes) HeadRepo(interactive bool) (Interface, error) {
 			add(fProject)
 		}
 		add(&r.network[i])
-	}
-
-	if len(repoNames) == 0 {
-		return r.remotes[0], nil
 	}
 
 	headName := repoNames[0]

--- a/internal/glrepo/resolver_test.go
+++ b/internal/glrepo/resolver_test.go
@@ -354,7 +354,7 @@ func Test_BaseRepo(t *testing.T) {
 		localRem.network = nil
 
 		_, err := localRem.BaseRepo(true)
-		assert.Error(t, err, "no GitLab Projects found from remotes")
+		assert.EqualError(t, err, "no GitLab Projects found from remotes")
 	})
 
 	t.Run("Consult the network, multiple projects, pick origin", func(t *testing.T) {
@@ -644,7 +644,7 @@ func Test_HeadRepo(t *testing.T) {
 		localRem.network = nil
 
 		_, err := localRem.HeadRepo(true)
-		assert.Error(t, err, "no GitLab Projects found from remotes")
+		assert.EqualError(t, err, "no GitLab Projects found from remotes")
 	})
 
 	t.Run("Consult the network, multiple projects, pick origin", func(t *testing.T) {

--- a/pkg/prompt/stubber.go
+++ b/pkg/prompt/stubber.go
@@ -44,8 +44,19 @@ func InitAskStubber() (*AskStubber, func()) {
 		if stubbedPrompt.Default {
 			// TODO this is failing for basic AskOne invocations with a string result.
 			defaultValue := reflect.ValueOf(p).Elem().FieldByName("Default")
+
+			// If the user passed us an error, return it
+			if err, ok := defaultValue.Interface().(error); ok {
+				return err
+			}
+
 			_ = core.WriteAnswer(response, "", defaultValue)
 		} else {
+			// If the user passed us an error, return it
+			if err, ok := stubbedPrompt.Value.(error); ok {
+				return err
+			}
+
 			_ = core.WriteAnswer(response, "", stubbedPrompt.Value)
 		}
 
@@ -69,8 +80,19 @@ func InitAskStubber() (*AskStubber, func()) {
 			}
 			if sq.Default {
 				defaultValue := reflect.ValueOf(q.Prompt).Elem().FieldByName("Default")
+
+				// If the user passed us an error, return it
+				if err, ok := defaultValue.Interface().(error); ok {
+					return err
+				}
+
 				_ = core.WriteAnswer(response, q.Name, defaultValue)
 			} else {
+				// If the user passed us an error, return it
+				if err, ok := sq.Value.(error); ok {
+					return err
+				}
+
 				_ = core.WriteAnswer(response, q.Name, sq.Value)
 			}
 		}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
refactor(internal/glrepo/resolver.go): remove code that is always false

This code is always false because of the following code that comes a bit
before.

```golang
if r.network == nil {
    resolveNetwork(r)
    if len(r.network) == 0 {
        return nil, errors.New("no GitLab Projects found from remotes")
    }
}
```

This code will always return err if there are no `gitlab.Project` in
r.network even after using `resolveNetwork()`, and the amount of values
in `repoNames` on how many values there are in r.network.

Thus the code we are removing is never actually reached, or rather, it
is in all situations, false.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
