### PR TITLE
feat(commands/mr/checkout): add --set-upstream-to flag

### DIFF
--- a/commands/mr/checkout/mr_checkout.go
+++ b/commands/mr/checkout/mr_checkout.go
@@ -1,7 +1,9 @@
 package checkout
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -14,8 +16,9 @@ import (
 )
 
 type mrCheckoutConfig struct {
-	branch string
-	track  bool
+	branch   string
+	track    bool
+	upstream string
 }
 
 var (
@@ -31,12 +34,34 @@ func NewCmdCheckout(f *cmdutils.Factory) *cobra.Command {
 			$ glab mr checkout 1
 			$ glab mr checkout branch --track
 			$ glab mr checkout 12 --branch todo-fix
+			$ glab mr checkout new-feature --set-upstream-to=upstream/trunk
 			$ glab mr checkout   # use checked out branch
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			var err error
+			var upstream string
+
+			if mrCheckoutCfg.upstream != "" {
+				// Make sure we don't have the mutually exclusive flags --track and --set-upstream-to
+				if mrCheckoutCfg.track {
+					return &cmdutils.FlagError{Err: errors.New("--track and --set-upstream-to are mutually exclusive")}
+				}
+
+				upstream = mrCheckoutCfg.upstream
+
+				if val := strings.Split(mrCheckoutCfg.upstream, "/"); len(val) > 1 {
+					// Verify that we have the remote set
+					repo, err := f.Remotes()
+					if err != nil {
+						return err
+					}
+					_, err = repo.FindByName(val[0])
+					if err != nil {
+						return err
+					}
+				}
+			}
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -91,11 +116,18 @@ func NewCmdCheckout(f *cmdutils.Factory) *cobra.Command {
 			if err := git.CheckoutBranch(mrCheckoutCfg.branch); err != nil {
 				return err
 			}
+
+			// Check out the branch
+			if upstream != "" {
+				if err := git.RunCmd([]string{"branch", "--set-upstream-to", upstream}); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}
 	mrCheckoutCmd.Flags().StringVarP(&mrCheckoutCfg.branch, "branch", "b", "", "checkout merge request with <branch> name")
 	mrCheckoutCmd.Flags().BoolVarP(&mrCheckoutCfg.track, "track", "t", false, "set checked out branch to track remote branch, adds remote if needed")
-
+	mrCheckoutCmd.Flags().StringVarP(&mrCheckoutCfg.upstream, "set-upstream-to", "u", "", "set tracking of checked out branch to [REMOTE/]BRANCH")
 	return mrCheckoutCmd
 }


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This adds the `--set-upstream-to` | `-u` flag which denotes a `[REMOTE/]BRANCH` to track.

This is mutually exclusive with `--track` because that also sets a tracking.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #544 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`glab mr checkout rspamd --set-upstream-to upstream/master`

**Screenshots (if appropriate):**
![image](https://user-images.githubusercontent.com/30738253/104077088-fc33f400-51f6-11eb-9c62-bacff7be5173.png)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
