### PR TITLE
chore(ci): add github action to get GitLab Issues

### DIFF
--- a/.github/gitlab_issue_tpl.md
+++ b/.github/gitlab_issue_tpl.md
@@ -1,0 +1,11 @@
+By **[[author]]([authorURL])**,
+
+---
+
+[description]
+
+---
+
+***Last updated: [updatedAt]***
+
+[GitLabIssueURL]

--- a/.github/workflows/gitlab-issues-to-github.yml
+++ b/.github/workflows/gitlab-issues-to-github.yml
@@ -1,0 +1,48 @@
+name: "GitLab Sync"
+on:
+  schedule:
+    # runs every 5 minutes
+    - cron:  '*/5 * * * *'
+
+jobs:
+  issues:
+    runs-on: ubuntu-latest
+    if: github.repository == 'profclems/glab' # do not run on forks
+    env:
+      GITLAB_TOKEN: ${{ secrets.BOT_GITLAB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      NO_PROMPT: 1
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Add GitLab Remote
+        run: git remote add gitlab git@gitlab.com:profclems/glab.git
+
+      - name: Install GLab
+        run: brew install --build-from-source glab
+
+      - name: Get GitLab Issues
+        run: |
+          glab api /projects/:id/issues -f labels=gh-new -f state=opened -X GET --paginate >> issues.json
+
+      - name: Clone New Issues on GitHub
+        run: |
+          jq -c '.[]' issues.json | while read -r i; do
+              title=$(echo $i | jq -r '.title')
+              id=$(echo $i | jq -r '.iid')
+              description=$(echo $i | jq -r '.description')
+              weburl=$(echo $i | jq -r '.web_url')
+              updatedAt=$(echo $i | jq -r '.updated_at')
+              body=$(< .github/gitlab_issue_tpl.md)
+              body=${body//"[author]"/"profclems"}
+              body=${body//"[authorURL]"/"gitlab.com"}
+              body=${body//"[updatedAt]"/"$updatedAt"}
+              body=${body//"[GitLabIssueURL]"/"$weburl"}
+              body=${body//"[description]"/"$description"}
+
+              issueMsg=$(gh issue create -t "$title" -b "$body"
+              glab issue note ${id} -m "This issue has been moved to GitHub. Follow this issue on GitHub at ${issueMsg}"
+              glab issue update ${id} --unlabel "gh-new" -l "gh-cloned"
+          done

--- a/.gitlab/issue_templates/Bug.md
+++ b/.gitlab/issue_templates/Bug.md
@@ -1,22 +1,8 @@
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
----
-
-<!--- Provide a general summary of the issue in the Title above -->
-
 **Description**
 <!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
 
-**Expected Behavior**
-<!--- Tell us what should happen -->
-
-**Actual Behavior**
-<!--- Tell us what happens instead -->
+**Expected Behavior vs Actual Behavior**
+<!--- A clear and concise description of what should have happened and what happens instead -->
 
 **Possible Fix**
 <!--- Not obligatory, but suggest a fix or reason for the bug -->
@@ -24,15 +10,16 @@ assignees: ''
 **Steps to Reproduce**
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. Include code to reproduce, if relevant -->
-1.
-2.
-3.
-4.
+1. Type this '...'
+2. View the output '....'
+3. See error
 
-**Context**
-<!--- How has this bug affected you? What were you trying to accomplish? -->
+**Logs**
+<!--- Paste the activity log from your command line -->
 
 **Your Environment**
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-* Version used:
+* Version used (Run `glab --version`):
 * Operating System and version:
+
+/label ~"gh-new"

--- a/.gitlab/issue_templates/Feature Request.md
+++ b/.gitlab/issue_templates/Feature Request.md
@@ -1,20 +1,10 @@
----
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
+**Describe the feature or problem you'd like to solve**
+<!-- A clear and concise description of what the feature or problem is. Ex. I'm always frustrated when [...] so having [...] -->
 
----
-
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Propose a Solution**
+<!-- A clear and concise description of what you want to happen and alternatives you have considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->
+
+/label ~"gh-new"

--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,5 +1,3 @@
-<!--- Provide a general summary of your changes in the Title above -->
-
 **Description**
 <!--- Describe your changes in detail -->
 
@@ -7,10 +5,7 @@
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
-
-**Motivation and Context**
-<!--- Why is this change required? What problem does it solve? -->
+Resolves #[issue_number]
 
 **How Has This Been Tested?**
 <!--- Please describe in detail how you tested your changes. -->
@@ -24,13 +19,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation
+- [ ] Chore (Related to CI or Packaging to platforms)
 
-**Checklist:**
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
-- [ ] I have read the **CONTRIBUTING** document.
-- [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+/label ~"gh-new"


### PR DESCRIPTION
This PR adds a GitHub action that gets all open issues created on GitLab for glab and recreates them on GitHub.

The issue must have `gh-new` label in order to be recreated on GitHub. The action automatically removes the label after recreating on GitHub, add a comment with the url to the GitHub issue on GitLab Issue.

This is to enable `glab` users file issues on GitLab with `glab issue create -R profclems/glab`.

Partially resolves #524 