### PR TITLE
Unassign

### DIFF
--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -31,6 +31,15 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			var ua *cmdutils.UserAssignments
 			out := f.IO.StdOut
 
+			if cmd.Flags().Changed("unassign") {
+				if cmd.Flags().Changed("assignee") {
+					return &cmdutils.FlagError{Err: fmt.Errorf("--assignee and --unassign are mutually exclusive")}
+				}
+				ua = &cmdutils.UserAssignments{
+					ToReplace: []string{"0"},
+				}
+			}
+
 			// Parse assignees Early so we can fail early in case of conflicts
 			if cmd.Flags().Changed("assignee") {
 				givenAssignees, err := cmd.Flags().GetStringSlice("assignee")
@@ -155,6 +164,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	issueUpdateCmd.Flags().BoolP("confidential", "c", false, "Make issue confidential")
 	issueUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")
 	issueUpdateCmd.Flags().StringSliceP("assignee", "a", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing assignees, '+' to add, otherwise replace existing assignees with given users")
+	issueUpdateCmd.Flags().Bool("unassign", false, "unassign all users")
 
 	return issueUpdateCmd
 }

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -31,6 +31,13 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			var actions []string
 			var ua *cmdutils.UserAssignments
 
+			if cmd.Flags().Changed("unassign") {
+				if cmd.Flags().Changed("assignee") {
+					return &cmdutils.FlagError{Err: fmt.Errorf("--assignee and --unassign are mutually exclusive")}
+				}
+				ua.ToReplace = []string{"0"}
+			}
+
 			// Parse assignees Early so we can fail early in case of conflicts
 			if cmd.Flags().Changed("assignee") {
 				givenAssignees, err := cmd.Flags().GetStringSlice("assignee")
@@ -177,6 +184,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().StringSliceP("label", "l", []string{}, "add labels")
 	mrUpdateCmd.Flags().StringSliceP("unlabel", "u", []string{}, "remove labels")
 	mrUpdateCmd.Flags().StringSliceP("assignee", "a", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing assignees, '+' to add, otherwise replace existing assignees with given users")
+	mrUpdateCmd.Flags().Bool("unassign", false, "unassign all users")
 	mrUpdateCmd.Flags().BoolP("remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")
 


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This allows one to use --assignee "@nobody" to unassign all users, this overrides any other user given to `--assigneee` as there is no reason to use `@nobody` if one wants to assign another user

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #483 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on `gitlab.alpinelinux.org`

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
