### PR TITLE
Make LabelsPrompt() respect labels and not cache

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -163,7 +163,11 @@ func LabelsPrompt(response *[]string, apiClient *gitlab.Client, repoRemote *glre
 		if err != nil {
 			return err
 		}
-		*response = selectedLabels
+		// Add each element to the array instead of just assigning it so we respect values already
+		// present, given from the `--label` flag
+		for _, x := range selectedLabels {
+			*response = append(*response, x)
+		}
 
 	} else {
 		var responseString string
@@ -171,7 +175,9 @@ func LabelsPrompt(response *[]string, apiClient *gitlab.Client, repoRemote *glre
 		if err != nil {
 			return err
 		}
-		*response = strings.Split(responseString, ",")
+		for _, x := range strings.Split(responseString, ",") {
+			*response = append(*response, x)
+		}
 	}
 
 	return nil

--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -282,25 +282,13 @@ func ConfirmSubmission(allowPreview bool, allowAddMetadata bool) (Action, error)
 	}
 	options = append(options, cancelLabel)
 
-	confirmAnswers := struct {
-		Confirmation int
-	}{}
-	confirmQs := []*survey.Question{
-		{
-			Name: "confirmation",
-			Prompt: &survey.Select{
-				Message: "What's next?",
-				Options: options,
-			},
-		},
-	}
-
-	err := prompt.Ask(confirmQs, &confirmAnswers)
+	var confirmAnswer string
+	err := prompt.Select(&confirmAnswer, "confirmation", "What's next?", options)
 	if err != nil {
 		return -1, fmt.Errorf("could not prompt: %w", err)
 	}
 
-	switch options[confirmAnswers.Confirmation] {
+	switch confirmAnswer {
 	case submitLabel:
 		return SubmitAction, nil
 	case previewLabel:
@@ -310,7 +298,7 @@ func ConfirmSubmission(allowPreview bool, allowAddMetadata bool) (Action, error)
 	case cancelLabel:
 		return CancelAction, nil
 	default:
-		return -1, fmt.Errorf("invalid index: %d", confirmAnswers.Confirmation)
+		return -1, fmt.Errorf("invalid value: %s", confirmAnswer)
 	}
 }
 

--- a/commands/cmdutils/cmdutils_test.go
+++ b/commands/cmdutils/cmdutils_test.go
@@ -771,6 +771,18 @@ func Test_AssigneesPrompt(t *testing.T) {
 		assert.EqualError(t, err, "meant to fail")
 	})
 
+	t.Run("API Failed", func(t *testing.T) {
+		var got []string
+
+		api.ListProjectMembers = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectMembersOptions) ([]*gitlab.ProjectMember, error) {
+			return nil, errors.New("meant to fail")
+		}
+
+		err := AssigneesPrompt(&got, &gitlab.Client{}, repoRemote, nil, 20)
+		assert.Empty(t, got)
+		assert.EqualError(t, err, "meant to fail")
+	})
+
 	t.Run("respect-flags", func(t *testing.T) {
 		got := []string{"foo"}
 


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This makes `LabelsPrompt()`:

- Not overwrite values given by `--label` 
- Not cache value of labels

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #526 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested yet, just testsuite

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
