### PR TITLE
feat(command/issue): allow issue URL as argument

### DIFF
--- a/.github/workflows/gitlab-issues-to-github.yml
+++ b/.github/workflows/gitlab-issues-to-github.yml
@@ -35,14 +35,15 @@ jobs:
               description=$(echo $i | jq -r '.description')
               weburl=$(echo $i | jq -r '.web_url')
               updatedAt=$(echo $i | jq -r '.updated_at')
+              author=$(echo $i | jq -r '.author."username"')
+              authorURL=$(echo $i | jq -r '.author."web_url"')
               body=$(< .github/gitlab_issue_tpl.md)
-              body=${body//"[author]"/"profclems"}
-              body=${body//"[authorURL]"/"gitlab.com"}
+              body=${body//"[author]"/"$author"}
+              body=${body//"[authorURL]"/"$authorURL"}
               body=${body//"[updatedAt]"/"$updatedAt"}
               body=${body//"[GitLabIssueURL]"/"$weburl"}
               body=${body//"[description]"/"$description"}
-
-              issueMsg=$(gh issue create -t "$title" -b "$body"
+              issueMsg=$(gh issue create -t "$title" -b "$body")
               glab issue note ${id} -m "This issue has been moved to GitHub. Follow this issue on GitHub at ${issueMsg}"
               glab issue update ${id} --unlabel "gh-new" -l "gh-cloned"
           done

--- a/commands/issue/delete/issue_delete.go
+++ b/commands/issue/delete/issue_delete.go
@@ -2,9 +2,9 @@ package delete
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/issue/issueutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 
@@ -19,8 +19,6 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"del"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			issueID := strings.TrimSpace(args[0])
 			var err error
 
 			apiClient, err := f.HttpClient()
@@ -28,18 +26,17 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			issues, repo, err := issueutils.IssuesFromArgs(apiClient, f.BaseRepo, args)
 			if err != nil {
 				return err
 			}
 
-			arrIds := strings.Split(strings.Trim(issueID, "[] "), ",")
-			for _, i2 := range arrIds {
+			for _, issue := range issues {
 				if f.IO.IsErrTTY && f.IO.IsaTTY {
-					fmt.Fprintln(f.IO.StdOut, "- Deleting Issue #"+i2)
+					fmt.Fprintf(f.IO.StdOut, "- Deleting Issue #%d\n", issue.IID)
 				}
 
-				err := api.DeleteIssue(apiClient, repo.FullName(), utils.StringToInt(i2))
+				err := api.DeleteIssue(apiClient, repo.FullName(), issue.IID)
 				if err != nil {
 					return err
 				}

--- a/commands/issue/delete/issue_delete.go
+++ b/commands/issue/delete/issue_delete.go
@@ -33,7 +33,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 
 			for _, issue := range issues {
 				if f.IO.IsErrTTY && f.IO.IsaTTY {
-					fmt.Fprintf(f.IO.StdOut, "- Deleting Issue #%d\n", issue.IID)
+					fmt.Fprintf(f.IO.StdErr, "- Deleting Issue #%d\n", issue.IID)
 				}
 
 				err := api.DeleteIssue(apiClient, repo.FullName(), issue.IID)
@@ -41,7 +41,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 					return err
 				}
 
-				fmt.Fprintln(f.IO.StdOut, utils.GreenCheck(), "Issue Deleted")
+				fmt.Fprintln(f.IO.StdErr, utils.GreenCheck(), "Issue Deleted")
 			}
 			return nil
 		},

--- a/commands/issue/delete/issue_delete_test.go
+++ b/commands/issue/delete/issue_delete_test.go
@@ -7,16 +7,14 @@ import (
 
 	"github.com/profclems/glab/internal/utils"
 
-	"github.com/acarl005/stripansi"
 	"github.com/profclems/glab/commands/cmdtest"
 	"github.com/profclems/glab/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/xanzy/go-gitlab"
 )
 
-// TODO: test by mocking the appropriate api function
 func TestMain(m *testing.M) {
-	cmdtest.InitTest(m, "mr_delete_test")
+	cmdtest.InitTest(m, "issue_delete_test")
 }
 
 func TestNewCmdDelete(t *testing.T) {
@@ -28,6 +26,14 @@ func TestNewCmdDelete(t *testing.T) {
 			return fmt.Errorf("error expected")
 		}
 		return nil
+	}
+	api.GetIssue = func(client *gitlab.Client, projectID interface{}, issueID int) (*gitlab.Issue, error) {
+		if projectID == "" || projectID == "WRONG_REPO" || projectID == "expected_err" {
+			return nil, fmt.Errorf("error expected")
+		}
+		return &gitlab.Issue{
+			IID: issueID,
+		}, nil
 	}
 
 	tests := []struct {
@@ -41,59 +47,47 @@ func TestNewCmdDelete(t *testing.T) {
 			name:    "delete",
 			args:    []string{"0", "-R", "NAMESPACE/WRONG_REPO"},
 			wantErr: true,
-
-			assertFunc: func(t *testing.T, out string, err string) {
-				assert.Contains(t, err, "error expected")
-			},
 		},
 		{
 			name:    "id exists",
 			args:    []string{"1"},
 			wantErr: false,
 			assertFunc: func(t *testing.T, out string, err string) {
-				assert.Contains(t, out, "✓ Issue Deleted\n")
+				assert.Contains(t, err, "✓ Issue Deleted\n")
 			},
 		},
 		{
 			name:    "delete on different repo",
 			args:    []string{"12", "-R", "profclems/glab"},
 			wantErr: false,
-			assertFunc: func(t *testing.T, out string, err string) {
-				assert.Contains(t, out, "✓ Issue Deleted\n")
+			assertFunc: func(t *testing.T, out string, stderr string) {
+				assert.Contains(t, stderr, "✓ Issue Deleted\n")
 			},
 		},
 	}
 
-	io, _, stdout, stderr := utils.IOTest()
-	f := cmdtest.StubFactory("")
-	f.IO = io
-	f.IO.IsaTTY = true
-	f.IO.IsErrTTY = true
-
-	cmd := NewCmdDelete(f)
-
-	cmd.Flags().StringP("repo", "R", "", "")
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
+			io, _, stdout, stderr := utils.IOTest()
+			f := cmdtest.StubFactory("")
+			f.IO = io
+			f.IO.IsaTTY = true
+			f.IO.IsErrTTY = true
+
+			cmd := NewCmdDelete(f)
+
+			cmd.Flags().StringP("repo", "R", "", "")
 
 			cli := strings.Join(tt.args, " ")
 			t.Log(cli)
 			_, err := cmdtest.RunCommand(cmd, cli)
 			if !tt.wantErr {
 				assert.Nil(t, err)
+				tt.assertFunc(t, stdout.String(), stderr.String())
 			} else {
 				assert.NotNil(t, err)
-				stderr.WriteString(err.Error()) // write err to stderr
 			}
-
-			out := stripansi.Strip(stdout.String())
-			outErr := stripansi.Strip(stderr.String())
-
-			tt.assertFunc(t, out, outErr)
-			assert.Contains(t, outErr, tt.errMsg)
-			stderr.Reset()
-			stdout.Reset()
 		})
 	}
 

--- a/commands/issue/issueutils/utils.go
+++ b/commands/issue/issueutils/utils.go
@@ -160,6 +160,9 @@ func issueMetadataFromURL(s string) (int, glrepo.Interface) {
 	u.Path = strings.Replace(u.Path, fmt.Sprintf("/issues/%d", issueIID), "", 1)
 
 	repo, err := glrepo.FromURL(u)
+	if err != nil {
+		return 0, nil
+	}
 	return issueIID, repo
 }
 

--- a/commands/issue/issueutils/utils.go
+++ b/commands/issue/issueutils/utils.go
@@ -1,8 +1,17 @@
 package issueutils
 
 import (
+	"context"
 	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
+
+	"github.com/profclems/glab/internal/config"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/api"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/tableprinter"
@@ -44,4 +53,116 @@ func IssueState(i *gitlab.Issue) (issueID string) {
 		issueID = utils.Red(fmt.Sprintf("#%d", i.IID))
 	}
 	return
+}
+
+func IssuesFromArgs(apiClient *gitlab.Client, baseRepoFn func() (glrepo.Interface, error), args []string) ([]*gitlab.Issue, glrepo.Interface, error) {
+	baseRepo, err := baseRepoFn()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(args) <= 1 {
+		if len(args) == 1 {
+			args = strings.Split(args[0], ",")
+		}
+		if len(args) <= 1 {
+			issue, repo, err := IssueFromArg(apiClient, baseRepoFn, args[0])
+			if err != nil {
+				return nil, nil, err
+			}
+			baseRepo = repo
+			return []*gitlab.Issue{issue}, baseRepo, err
+		}
+	}
+
+	errGroup, _ := errgroup.WithContext(context.Background())
+	issues := make([]*gitlab.Issue, len(args))
+	for i, arg := range args {
+		i, arg := i, arg
+		errGroup.Go(func() error {
+			issue, repo, err := IssueFromArg(apiClient, baseRepoFn, arg)
+			if err != nil {
+				return err
+			}
+			baseRepo = repo
+			issues[i] = issue
+			return nil
+		})
+	}
+	if err := errGroup.Wait(); err != nil {
+		return nil, nil, err
+	}
+	return issues, baseRepo, nil
+
+}
+
+func IssueFromArg(apiClient *gitlab.Client, baseRepoFn func() (glrepo.Interface, error), arg string) (*gitlab.Issue, glrepo.Interface, error) {
+	issueIID, baseRepo := issueMetadataFromURL(arg)
+	if issueIID == 0 {
+		var err error
+		issueIID, err = strconv.Atoi(strings.TrimPrefix(arg, "#"))
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid issue format: %q", arg)
+		}
+	}
+
+	if baseRepo == nil {
+		var err error
+		baseRepo, err = baseRepoFn()
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not determine base repo: %w", err)
+		}
+	} else {
+		// initialize a new HTTP Client with the new host
+		// TODO: avoid reinitializing the config, get the config as a parameter
+
+		cfg, _ := config.Init()
+		a, err := api.NewClientWithCfg(baseRepo.RepoHost(), cfg, false)
+		if err != nil {
+			return nil, nil, err
+		}
+		apiClient = a.Lab()
+	}
+
+	issue, err := issueFromIID(apiClient, baseRepo, issueIID)
+	return issue, baseRepo, err
+}
+
+// FIXME: have a single regex to match either of the following
+//  OWNER/REPO/issues/id
+//  GROUP/NAMESPACE/REPO/issues/id
+var issueURLPersonalRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/issues/(\d+)`)
+var issueURLGroupRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/([^/]+)/issues/(\d+)`)
+
+func issueMetadataFromURL(s string) (int, glrepo.Interface) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return 0, nil
+	}
+
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return 0, nil
+	}
+
+	u.Path = strings.Replace(u.Path, "/-/issues", "/issues", 1)
+
+	m := issueURLPersonalRE.FindStringSubmatch(u.Path)
+	if m == nil {
+		m = issueURLGroupRE.FindStringSubmatch(u.Path)
+		if m == nil {
+			return 0, nil
+		}
+	}
+	var issueIID int
+	if len(m) > 0 {
+		issueIID, _ = strconv.Atoi(m[len(m)-1])
+	}
+
+	u.Path = strings.Replace(u.Path, fmt.Sprintf("/issues/%d", issueIID), "", 1)
+
+	repo, err := glrepo.FromURL(u)
+	return issueIID, repo
+}
+
+func issueFromIID(apiClient *gitlab.Client, repo glrepo.Interface, issueIID int) (*gitlab.Issue, error) {
+	return api.GetIssue(apiClient, repo.FullName(), issueIID)
 }

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -167,18 +167,9 @@ func listRun(opts *ListOptions) error {
 		listOpts.NotAssigneeID = IDs
 	}
 	if opts.Author != "" {
-		var u *gitlab.User
-		if opts.Author == "@me" {
-			u, err = api.CurrentUser(nil)
-			if err != nil {
-				return err
-			}
-		} else {
-			// go-gitlab still doesn't have an AuthorUsername field so convert to ID
-			u, err = api.UserByName(apiClient, opts.Author)
-			if err != nil {
-				return err
-			}
+		u, err := api.UserByName(apiClient, opts.Author)
+		if err != nil {
+			return err
 		}
 		listOpts.AuthorID = gitlab.Int(u.ID)
 	}

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -79,7 +79,6 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	issueListCmd.Flags().StringVar(&opts.Author, "author", "", "Filter issue by author <username>")
 	issueListCmd.Flags().StringVarP(&opts.Labels, "label", "l", "", "Filter issue by label <name>")
 	issueListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter issue by milestone <id>")
-	issueListCmd.Flags().BoolVarP(&opts.Mine, "mine", "M", false, "Filter only issues issues assigned to me")
 	issueListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all issues")
 	issueListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed issues")
 	issueListCmd.Flags().BoolVarP(&opts.Confidential, "confidential", "C", false, "Filter by confidential issues")
@@ -89,6 +88,10 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	issueListCmd.Flags().BoolP("opened", "o", false, "Get only opened issues")
 	issueListCmd.Flags().MarkHidden("opened")
 	issueListCmd.Flags().MarkDeprecated("opened", "default if --closed is not used")
+
+	issueListCmd.Flags().BoolVarP(&opts.Mine, "mine", "M", false, "Filter only issues issues assigned to me")
+	issueListCmd.Flags().MarkHidden("mine")
+	issueListCmd.Flags().MarkDeprecated("mine", "use --assignee=@me")
 
 	return issueListCmd
 }
