### PR TITLE
respect GITLAB_HOST when resolving remotes

### DIFF
--- a/commands/cmdutils/factory.go
+++ b/commands/cmdutils/factory.go
@@ -3,6 +3,7 @@ package cmdutils
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/git"
@@ -55,11 +56,15 @@ func LabClientFunc(repoHost string, cfg config.Config, isGraphQL bool) (*gitlab.
 }
 
 func remotesFunc() (glrepo.Remotes, error) {
+	hostOverride := ""
+	if !strings.EqualFold(glinstance.Default(), glinstance.OverridableDefault()) {
+		hostOverride = glinstance.OverridableDefault()
+	}
 	rr := &remoteResolver{
 		readRemotes: git.Remotes,
 		getConfig:   configFunc,
 	}
-	fn := rr.Resolver()
+	fn := rr.Resolver(hostOverride)
 	return fn()
 }
 

--- a/commands/cmdutils/remote_resolver_test.go
+++ b/commands/cmdutils/remote_resolver_test.go
@@ -33,11 +33,40 @@ func Test_remoteResolver(t *testing.T) {
 		},
 	}
 
-	resolver := rr.Resolver()
+	resolver := rr.Resolver("")
 	remotes, err := resolver()
 	require.NoError(t, err)
 	require.Equal(t, 2, len(remotes))
 
 	assert.Equal(t, "upstream", remotes[0].Name)
 	assert.Equal(t, "fork", remotes[1].Name)
+}
+
+func Test_remoteResolverOverride(t *testing.T) {
+	rr := &remoteResolver{
+		readRemotes: func() (git.RemoteSet, error) {
+			return git.RemoteSet{
+				git.NewRemote("fork", "https://example.org/ghe-owner/ghe-fork.git"),
+				git.NewRemote("origin", "https://gitlab.com/owner/repo.git"),
+				git.NewRemote("upstream", "https://example.org/ghe-owner/ghe-repo.git"),
+			}, nil
+		},
+		getConfig: func() (config.Config, error) {
+			return config.NewFromString(heredoc.Doc(`
+				hosts:
+				  example.org:
+				    oauth_token: GHETOKEN
+			`)), nil
+		},
+		urlTranslator: func(u *url.URL) *url.URL {
+			return u
+		},
+	}
+
+	resolver := rr.Resolver("gitlab.com")
+	remotes, err := resolver()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(remotes))
+
+	assert.Equal(t, "origin", remotes[0].Name)
 }


### PR DESCRIPTION
When GITLAB_HOST or GITLAB_URI has been set, we resolve only local remotes that match the set hostname.
With this in place, a heterogeneous mix of hosts in a local remote file will not cause GITLAB_HOST to be ignored.

An error is returned if the hostname specified in GITLAB_HOST is not present in the local remotes.

Resolves #499 