### PR TITLE
feat(commands/variable): add `variable set` command

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -16,6 +16,7 @@ import (
 	releaseCmd "github.com/profclems/glab/commands/release"
 	updateCmd "github.com/profclems/glab/commands/update"
 	userCmd "github.com/profclems/glab/commands/user"
+	variableCmd "github.com/profclems/glab/commands/variable"
 	versionCmd "github.com/profclems/glab/commands/version"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/internal/utils"
@@ -101,6 +102,7 @@ func NewCmdRoot(f *cmdutils.Factory, version, buildDate string) *cobra.Command {
 	rootCmd.AddCommand(projectCmd.NewCmdRepo(f))
 	rootCmd.AddCommand(releaseCmd.NewCmdRelease(f))
 	rootCmd.AddCommand(userCmd.NewCmdUser(f))
+	rootCmd.AddCommand(variableCmd.NewVariableCmd(f))
 	rootCmd.AddCommand(apiCmd.NewCmdApi(f, nil))
 
 	rootCmd.Flags().BoolP("version", "v", false, "show glab version information")

--- a/commands/variable/set/set.go
+++ b/commands/variable/set/set.go
@@ -1,0 +1,151 @@
+package set
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+type SetOpts struct {
+	HTTPClient func() (*gitlab.Client, error)
+	IO         *utils.IOStreams
+	BaseRepo   func() (glrepo.Interface, error)
+
+	Key       string
+	Value     string
+	Type      string
+	Scope     string
+	Protected bool
+	Masked    bool
+	Group     string
+}
+
+func NewVariableCmd(f *cmdutils.Factory, runE func(opts *SetOpts) error) *cobra.Command {
+	opts := &SetOpts{
+		IO: f.IO,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "set <key> <value>",
+		Short:   "Create a new project or group variable",
+		Aliases: []string{"new", "create"},
+		Args:    cobra.RangeArgs(1, 2),
+		Example: heredoc.Doc(`
+			$ glab variable set WITH_ARG "some value"
+			$ glab variable set FROM_FLAG -v "some value"
+			$ glab variable set FROM_ENV_WITH_ARG "${ENV_VAR}"
+			$ glab variable set FROM_ENV_WITH_FLAG -v"${ENV_VAR}"
+			$ glab variable set FROM_FILE < secret.txt
+			$ cat file.txt | glab variable set SERVER_TOKEN
+			$ cat token.txt | glab variable set GROUP_TOKEN -g mygroup --scope=prod
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Supports repo override
+			opts.HTTPClient = f.HttpClient
+			opts.BaseRepo = f.BaseRepo
+
+			opts.Key = args[0]
+
+			if opts.Value != "" && len(args) == 2 {
+				if opts.Value != "" {
+					return cmdutils.FlagError{Err: errors.New("specify value either by second positional argument or --value flag")}
+				}
+				opts.Value = args[1]
+			}
+
+			if cmd.Flags().Changed("scope") && opts.Group != "" {
+				return cmdutils.FlagError{Err: errors.New("scope is not required for group variables")}
+			}
+
+			valueSet := cmd.Flags().Changed("value") || len(args) == 2
+
+			if !valueSet && opts.Value == "" {
+				if opts.IO.IsInTTY {
+					return &cmdutils.FlagError{Err: errors.New("no value specified but nothing on STDIN")}
+				}
+				// read value from STDIN if not provided
+
+				defer opts.IO.In.Close()
+				value, err := ioutil.ReadAll(opts.IO.In)
+				if err != nil {
+					return fmt.Errorf("failed to read value from STDIN: %w", err)
+				}
+				opts.Value = strings.TrimSpace(string(value))
+
+			}
+
+			if cmd.Flags().Changed("type") {
+				if opts.Type != "env_var" && opts.Type != "file" {
+					return cmdutils.FlagError{Err: fmt.Errorf("invalid type: %s. --type must be one of `env_var` or `file`", opts.Type)}
+				}
+			}
+
+			if runE != nil {
+				return runE(opts)
+			}
+			return setRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Value, "value", "v", "", "The value of a variable")
+	cmd.Flags().StringVarP(&opts.Type, "type", "t", "env_var", "The type of a variable: {env_var|file}")
+	cmd.Flags().StringVarP(&opts.Scope, "scope", "s", "*", "The environment_scope of the variable. All (*), or specific environments")
+	cmd.Flags().StringVarP(&opts.Group, "group", "g", "", "Set variable for a group")
+	cmd.Flags().BoolVarP(&opts.Masked, "masked", "m", false, "Whether the variable is masked")
+	cmd.Flags().BoolVarP(&opts.Protected, "protected", "p", false, "Whether the variable is protected")
+	return cmd
+}
+
+func setRun(opts *SetOpts) error {
+	httpClient, err := opts.HTTPClient()
+	if err != nil {
+		return err
+	}
+	if opts.Group != "" {
+		// creating project-level variable
+		createVarOpts := &gitlab.CreateGroupVariableOptions{
+			Key:          gitlab.String(opts.Key),
+			Value:        gitlab.String(opts.Value),
+			VariableType: gitlab.VariableType(gitlab.VariableTypeValue(opts.Type)),
+			Masked:       gitlab.Bool(opts.Masked),
+			Protected:    gitlab.Bool(opts.Protected),
+		}
+		_, err = api.CreateGroupVariable(httpClient, opts.Group, createVarOpts)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(opts.IO.StdOut, "%s Created variable %s for group %s\n", utils.GreenCheck(), opts.Key, opts.Group)
+		return nil
+	}
+
+	// creating group-level variable
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+	createVarOpts := &gitlab.CreateProjectVariableOptions{
+		Key:              gitlab.String(opts.Key),
+		Value:            gitlab.String(opts.Value),
+		EnvironmentScope: gitlab.String(opts.Scope),
+		Masked:           gitlab.Bool(opts.Masked),
+		Protected:        gitlab.Bool(opts.Protected),
+		VariableType:     gitlab.VariableType(gitlab.VariableTypeValue(opts.Type)),
+	}
+	_, err = api.CreateProjectVariable(httpClient, baseRepo.FullName(), createVarOpts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(opts.IO.StdOut, "%s Created variable %s for %s\n", utils.GreenCheck(), opts.Key, baseRepo.FullName())
+	return nil
+}

--- a/commands/variable/set/set_test.go
+++ b/commands/variable/set/set_test.go
@@ -1,0 +1,43 @@
+package set
+
+import "testing"
+
+func Test_isValidKey(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "key is empty",
+			args: args{
+				key: "",
+			},
+			want: false,
+		},
+		{
+			name: "key is valid",
+			args: args{
+				key: "abc123_",
+			},
+			want: true,
+		},
+		{
+			name: "key is invalid",
+			args: args{
+				key: "abc-123",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidKey(tt.args.key); got != tt.want {
+				t.Errorf("isValidKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/commands/variable/set/set_test.go
+++ b/commands/variable/set/set_test.go
@@ -1,6 +1,19 @@
 package set
 
-import "testing"
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/google/shlex"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/profclems/glab/pkg/httpmock"
+	"github.com/xanzy/go-gitlab"
+)
 
 func Test_isValidKey(t *testing.T) {
 	type args struct {
@@ -40,4 +53,219 @@ func Test_isValidKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_getValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		valueArg string
+		want     string
+		stdin    string
+	}{
+		{
+			name:     "literal value",
+			valueArg: "a secret",
+			want:     "a secret",
+		},
+		{
+			name:  "from stdin",
+			want:  "a secret",
+			stdin: "a secret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, stdin, _, _ := utils.IOTest()
+
+			io.IsInTTY = false
+
+			_, err := stdin.WriteString(tt.stdin)
+			assert.NoError(t, err)
+
+			value, err := getValue(&SetOpts{
+				Value: tt.valueArg,
+				IO:    io,
+			})
+			assert.NoError(t, err)
+
+			assert.Equal(t, value, tt.want)
+		})
+	}
+}
+
+func Test_NewCmdSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    SetOpts
+		stdinTTY bool
+		wantsErr bool
+	}{
+		{
+			name:     "invalid type",
+			cli:      "cool_secret -g coolGroup -t 'mV'",
+			wantsErr: true,
+		},
+		{
+			name:     "value argument and value flag specified",
+			cli:      `cool_secret value -v"another value"`,
+			wantsErr: true,
+		},
+		{
+			name:     "no name",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name:     "no value, stdin is terminal",
+			cli:      "cool_secret",
+			stdinTTY: true,
+			wantsErr: true,
+		},
+		{
+			name: "protected var",
+			cli:  `cool_secret -v"a secret" -p`,
+			wants: SetOpts{
+				Key:       "cool_secret",
+				Protected: true,
+				Value:     "a secret",
+				Group:     "",
+			},
+		},
+		{
+			name: "protected var in group",
+			cli:  `cool_secret --group coolGroup -v"cool"`,
+			wants: SetOpts{
+				Key:       "cool_secret",
+				Protected: false,
+				Value:     "cool",
+				Group:     "coolGroup",
+			},
+		},
+		{
+			name: "leading numbers in name",
+			cli:  `123_TOKEN -v"cool"`,
+			wants: SetOpts{
+				Key:       "123_TOKEN",
+				Protected: false,
+				Value:     "cool",
+				Group:     "",
+			},
+		},
+		{
+			name:     "invalid characters in name",
+			cli:      `BAD-SECRET -v"cool"`,
+			wantsErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, _, _ := utils.IOTest()
+			f := &cmdutils.Factory{
+				IO: io,
+			}
+
+			io.IsInTTY = tt.stdinTTY
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *SetOpts
+			cmd := NewCmdSet(f, func(opts *SetOpts) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Key, gotOpts.Key)
+			assert.Equal(t, tt.wants.Value, gotOpts.Value)
+			assert.Equal(t, tt.wants.Group, gotOpts.Group)
+		})
+	}
+}
+
+func Test_setRun_project(t *testing.T) {
+	reg := &httpmock.Mocker{}
+	defer reg.Verify(t)
+
+	reg.RegisterResponder("POST", "/projects/owner/repo/variables",
+		httpmock.NewStringResponse(201, `
+			{
+    			"key": "NEW_VARIABLE",
+    			"value": "new value",
+    			"variable_type": "env_var",
+    			"protected": false,
+    			"masked": false
+			}
+		`),
+	)
+
+	io, _, stdout, _ := utils.IOTest()
+
+	opts := &SetOpts{
+		HTTPClient: func() (*gitlab.Client, error) {
+			a, _ := api.TestClient(&http.Client{Transport: reg}, "", "gitlab.com", false)
+			return a.Lab(), nil
+		},
+		BaseRepo: func() (glrepo.Interface, error) {
+			return glrepo.FromFullName("owner/repo")
+		},
+		IO:    io,
+		Key:   "NEW_VARIABLE",
+		Value: "new value",
+	}
+	_, _ = opts.HTTPClient()
+
+	err := setRun(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, stdout.String(), "✓ Created variable NEW_VARIABLE for owner/repo\n")
+}
+
+func Test_setRun_group(t *testing.T) {
+	reg := &httpmock.Mocker{}
+	defer reg.Verify(t)
+
+	reg.RegisterResponder("POST", "/groups/mygroup/variables",
+		httpmock.NewStringResponse(201, `
+			{
+    			"key": "NEW_VARIABLE",
+    			"value": "new value",
+    			"variable_type": "env_var",
+    			"protected": false,
+    			"masked": false
+			}
+		`),
+	)
+
+	io, _, stdout, _ := utils.IOTest()
+
+	opts := &SetOpts{
+		HTTPClient: func() (*gitlab.Client, error) {
+			a, _ := api.TestClient(&http.Client{Transport: reg}, "", "gitlab.com", false)
+			return a.Lab(), nil
+		},
+		BaseRepo: func() (glrepo.Interface, error) {
+			return glrepo.FromFullName("owner/repo")
+		},
+		IO:    io,
+		Key:   "NEW_VARIABLE",
+		Value: "new value",
+		Group: "mygroup",
+	}
+	_, _ = opts.HTTPClient()
+
+	err := setRun(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, stdout.String(), "✓ Created variable NEW_VARIABLE for group mygroup\n")
 }

--- a/commands/variable/variable.go
+++ b/commands/variable/variable.go
@@ -1,0 +1,20 @@
+package variable
+
+import (
+	"github.com/profclems/glab/commands/cmdutils"
+	setCmd "github.com/profclems/glab/commands/variable/set"
+	"github.com/spf13/cobra"
+)
+
+func NewVariableCmd(f *cmdutils.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "variable",
+		Short:   "Manage GitLab Project and Group Variables",
+		Aliases: []string{"var"},
+	}
+
+	cmdutils.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(setCmd.NewVariableCmd(f, nil))
+	return cmd
+}

--- a/commands/variable/variable.go
+++ b/commands/variable/variable.go
@@ -15,6 +15,6 @@ func NewVariableCmd(f *cmdutils.Factory) *cobra.Command {
 
 	cmdutils.EnableRepoOverride(cmd, f)
 
-	cmd.AddCommand(setCmd.NewVariableCmd(f, nil))
+	cmd.AddCommand(setCmd.NewCmdSet(f, nil))
 	return cmd
 }

--- a/commands/variable/variable_test.go
+++ b/commands/variable/variable_test.go
@@ -1,0 +1,34 @@
+package variable
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVariableCmd(t *testing.T) {
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	assert.Nil(t, NewVariableCmd(&cmdutils.Factory{}).Execute())
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = old // restoring the real stdout
+	out := <-outC
+
+	assert.Contains(t, out, "Use \"variable [command] --help\" for more information about a command.\n")
+}

--- a/pkg/api/variable.go
+++ b/pkg/api/variable.go
@@ -1,0 +1,27 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+var CreateProjectVariable = func(client *gitlab.Client, projectID interface{}, opts *gitlab.CreateProjectVariableOptions) (*gitlab.ProjectVariable, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	vars, _, err := client.ProjectVariables.CreateVariable(projectID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return vars, nil
+}
+
+var CreateGroupVariable = func(client *gitlab.Client, groupID interface{}, opts *gitlab.CreateGroupVariableOptions) (*gitlab.GroupVariable, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	vars, _, err := client.GroupVariables.CreateVariable(groupID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return vars, nil
+}


### PR DESCRIPTION
Adds `variable set` command for creating GitLab environment variables.

Variable can be created for a project or a group specified with `--group | -g` flag.

Resolves #515