@@ -145,14 +148,6 @@ func listRun(opts *ListOptions) error {
 		opts.ListType = "search"
 	}
 
-	if opts.Mine {
-		u, err := api.CurrentUser(nil)
-		if err != nil {
-			return err
-		}
-		listOpts.AssigneeUsername = gitlab.String(u.Username)
-		opts.ListType = "search"
-	}
 	issues, err := api.ListIssues(apiClient, repo.FullName(), listOpts)
 	if err != nil {
 		return err

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -19,7 +19,7 @@ type ListOptions struct {
 	// metadata
 	Assignee  string
 	Author    string
-	Labels    string
+	Labels    []string
 	NotLabels []string
 	Milestone string
 	Mine      bool
@@ -91,7 +91,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	issueListCmd.Flags().StringVar(&opts.Author, "author", "", "Filter issue by author <username>")
 	issueListCmd.Flags().StringVar(&opts.Search, "search", "", "Search <string> in the fields defined by --in")
 	issueListCmd.Flags().StringVar(&opts.In, "in", "title,description", "search in {title|description}")
-	issueListCmd.Flags().StringVarP(&opts.Labels, "label", "l", "", "Filter issue by label <name>")
+	issueListCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Filter issue by label <name>")
 	issueListCmd.Flags().StringSliceVar(&opts.NotLabels, "not-label", []string{}, "Filter issue by lack of label <name>")
 	issueListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter issue by milestone <id>")
 	issueListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all issues")
@@ -159,11 +159,8 @@ func listRun(opts *ListOptions) error {
 		listOpts.Search = gitlab.String(opts.Search)
 		opts.ListType = "search"
 	}
-	if opts.Labels != "" {
-		label := gitlab.Labels{
-			opts.Labels,
-		}
-		listOpts.Labels = label
+	if len(opts.Labels) != 0 {
+		listOpts.Labels = opts.Labels
 		opts.ListType = "search"
 	}
 	if len(opts.NotLabels) != 0 {

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -17,6 +17,7 @@ import (
 type ListOptions struct {
 	// metadata
 	Assignee  string
+	Author    string
 	Labels    string
 	Milestone string
 	Mine      bool
@@ -75,6 +76,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 		},
 	}
 	issueListCmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter issue by assignee <username>")
+	issueListCmd.Flags().StringVar(&opts.Author, "author", "", "Filter issue by author <username>")
 	issueListCmd.Flags().StringVarP(&opts.Labels, "label", "l", "", "Filter issue by label <name>")
 	issueListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter issue by milestone <id>")
 	issueListCmd.Flags().BoolVarP(&opts.Mine, "mine", "M", false, "Filter only issues issues assigned to me")
@@ -107,6 +109,14 @@ func listRun(opts *ListOptions) error {
 
 	if opts.Assignee != "" {
 		listOpts.AssigneeUsername = gitlab.String(opts.Assignee)
+	}
+	if opts.Author != "" {
+		// go-gitlab still doesn't have an AuthorUsername field so convert to ID
+		u, err := api.UserByName(apiClient, opts.Author)
+		if err != nil {
+			return err
+		}
+		listOpts.AuthorID = gitlab.Int(u.ID)
 	}
 	if opts.Labels != "" {
 		label := gitlab.Labels{

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -156,15 +156,11 @@ func listRun(opts *ListOptions) error {
 		listOpts.AssigneeUsername = gitlab.String(opts.Assignee)
 	}
 	if len(opts.NotAssignee) != 0 {
-		us, err := api.UsersByNames(apiClient, opts.NotAssignee)
+		u, err := api.UsersByNames(apiClient, opts.NotAssignee)
 		if err != nil {
 			return err
 		}
-		var IDs []int
-		for i := range us {
-			IDs = append(IDs, us[i].ID)
-		}
-		listOpts.NotAssigneeID = IDs
+		listOpts.NotAssigneeID = cmdutils.IDsFromUsers(u)
 	}
 	if opts.Author != "" {
 		u, err := api.UserByName(apiClient, opts.Author)
@@ -174,15 +170,11 @@ func listRun(opts *ListOptions) error {
 		listOpts.AuthorID = gitlab.Int(u.ID)
 	}
 	if len(opts.NotAuthor) != 0 {
-		us, err := api.UsersByNames(apiClient, opts.NotAuthor)
+		u, err := api.UsersByNames(apiClient, opts.NotAuthor)
 		if err != nil {
 			return err
 		}
-		var IDs []int
-		for i := range us {
-			IDs = append(IDs, us[i].ID)
-		}
-		listOpts.NotAuthorID = IDs
+		listOpts.NotAuthorID = cmdutils.IDsFromUsers(u)
 	}
 	if opts.Search != "" {
 		listOpts.Search = gitlab.String(opts.Search)

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -82,10 +82,13 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	issueListCmd.Flags().BoolVarP(&opts.Mine, "mine", "M", false, "Filter only issues issues assigned to me")
 	issueListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all issues")
 	issueListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed issues")
-	issueListCmd.Flags().BoolVarP(&opts.Opened, "opened", "o", false, "Get only opened issues")
 	issueListCmd.Flags().BoolVarP(&opts.Confidential, "confidential", "C", false, "Filter by confidential issues")
 	issueListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
 	issueListCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page. (default 30)")
+
+	issueListCmd.Flags().BoolP("opened", "o", false, "Get only opened issues")
+	issueListCmd.Flags().MarkHidden("opened")
+	issueListCmd.Flags().MarkDeprecated("opened", "default if --closed is not used")
 
 	return issueListCmd
 }

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -79,7 +79,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	issueListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter issue by milestone <id>")
 	issueListCmd.Flags().BoolVarP(&opts.Mine, "mine", "M", false, "Filter only issues issues assigned to me")
 	issueListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all issues")
-	issueListCmd.Flags().BoolVarP(&opts.Opened, "closed", "c", false, "Get only closed issues")
+	issueListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed issues")
 	issueListCmd.Flags().BoolVarP(&opts.Opened, "opened", "o", false, "Get only opened issues")
 	issueListCmd.Flags().BoolVarP(&opts.Confidential, "confidential", "C", false, "Filter by confidential issues")
 	issueListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")

--- a/commands/issue/note/issue_note_create.go
+++ b/commands/issue/note/issue_note_create.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/profclems/glab/commands/issue/issueutils"
+
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
@@ -28,19 +30,12 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			issue, repo, err := issueutils.IssueFromArg(apiClient, f.BaseRepo, args[0])
 			if err != nil {
 				return err
 			}
-
-			issueID := args[0]
 
 			body, _ := cmd.Flags().GetString("message")
-
-			issue, err := api.GetIssue(apiClient, repo.FullName(), utils.StringToInt(issueID))
-			if err != nil {
-				return err
-			}
 
 			if body == "" {
 				body = utils.Editor(utils.EditorOptions{
@@ -54,7 +49,7 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 				return errors.New("aborted... Note is empty")
 			}
 
-			noteInfo, err := api.CreateIssueNote(apiClient, repo.FullName(), utils.StringToInt(issueID), &gitlab.CreateIssueNoteOptions{
+			noteInfo, err := api.CreateIssueNote(apiClient, repo.FullName(), issue.IID, &gitlab.CreateIssueNoteOptions{
 				Body: &body,
 			})
 			if err != nil {

--- a/commands/issue/subscribe/issue_subscribe.go
+++ b/commands/issue/subscribe/issue_subscribe.go
@@ -2,13 +2,11 @@ package subscribe
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/issue/issueutils"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,25 +26,22 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			issues, repo, err := issueutils.IssuesFromArgs(apiClient, f.BaseRepo, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := strings.TrimSpace(args[0])
-
-			arrIds := strings.Split(strings.Trim(mergeID, "[] "), ",")
-			for _, i2 := range arrIds {
+			for _, issue := range issues {
 				if f.IO.IsErrTTY && f.IO.IsaTTY {
-					fmt.Fprintln(out, "- Subscribing to Issue #"+i2)
+					fmt.Fprintf(out, "- Subscribing to Issue #%d in %s\n", issue.IID, utils.Cyan(repo.FullName()))
 				}
 
-				issue, err := api.SubscribeToIssue(apiClient, repo.FullName(), utils.StringToInt(i2), nil)
+				issue, err := api.SubscribeToIssue(apiClient, repo.FullName(), issue.IID, nil)
 				if err != nil {
 					return err
 				}
 
-				fmt.Fprintln(out, utils.GreenCheck(), "Subscribed to issue #"+i2)
+				fmt.Fprintln(out, utils.GreenCheck(), "Subscribed")
 				fmt.Fprintln(out, issueutils.DisplayIssue(issue))
 			}
 			return nil

--- a/commands/issue/subscribe/issue_subscribe.go
+++ b/commands/issue/subscribe/issue_subscribe.go
@@ -18,9 +18,6 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"sub"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out := f.IO.StdOut
-			var err error
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -33,7 +30,7 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 
 			for _, issue := range issues {
 				if f.IO.IsErrTTY && f.IO.IsaTTY {
-					fmt.Fprintf(out, "- Subscribing to Issue #%d in %s\n", issue.IID, utils.Cyan(repo.FullName()))
+					fmt.Fprintf(f.IO.StdErr, "- Subscribing to Issue #%d in %s\n", issue.IID, utils.Cyan(repo.FullName()))
 				}
 
 				issue, err := api.SubscribeToIssue(apiClient, repo.FullName(), issue.IID, nil)
@@ -41,8 +38,8 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 					return err
 				}
 
-				fmt.Fprintln(out, utils.GreenCheck(), "Subscribed")
-				fmt.Fprintln(out, issueutils.DisplayIssue(issue))
+				fmt.Fprintln(f.IO.StdErr, utils.GreenCheck(), "Subscribed")
+				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(issue))
 			}
 			return nil
 		},

--- a/commands/issue/subscribe/issue_subscribe_test.go
+++ b/commands/issue/subscribe/issue_subscribe_test.go
@@ -47,17 +47,17 @@ func TestNewCmdSubscribe(t *testing.T) {
 		{
 			Name:        "Issue Exists",
 			Issue:       "1",
-			ExpectedMsg: []string{"- Subscribing to Issue #1", "✓ Subscribed to issue #1"},
+			ExpectedMsg: []string{"- Subscribing to Issue #1 in glab-cli/test", "✓ Subscribed to issue #1"},
 		},
 		{
 			Name:        "Issue on another repo",
 			Issue:       "1 -R profclems/glab",
-			ExpectedMsg: []string{"- Subscribing to Issue #1", "✓ Subscribed to issue #1"},
+			ExpectedMsg: []string{"- Subscribing to Issue #1 in profclems/glab", "✓ Subscribed to issue #1"},
 		},
 		{
 			Name:        "Issue Does Not Exist",
 			Issue:       "0",
-			ExpectedMsg: []string{"- Subscribing to Issue #0", "error expected"},
+			ExpectedMsg: []string{"- Subscribing to Issue #0 in glab-cli/test", "error expected"},
 			wantErr:     true,
 		},
 	}

--- a/commands/issue/subscribe/issue_subscribe_test.go
+++ b/commands/issue/subscribe/issue_subscribe_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/profclems/glab/internal/utils"
 
-	"github.com/acarl005/stripansi"
 	"github.com/profclems/glab/commands/cmdtest"
 	"github.com/profclems/glab/pkg/api"
 	"github.com/stretchr/testify/assert"
@@ -39,40 +38,34 @@ func TestNewCmdSubscribe(t *testing.T) {
 	}
 
 	testCases := []struct {
-		Name        string
-		Issue       string
-		ExpectedMsg []string
-		wantErr     bool
+		Name    string
+		Issue   string
+		stderr  string
+		wantErr bool
 	}{
 		{
-			Name:        "Issue Exists",
-			Issue:       "1",
-			ExpectedMsg: []string{"- Subscribing to Issue #1 in glab-cli/test", "✓ Subscribed to issue #1"},
+			Name:   "Issue Exists",
+			Issue:  "1",
+			stderr: "- Subscribing to Issue #1 in glab-cli/test\n✓ Subscribed\n",
 		},
 		{
-			Name:        "Issue on another repo",
-			Issue:       "1 -R profclems/glab",
-			ExpectedMsg: []string{"- Subscribing to Issue #1 in profclems/glab", "✓ Subscribed to issue #1"},
-		},
-		{
-			Name:        "Issue Does Not Exist",
-			Issue:       "0",
-			ExpectedMsg: []string{"- Subscribing to Issue #0 in glab-cli/test", "error expected"},
-			wantErr:     true,
+			Name:    "Issue Does Not Exist",
+			Issue:   "0",
+			stderr:  "- Subscribing to Issue #0 in glab-cli/test\nerror expected\n",
+			wantErr: true,
 		},
 	}
 
-	io, _, stdout, stderr := utils.IOTest()
-	f := cmdtest.StubFactory("https://gitlab.com/glab-cli/test")
-	f.IO = io
-	f.IO.IsaTTY = true
-	f.IO.IsErrTTY = true
-
-	cmd := NewCmdSubscribe(f)
-	cmd.Flags().StringP("repo", "R", "", "")
-
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			io, _, _, stderr := utils.IOTest()
+			f := cmdtest.StubFactory("https://gitlab.com/glab-cli/test")
+			f.IO = io
+			f.IO.IsaTTY = true
+			f.IO.IsErrTTY = true
+
+			cmd := NewCmdSubscribe(f)
+			cmd.Flags().StringP("repo", "R", "", "")
 
 			_, err := cmdtest.RunCommand(cmd, tc.Issue)
 			if tc.wantErr {
@@ -81,13 +74,7 @@ func TestNewCmdSubscribe(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-
-			out := stripansi.Strip(stdout.String())
-
-			for _, msg := range tc.ExpectedMsg {
-				assert.Contains(t, out, msg)
-				assert.Contains(t, stderr.String(), "")
-			}
+			assert.Equal(t, tc.stderr, stderr.String())
 		})
 	}
 

--- a/commands/issue/unsubscribe/issue_unsubscribe.go
+++ b/commands/issue/unsubscribe/issue_unsubscribe.go
@@ -19,9 +19,6 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"unsub"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			out := f.IO.StdOut
-
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
@@ -34,7 +31,7 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 
 			for _, issue := range issues {
 				if f.IO.IsaTTY && f.IO.IsErrTTY {
-					fmt.Fprintf(out, "- Unsubscribing from Issue #%d in %s\n", issue.IID, utils.Cyan(repo.FullName()))
+					fmt.Fprintf(f.IO.StdErr, "- Unsubscribing from Issue #%d in %s\n", issue.IID, utils.Cyan(repo.FullName()))
 				}
 
 				issue, err := api.UnsubscribeFromIssue(apiClient, repo.FullName(), issue.IID, nil)
@@ -42,8 +39,8 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 					return err
 				}
 
-				fmt.Fprintln(out, utils.Red("✔"), "Unsubscribed")
-				fmt.Fprintln(out, issueutils.DisplayIssue(issue))
+				fmt.Fprintln(f.IO.StdErr, utils.Red("✔"), "Unsubscribed")
+				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(issue))
 			}
 			return nil
 		},

--- a/commands/issue/unsubscribe/issue_unsubscribe.go
+++ b/commands/issue/unsubscribe/issue_unsubscribe.go
@@ -2,7 +2,6 @@ package unsubscribe
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/issue/issueutils"
@@ -28,25 +27,22 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			repo, err := f.BaseRepo()
+			issues, repo, err := issueutils.IssuesFromArgs(apiClient, f.BaseRepo, args)
 			if err != nil {
 				return err
 			}
 
-			mergeID := strings.TrimSpace(args[0])
-
-			arrIds := strings.Split(strings.Trim(mergeID, "[] "), ",")
-			for _, i2 := range arrIds {
+			for _, issue := range issues {
 				if f.IO.IsaTTY && f.IO.IsErrTTY {
-					fmt.Fprintln(out, "- Unsubscribing from Issue #"+i2)
+					fmt.Fprintf(out, "- Unsubscribing from Issue #%d in %s\n", issue.IID, utils.Cyan(repo.FullName()))
 				}
 
-				issue, err := api.UnsubscribeFromIssue(apiClient, repo.FullName(), utils.StringToInt(i2), nil)
+				issue, err := api.UnsubscribeFromIssue(apiClient, repo.FullName(), issue.IID, nil)
 				if err != nil {
 					return err
 				}
 
-				fmt.Fprintln(out, utils.Red("✔"), "Unsubscribed from issue #"+i2)
+				fmt.Fprintln(out, utils.Red("✔"), "Unsubscribed")
 				fmt.Fprintln(out, issueutils.DisplayIssue(issue))
 			}
 			return nil

--- a/commands/issue/unsubscribe/issue_unsubscribe_test.go
+++ b/commands/issue/unsubscribe/issue_unsubscribe_test.go
@@ -47,17 +47,17 @@ func TestNewCmdUnsubscribe(t *testing.T) {
 		{
 			Name:        "Issue Exists",
 			Issue:       "1",
-			ExpectedMsg: []string{"- Unsubscribing from Issue #1", "✔ Unsubscribed from issue #1"},
+			ExpectedMsg: []string{"- Unsubscribing from Issue #1 in glab-cli/test", "✔ Unsubscribed from issue #1"},
 		},
 		{
 			Name:        "Issue on another repo",
 			Issue:       "1 -R profclems/glab",
-			ExpectedMsg: []string{"- Unsubscribing from Issue #1", "✔ Unsubscribed from issue #1"},
+			ExpectedMsg: []string{"- Unsubscribing from Issue #1 in profclems/glab", "✔ Unsubscribed from issue #1"},
 		},
 		{
 			Name:        "Issue Does Not Exist",
 			Issue:       "0",
-			ExpectedMsg: []string{"- Unsubscribing from Issue #0", "error expected"},
+			ExpectedMsg: []string{"- Unsubscribing from Issue #0 in glab-cli/test", "error expected"},
 			wantErr:     true,
 		},
 	}

--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -65,12 +65,10 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			repo, err := f.BaseRepo()
+			issue, repo, err := issueutils.IssueFromArg(apiClient, f.BaseRepo, args[0])
 			if err != nil {
 				return err
 			}
-
-			issueID := utils.StringToInt(args[0])
 			l := &gitlab.UpdateIssueOptions{}
 
 			if m, _ := cmd.Flags().GetString("title"); m != "" {
@@ -127,7 +125,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 						return err
 					}
 				} else if len(ua.ToAdd) != 0 || len(ua.ToRemove) != 0 {
-					issue, err := api.GetIssue(apiClient, repo.FullName(), issueID)
+					issue, err := api.GetIssue(apiClient, repo.FullName(), issue.IID)
 					if err != nil {
 						return err
 					}
@@ -138,9 +136,9 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				}
 			}
 
-			fmt.Fprintf(out, "- Updating issue #%d\n", issueID)
+			fmt.Fprintf(out, "- Updating issue #%d\n", issue.IID)
 
-			issue, err := api.UpdateIssue(apiClient, repo.FullName(), issueID, l)
+			issue, err = api.UpdateIssue(apiClient, repo.FullName(), issue.IID, l)
 			if err != nil {
 				return err
 			}

--- a/commands/issue/view/issue_view.go
+++ b/commands/issue/view/issue_view.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/profclems/glab/commands/issue/issueutils"
+
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/glrepo"
 
@@ -36,7 +38,6 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 		Aliases: []string{"show"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pid := utils.StringToInt(args[0])
 
 			var err error
 			out := f.IO.StdOut
@@ -45,15 +46,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			repo, err := f.BaseRepo()
-			if err != nil {
-				return err
-			}
-
-			baseRepo = repo
 			cfg, _ = f.Config()
 
-			issue, err := api.GetIssue(apiClient, repo.FullName(), pid)
+			issue, baseRepo, err := issueutils.IssueFromArg(apiClient, f.BaseRepo, args[0])
 			if err != nil {
 				return err
 			}
@@ -64,7 +59,7 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 					fmt.Fprintf(out, "Opening %s in your browser.\n", utils.DisplayURL(issue.WebURL))
 				}
 
-				browser, _ := cfg.Get(repo.RepoHost(), "browser")
+				browser, _ := cfg.Get(baseRepo.RepoHost(), "browser")
 				return utils.OpenInBrowser(issue.WebURL, browser)
 			}
 

--- a/commands/issue/view/issue_view.go
+++ b/commands/issue/view/issue_view.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/profclems/glab/commands/issue/issueutils"
 
-	"github.com/profclems/glab/internal/config"
-	"github.com/profclems/glab/internal/glrepo"
-
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/utils"
 	"github.com/profclems/glab/pkg/api"
 
@@ -24,7 +22,6 @@ var (
 	showComments   bool
 	limit          int
 	pageNumber     int
-	baseRepo       glrepo.Interface
 	cfg            config.Config
 	glamourStyle   string
 	notes          []*gitlab.Note

--- a/commands/mr/checkout/mr_checkout.go
+++ b/commands/mr/checkout/mr_checkout.go
@@ -1,7 +1,9 @@
 package checkout
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -14,8 +16,9 @@ import (
 )
 
 type mrCheckoutConfig struct {
-	branch string
-	track  bool
+	branch   string
+	track    bool
+	upstream string
 }
 
 var (
@@ -31,12 +34,34 @@ func NewCmdCheckout(f *cmdutils.Factory) *cobra.Command {
 			$ glab mr checkout 1
 			$ glab mr checkout branch --track
 			$ glab mr checkout 12 --branch todo-fix
+			$ glab mr checkout new-feature --set-upstream-to=upstream/trunk
 			$ glab mr checkout   # use checked out branch
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			var err error
+			var upstream string
+
+			if mrCheckoutCfg.upstream != "" {
+				// Make sure we don't have the mutually exclusive flags --track and --set-upstream-to
+				if mrCheckoutCfg.track {
+					return &cmdutils.FlagError{Err: errors.New("--track and --set-upstream-to are mutually exclusive")}
+				}
+
+				upstream = mrCheckoutCfg.upstream
+
+				if val := strings.Split(mrCheckoutCfg.upstream, "/"); len(val) > 1 {
+					// Verify that we have the remote set
+					repo, err := f.Remotes()
+					if err != nil {
+						return err
+					}
+					_, err = repo.FindByName(val[0])
+					if err != nil {
+						return err
+					}
+				}
+			}
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
@@ -91,11 +116,18 @@ func NewCmdCheckout(f *cmdutils.Factory) *cobra.Command {
 			if err := git.CheckoutBranch(mrCheckoutCfg.branch); err != nil {
 				return err
 			}
+
+			// Check out the branch
+			if upstream != "" {
+				if err := git.RunCmd([]string{"branch", "--set-upstream-to", upstream}); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}
 	mrCheckoutCmd.Flags().StringVarP(&mrCheckoutCfg.branch, "branch", "b", "", "checkout merge request with <branch> name")
 	mrCheckoutCmd.Flags().BoolVarP(&mrCheckoutCfg.track, "track", "t", false, "set checked out branch to track remote branch, adds remote if needed")
-
+	mrCheckoutCmd.Flags().StringVarP(&mrCheckoutCfg.upstream, "set-upstream-to", "u", "", "set tracking of checked out branch to [REMOTE/]BRANCH")
 	return mrCheckoutCmd
 }

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -24,6 +24,7 @@ type ListOptions struct {
 	Milestone    string
 	SourceBranch string
 	TargetBranch string
+	Search       string
 	Mine         bool
 
 	// issue states
@@ -101,6 +102,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	mrListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter merge request by milestone <id>")
 	mrListCmd.Flags().StringVarP(&opts.SourceBranch, "source-branch", "s", "", "Filter by source branch <name>")
 	mrListCmd.Flags().StringVarP(&opts.TargetBranch, "target-branch", "t", "", "Filter by target branch <name>")
+	mrListCmd.Flags().StringVar(&opts.Search, "search", "", "Filter by <string> in title and description")
 	mrListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Merged, "merged", "M", false, "Get only merged merge requests")
@@ -150,6 +152,10 @@ func listRun(opts *ListOptions) error {
 	}
 	if opts.TargetBranch != "" {
 		l.TargetBranch = gitlab.String(opts.TargetBranch)
+		opts.ListType = "search"
+	}
+	if opts.Search != "" {
+		l.Search = gitlab.String(opts.Search)
 		opts.ListType = "search"
 	}
 	if len(opts.Labels) > 0 {

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -18,11 +18,13 @@ import (
 
 type ListOptions struct {
 	// metadata
-	Assignee  []string
-	Author    string
-	Labels    []string
-	Milestone string
-	Mine      bool
+	Assignee     []string
+	Author       string
+	Labels       []string
+	Milestone    string
+	SourceBranch string
+	TargetBranch string
+	Mine         bool
 
 	// issue states
 	State  string
@@ -96,6 +98,8 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	mrListCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Filter merge request by label <name>")
 	mrListCmd.Flags().StringVar(&opts.Author, "author", "", "Fitler merge request by Author <username>")
 	mrListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter merge request by milestone <id>")
+	mrListCmd.Flags().StringVarP(&opts.SourceBranch, "source-branch", "s", "", "Filter by source branch <name>")
+	mrListCmd.Flags().StringVarP(&opts.TargetBranch, "target-branch", "t", "", "Filter by target branch <name>")
 	mrListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Merged, "merged", "M", false, "Get only merged merge requests")
@@ -136,6 +140,14 @@ func listRun(opts *ListOptions) error {
 			return err
 		}
 		l.AuthorID = gitlab.Int(u.ID)
+		opts.ListType = "search"
+	}
+	if opts.SourceBranch != "" {
+		l.SourceBranch = gitlab.String(opts.SourceBranch)
+		opts.ListType = "search"
+	}
+	if opts.TargetBranch != "" {
+		l.TargetBranch = gitlab.String(opts.TargetBranch)
 		opts.ListType = "search"
 	}
 	if len(opts.Labels) > 0 {

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -26,7 +26,6 @@ type ListOptions struct {
 	// issue states
 	State  string
 	Closed bool
-	Opened bool
 	Merged bool
 	All    bool
 
@@ -67,8 +66,10 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 			opts.HTTPClient = f.HttpClient
 
 			// check if any of the two or all of states flag are specified
-			if opts.Closed && (opts.Merged || opts.Opened) || (opts.Merged && opts.Opened) {
-				return cmdutils.FlagError{Err: errors.New("specify either --closed, --merged or --opened. Use --all issues in all states")}
+			if opts.Closed && opts.Merged {
+				return cmdutils.FlagError{
+					Err: errors.New("specify either --closed or --merged. Use --all issues in all states"),
+				}
 			}
 			if opts.All {
 				opts.State = "all"
@@ -95,12 +96,15 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	mrListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter merge request by milestone <id>")
 	mrListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed merge requests")
-	mrListCmd.Flags().BoolVarP(&opts.Opened, "opened", "o", false, "Get only open merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Merged, "merged", "M", false, "Get only merged merge requests")
 	mrListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
 	mrListCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page")
 	mrListCmd.Flags().BoolVarP(&opts.Mine, "mine", "", false, "Get only merge requests assigned to me")
 	mrListCmd.Flags().StringSliceVarP(&opts.Assignee, "assignee", "a", []string{}, "Get only merge requests assigned to users")
+
+	mrListCmd.Flags().BoolP("opened", "o", false, "Get only open merge requests")
+	mrListCmd.Flags().MarkHidden("opened")
+	mrListCmd.Flags().MarkDeprecated("opened", "default value if neither --closed, --locked or --merged is used")
 
 	return mrListCmd
 }

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -31,6 +31,7 @@ type ListOptions struct {
 	Closed bool
 	Merged bool
 	All    bool
+	Draft  bool
 
 	// Pagination
 	Page    int
@@ -103,6 +104,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	mrListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Merged, "merged", "M", false, "Get only merged merge requests")
+	mrListCmd.Flags().BoolVarP(&opts.Draft, "draft", "d", false, "Filter by draft merge requests")
 	mrListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
 	mrListCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page")
 	mrListCmd.Flags().BoolVarP(&opts.Mine, "mine", "", false, "Get only merge requests assigned to me")
@@ -163,6 +165,10 @@ func listRun(opts *ListOptions) error {
 	}
 	if opts.PerPage != 0 {
 		l.PerPage = opts.PerPage
+	}
+	if opts.Draft {
+		l.WIP = gitlab.String("yes")
+		opts.ListType = "search"
 	}
 
 	if opts.Mine {

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -60,9 +60,12 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 		Example: heredoc.Doc(`
 			$ glab mr list --all
 			$ glab mr ls -a
-			$ glab mr list --mine
+			$ glab mr list --assignee=@me
+			$ glab mr list --source-branch=new-feature
+			$ glab mr list --target-branch=trunk
+			$ glab mr list --search "this adds feature X"
 			$ glab mr list --label needs-review
-			$ glab mr list -o --per-page 10
+			$ glab mr list -M --per-page 10
 		`),
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -19,6 +19,7 @@ import (
 type ListOptions struct {
 	// metadata
 	Assignee  []string
+	Author    string
 	Labels    []string
 	Milestone string
 	Mine      bool
@@ -93,6 +94,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	}
 
 	mrListCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Filter merge request by label <name>")
+	mrListCmd.Flags().StringVar(&opts.Author, "author", "", "Fitler merge request by Author <username>")
 	mrListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter merge request by milestone <id>")
 	mrListCmd.Flags().BoolVarP(&opts.All, "all", "A", false, "Get all merge requests")
 	mrListCmd.Flags().BoolVarP(&opts.Closed, "closed", "c", false, "Get only closed merge requests")
@@ -128,6 +130,14 @@ func listRun(opts *ListOptions) error {
 	l.Page = 1
 	l.PerPage = 30
 
+	if opts.Author != "" {
+		u, err := api.UserByName(apiClient, opts.Author)
+		if err != nil {
+			return err
+		}
+		l.AuthorID = gitlab.Int(u.ID)
+		opts.ListType = "search"
+	}
 	if len(opts.Labels) > 0 {
 		l.Labels = opts.Labels
 		opts.ListType = "search"

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -21,6 +21,7 @@ type ListOptions struct {
 	Assignee     []string
 	Author       string
 	Labels       []string
+	NotLabels    []string
 	Milestone    string
 	SourceBranch string
 	TargetBranch string
@@ -65,6 +66,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 			$ glab mr list --target-branch=trunk
 			$ glab mr list --search "this adds feature X"
 			$ glab mr list --label needs-review
+			$ glab mr list --not-label waiting-maintainer-feedback,subsystem-x
 			$ glab mr list -M --per-page 10
 		`),
 		Args: cobra.ExactArgs(0),
@@ -72,6 +74,12 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 			// supports repo override
 			opts.BaseRepo = f.BaseRepo
 			opts.HTTPClient = f.HttpClient
+
+			if len(opts.Labels) != 0 && len(opts.NotLabels) != 0 {
+				return cmdutils.FlagError{
+					Err: errors.New("flags --label and --not-label are mutually exclusive"),
+				}
+			}
 
 			// check if any of the two or all of states flag are specified
 			if opts.Closed && opts.Merged {
@@ -101,6 +109,7 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	}
 
 	mrListCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Filter merge request by label <name>")
+	mrListCmd.Flags().StringSliceVar(&opts.NotLabels, "not-label", []string{}, "Filter merge requests by not having label <name>")
 	mrListCmd.Flags().StringVar(&opts.Author, "author", "", "Fitler merge request by Author <username>")
 	mrListCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter merge request by milestone <id>")
 	mrListCmd.Flags().StringVarP(&opts.SourceBranch, "source-branch", "s", "", "Filter by source branch <name>")

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -109,12 +109,15 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	mrListCmd.Flags().BoolVarP(&opts.Draft, "draft", "d", false, "Filter by draft merge requests")
 	mrListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
 	mrListCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page")
-	mrListCmd.Flags().BoolVarP(&opts.Mine, "mine", "", false, "Get only merge requests assigned to me")
 	mrListCmd.Flags().StringSliceVarP(&opts.Assignee, "assignee", "a", []string{}, "Get only merge requests assigned to users")
 
 	mrListCmd.Flags().BoolP("opened", "o", false, "Get only open merge requests")
 	mrListCmd.Flags().MarkHidden("opened")
 	mrListCmd.Flags().MarkDeprecated("opened", "default value if neither --closed, --locked or --merged is used")
+
+	mrListCmd.Flags().BoolVarP(&opts.Mine, "mine", "", false, "Get only merge requests assigned to me")
+	mrListCmd.Flags().MarkHidden("mine")
+	mrListCmd.Flags().MarkDeprecated("mine", "use --assignee=@me")
 
 	return mrListCmd
 }

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -92,7 +92,7 @@ func MRState(m *gitlab.MergeRequest) string {
 	if m.State == "opened" {
 		return utils.Green(fmt.Sprintf("!%d", m.IID))
 	} else if m.State == "merged" {
-		return utils.Blue(fmt.Sprintf("!%d", m.IID))
+		return utils.Magenta(fmt.Sprintf("!%d", m.IID))
 	} else {
 		return utils.Red(fmt.Sprintf("!%d", m.IID))
 	}

--- a/pkg/api/issue.go
+++ b/pkg/api/issue.go
@@ -2,6 +2,8 @@
 package api
 
 import (
+	"errors"
+
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -101,8 +103,14 @@ var SubscribeToIssue = func(client *gitlab.Client, projectID interface{}, issueI
 		client = apiClient.Lab()
 	}
 
-	issue, _, err := client.Issues.SubscribeToIssue(projectID, issueID, opts)
+	issue, resp, err := client.Issues.SubscribeToIssue(projectID, issueID, opts)
 	if err != nil {
+		if resp != nil {
+			// If the user is already subscribed to the issue, the status code 304 is returned.
+			if resp.StatusCode == 304 {
+				return nil, errors.New("you are already subscribed to this issue")
+			}
+		}
 		return issue, err
 	}
 
@@ -114,8 +122,14 @@ var UnsubscribeFromIssue = func(client *gitlab.Client, projectID interface{}, is
 		client = apiClient.Lab()
 	}
 
-	issue, _, err := client.Issues.UnsubscribeFromIssue(projectID, issueID, opts)
+	issue, resp, err := client.Issues.UnsubscribeFromIssue(projectID, issueID, opts)
 	if err != nil {
+		if resp != nil {
+			// If the user is not subscribed to the issue, the status code 304 is returned.
+			if resp.StatusCode == 304 {
+				return nil, errors.New("you are not subscribed to this issue")
+			}
+		}
 		return issue, err
 	}
 


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This PR enables issue URL to be passed as argument.

The user can now specify an issue by either the ID or URL.

Supports:
- `HOST/OWNER/REPO/issues/ID`
- `HOST/GROUP/NAMESPACE/issues/ID`
- `HOST/OWNER/REPO/-/issues/ID`
- `HOST/GROUP/NAMESPACE/-/issues/ID`

eg:
- `glab issue close https://gitlab.com/profclems/glab/issues/277`
- `glab issue close 277`
- `glab issue close https://gitlab.com/profclems/glab/-/issues/277`
- `glab issue close https://salsa.debian.org/GROUP/NAMESPACE/REPO/issues/123`

Also adds support for IDs prefixed with '#'
- `glab issue reopen "#277"`

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
None

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested on gitlab.com/profclems/glab, private group repo and a few repos on salsa.debian.org

TODO: add unit tests

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
