### PR TITLE
feat(ci/view): Change color of failed pipelines that allow failure

### DIFF
--- a/commands/ci/status/status.go
+++ b/commands/ci/status/status.go
@@ -82,7 +82,11 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 						var status string
 						switch s := job.Status; s {
 						case "failed":
-							status = utils.Red(s)
+							if job.AllowFailure {
+								status = utils.Yellow(s)
+							} else {
+								status = utils.Red(s)
+							}
 						case "success":
 							status = utils.Green(s)
 						default:

--- a/commands/ci/view/view.go
+++ b/commands/ci/view/view.go
@@ -477,8 +477,13 @@ func jobsView(app *tview.Application, jobsCh chan []*gitlab.Job, inputCh chan st
 			b.SetBorderColor(tcell.ColorGreen)
 			statChar = '✔'
 		case "failed":
-			b.SetBorderColor(tcell.ColorRed)
-			statChar = '✘'
+			if j.AllowFailure {
+				b.SetBorderColor(tcell.ColorOrange)
+				statChar = '!'
+			} else {
+				b.SetBorderColor(tcell.ColorRed)
+				statChar = '✘'
+			}
 		case "running":
 			b.SetBorderColor(tcell.ColorBlue)
 			statChar = '●'


### PR DESCRIPTION
**Description**
- feat(ci/view): Display orange color on allow failure
- feat(ci/status): Change color for piplines that allow failure

**Related Issue**
Resolves #373

**How Has This Been Tested?**
Before: 
![image](https://user-images.githubusercontent.com/14844365/104156929-c6f3f580-53f2-11eb-9918-e09c89bd7e75.png)
![image](https://user-images.githubusercontent.com/14844365/104156959-d7a46b80-53f2-11eb-9734-904eb8206bbe.png)

After:
![image](https://user-images.githubusercontent.com/14844365/104157003-f0148600-53f2-11eb-89e4-d55cfb4a2a9a.png)
![image](https://user-images.githubusercontent.com/14844365/104157042-00c4fc00-53f3-11eb-987b-7dec7554ab2a.png)


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
