### PR TITLE
chore(rom/deb): Fix wrong install directory for rpm/deb

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,7 +115,8 @@ nfpms:
     dependencies:
       - git
     # Override default /usr/local/bin destination for binaries
-    bindir: /usr/local/bin
+    # Since glab is already archived in the bin directory it would install in /usr/local/bin/bin/glab
+    bindir: /usr/local
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,8 +115,8 @@ nfpms:
     dependencies:
       - git
     # Override default /usr/local/bin destination for binaries
-    # Since glab is already archived in the bin directory it would install in /usr/local/bin/bin/glab
-    bindir: /usr/local
+    # Since glab is already archived in the bin directory it would install in /usr/bin/glab
+    bindir: /usr
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
**Description**
Since glab is built into a 'bin' directory it just ends up installing
into '/usr/local/bin/bin' instead of '/usr/local/bin/'.

**Related Issue**

Resolves #508

**How Has This Been Tested?**

```sh
 docker run --rm -v $PWD/dist:/rt debian:latest dpkg -c /rt/glab_v1.12.1_Linux_x86_64.deb
 drwxr-xr-x 0/0               0 2021-01-05 08:06 ./usr/
 drwxr-xr-x 0/0               0 2021-01-05 08:06 ./usr/local/
 drwxr-xr-x 0/0               0 2021-01-05 08:06 ./usr/local/bin/
 -rwxr-xr-x 0/0        17436672 2021-01-05 08:06 ./usr/local/bin/glab
```

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Chore (Related to CI or Packaging to platforms)
