### PR TITLE
feat: add auth status command

### DIFF
--- a/commands/auth/auth.go
+++ b/commands/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	authLoginCmd "github.com/profclems/glab/commands/auth/login"
+	authStatusCmd "github.com/profclems/glab/commands/auth/status"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,7 @@ func NewCmdAuth(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(authLoginCmd.NewCmdLogin(f))
+	cmd.AddCommand(authStatusCmd.NewCmdStatus(f, nil))
 
 	return cmd
 }

--- a/commands/auth/status/status.go
+++ b/commands/auth/status/status.go
@@ -1,0 +1,140 @@
+package status
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/config"
+	"github.com/profclems/glab/internal/glinstance"
+	"github.com/profclems/glab/internal/utils"
+	"github.com/profclems/glab/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+type StatusOpts struct {
+	HttpClient func() (*gitlab.Client, error)
+	IO         *utils.IOStreams
+	Config     func() (config.Config, error)
+
+	Hostname  string
+	ShowToken bool
+}
+
+func NewCmdStatus(f *cmdutils.Factory, runE func(*StatusOpts) error) *cobra.Command {
+	opts := &StatusOpts{
+		HttpClient: f.HttpClient,
+		IO:         f.IO,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Args:  cobra.ExactArgs(0),
+		Short: "View authentication status",
+		Long: heredoc.Doc(`Verifies and displays information about your authentication state.
+			
+			This command tests the authentication states of all known GitLab instances in the config file and reports issues if any
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runE != nil {
+				return runE(opts)
+			}
+
+			return statusRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Check a specific instance's authentication status")
+	cmd.Flags().BoolVarP(&opts.ShowToken, "show-token", "t", false, "Display the auth token")
+
+	return cmd
+}
+
+func statusRun(opts *StatusOpts) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	stderr := opts.IO.StdErr
+
+	statusInfo := map[string][]string{}
+
+	instances, err := cfg.Hosts()
+	if len(instances) == 0 || err != nil {
+		fmt.Fprintf(stderr,
+			"No GitLab instance has been authenticated with glab. Run %s to authenticate.\n", utils.Bold("glab auth login"))
+		return cmdutils.SilentError
+	}
+
+	var failed bool
+
+	for _, instance := range instances {
+		if opts.Hostname != "" && opts.Hostname != instance {
+			continue
+		}
+		statusInfo[instance] = []string{}
+		addMsg := func(x string, ys ...interface{}) {
+			statusInfo[instance] = append(statusInfo[instance], fmt.Sprintf(x, ys...))
+		}
+
+		token, tokenSource, _ := cfg.GetWithSource(instance, "token")
+		apiClient, err := api.NewClientWithCfg(instance, cfg, false)
+		if err == nil {
+			user, err := api.CurrentUser(apiClient.Lab())
+			if err != nil {
+				addMsg("%s %s: api call failed: %s", utils.FailedIcon(), instance, err)
+			} else {
+				addMsg("%s Logged in to %s as %s (%s)", utils.GreenCheck(), instance, utils.Bold(user.Username), tokenSource)
+			}
+		} else {
+			addMsg("%s %s: failed to initialize api client: %s", utils.FailedIcon(), instance, err)
+		}
+		proto, _ := cfg.Get(instance, "git_protocol")
+		if proto != "" {
+			addMsg("%s Git operations for %s configured to use %s protocol.",
+				utils.GreenCheck(), instance, utils.Bold(proto))
+		}
+		apiProto, _ := cfg.Get(instance, "api_protocol")
+		apiEndpoint := glinstance.APIEndpoint(instance, apiProto)
+		graphQLEndpoint := glinstance.GraphQLEndpoint(instance, apiProto)
+		if apiProto != "" {
+			addMsg("%s API calls for %s are made over %s protocol",
+				utils.GreenCheck(), instance, utils.Bold(apiProto))
+			addMsg("%s REST API Endpoint: %s",
+				utils.GreenCheck(), utils.Bold(apiEndpoint))
+			addMsg("%s GraphQL Endpoint: %s",
+				utils.GreenCheck(), utils.Bold(graphQLEndpoint))
+		}
+		if token != "" {
+			tokenDisplay := "********************"
+			if opts.ShowToken {
+				tokenDisplay = token
+			}
+			addMsg("%s Token: %s", utils.GreenCheck(), tokenDisplay)
+			if !api.IsValidToken(token) {
+				addMsg("%s Invalid token provided", utils.WarnIcon())
+			}
+		} else {
+			addMsg("%s No token provided", utils.FailedIcon())
+		}
+	}
+
+	for _, instance := range instances {
+		lines, ok := statusInfo[instance]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(stderr, "%s\n", utils.Bold(instance))
+		for _, line := range lines {
+			fmt.Fprintf(stderr, "  %s\n", line)
+		}
+	}
+
+	if failed {
+		return cmdutils.SilentError
+	}
+	return nil
+}

--- a/commands/auth/status/status_test.go
+++ b/commands/auth/status/status_test.go
@@ -1,0 +1,150 @@
+package status
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/profclems/glab/internal/config"
+	"github.com/profclems/glab/internal/utils"
+
+	"github.com/profclems/glab/commands/cmdutils"
+
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewCmdStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		cli   string
+		wants StatusOpts
+	}{
+		{
+			name:  "no arguments",
+			cli:   "",
+			wants: StatusOpts{},
+		},
+		{
+			name: "hostname set",
+			cli:  "--hostname gitlab.gnome.org",
+			wants: StatusOpts{
+				Hostname: "gitlab.gnome.org",
+			},
+		},
+		{
+			name: "show token",
+			cli:  "--show-token",
+			wants: StatusOpts{
+				ShowToken: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutils.Factory{}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *StatusOpts
+			cmd := NewCmdStatus(f, func(opts *StatusOpts) error {
+				gotOpts = opts
+				return nil
+			})
+
+			// TODO cobra hack-around
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Hostname, gotOpts.Hostname)
+		})
+	}
+}
+
+func Test_statusRun(t *testing.T) {
+	defer config.StubConfig(`---
+hosts:
+  gitlab.alpinelinux.org:
+    token: xxxxxxxxxxxxxxxxxxxx
+    git_protocol: ssh
+    api_protocol: https
+  somehost.com:
+    token: yyyyyyyyyyyyyyyyyyyy
+    git_protocol: ssh
+    api_protocol: https
+  another.host:
+    token: isinvalid
+`, "")()
+
+	configs, err := config.ParseConfig("config.yml")
+	assert.Nil(t, err)
+
+	io, _, stdout, stderr := utils.IOTest()
+
+	tests := []struct {
+		name    string
+		opts    *StatusOpts
+		wantErr bool
+		stderr  string
+	}{
+		{
+			name: "hostname set",
+			opts: &StatusOpts{
+				Hostname: "gitlab.alpinelinux.org",
+			},
+			stderr: `gitlab.alpinelinux.org
+  x gitlab.alpinelinux.org: api call failed: GET https://gitlab.alpinelinux.org/api/v4/user: 401 {message: 401 Unauthorized}
+  ✓ Git operations for gitlab.alpinelinux.org configured to use ssh protocol.
+  ✓ API calls for gitlab.alpinelinux.org are made over https protocol
+  ✓ REST API Endpoint: https://gitlab.alpinelinux.org/api/v4/
+  ✓ GraphQL Endpoint: https://gitlab.alpinelinux.org/api/graphql/
+  ✓ Token: ********************
+`,
+		},
+	}
+	for _, tt := range tests {
+		tt.opts.Config = func() (config.Config, error) {
+			return configs, nil
+		}
+		tt.opts.IO = io
+		t.Run(tt.name, func(t *testing.T) {
+			if err := statusRun(tt.opts); (err != nil) != tt.wantErr {
+				t.Errorf("statusRun() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, stdout.String(), "")
+			assert.Equal(t, tt.stderr, stderr.String())
+		})
+	}
+}
+
+func Test_statusRun_noinstance(t *testing.T) {
+	defer config.StubConfig(`---
+git_protocol: ssh
+`, "")()
+
+	configs, err := config.ParseConfig("config.yml")
+	assert.Nil(t, err)
+	io, _, stdout, stderr := utils.IOTest()
+
+	opts := &StatusOpts{
+		Config: func() (config.Config, error) {
+			return configs, nil
+		},
+		IO: io,
+	}
+	t.Run("no instance authenticated", func(t *testing.T) {
+		if err := statusRun(opts); (err != nil) != true {
+			t.Errorf("statusRun() error = %v, wantErr %v", err, true)
+		}
+		assert.Equal(t, stdout.String(), "")
+		assert.Equal(t, "No GitLab instance has been authenticated with glab. Run glab auth login to authenticate.\n", stderr.String())
+	})
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -102,6 +102,14 @@ func GreenCheck() string {
 	return Green("✓")
 }
 
+func FailedIcon() string {
+	return Red("x")
+}
+
+func WarnIcon() string {
+	return Yellow("!")
+}
+
 func RedCheck() string {
 	return Red("✔")
 }

--- a/pkg/api/default.go
+++ b/pkg/api/default.go
@@ -1,3 +1,12 @@
 package api
 
 var DefaultListLimit = 30
+
+//IsValidToken checks if a token provided is valid.
+// The token string must be 20 characters in length to be recognized as
+// a valid personal access token.
+//
+// TODO: check if token has minimum scopes required by glab
+func IsValidToken(token string) bool {
+	return len(token) == 20
+}

--- a/pkg/api/default_test.go
+++ b/pkg/api/default_test.go
@@ -1,0 +1,32 @@
+package api
+
+import "testing"
+
+func TestIsValidToken(t *testing.T) {
+	type args struct {
+		token string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Token Is Valid",
+			args: args{token: "xxxxxxxxxxxxxxxxxxxx"},
+			want: true,
+		},
+		{
+			name: "Token Is inValid",
+			args: args{token: "123"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidToken(tt.args.token); got != tt.want {
+				t.Errorf("IsValidToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/httpmock/mocker.go
+++ b/pkg/httpmock/mocker.go
@@ -6,10 +6,21 @@ import (
 	"sync"
 )
 
+type matchType int
+
+const (
+	PathOnly matchType = iota
+	HostOnly
+	FullURL
+	HostAndPath
+	PathAndQuerystring
+)
+
 type Mocker struct {
 	mu       sync.Mutex
 	stubs    []*Stub
 	Requests []*http.Request
+	MatchURL matchType // if false, only matches the path and if true, matches full url
 }
 
 func New() *Mocker {
@@ -18,7 +29,7 @@ func New() *Mocker {
 
 func (r *Mocker) RegisterResponder(method, path string, resp Responder) {
 	r.stubs = append(r.stubs, &Stub{
-		Matcher:   newRequest(method, path),
+		Matcher:   newRequest(method, path, r.MatchURL),
 		Responder: resp,
 	})
 }


### PR DESCRIPTION
This PR adds `auth status` command which verifies and displays information about your authentication state.

It tests the authentication states of all known GitLab instances in the config file and reports issues if any

![image](https://user-images.githubusercontent.com/41906128/104757116-8da1e980-5754-11eb-9aaf-69fb5b317d38.png)
