### PR TITLE
fix repo override `-R | --repo`

### DIFF
--- a/commands/cmdutils/repo_override.go
+++ b/commands/cmdutils/repo_override.go
@@ -7,7 +7,7 @@ import (
 )
 
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
-	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL or git URL")
+	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or full URL or git URL")
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		repoOverride, err := cmd.Flags().GetString("repo")

--- a/commands/cmdutils/repo_override.go
+++ b/commands/cmdutils/repo_override.go
@@ -7,15 +7,19 @@ import (
 )
 
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
-	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
+	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL or git URL")
 
-	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		repoOverride, _ := cmd.Flags().GetString("repo")
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		repoOverride, err := cmd.Flags().GetString("repo")
+		if err != nil {
+			return err
+		}
 		if repoFromEnv := os.Getenv("GITLAB_REPO"); repoOverride == "" && repoFromEnv != "" {
 			repoOverride = repoFromEnv
 		}
 		if repoOverride != "" {
-			_ = f.RepoOverride(repoOverride)
+			return f.RepoOverride(repoOverride)
 		}
+		return nil
 	}
 }

--- a/internal/git/url.go
+++ b/internal/git/url.go
@@ -54,7 +54,7 @@ func ParseURL(rawURL string) (u *url.URL, err error) {
 	return
 }
 
-// IsValidUrl tests a string to determine if it is a well-structured url or not.
+// IsValidUrl tests a string to determine if it is a valid Git url or not.
 func IsValidURL(u string) bool {
 	return strings.HasPrefix(u, "git@") || isSupportedProtocol(u)
 }

--- a/internal/glrepo/repo.go
+++ b/internal/glrepo/repo.go
@@ -6,9 +6,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/profclems/glab/internal/config"
+
 	"github.com/profclems/glab/internal/git"
 	"github.com/profclems/glab/internal/glinstance"
-
+	"github.com/profclems/glab/internal/utils"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -84,6 +86,15 @@ func New(owner, repo string) Interface {
 	return NewWithHost(owner, repo, glinstance.OverridableDefault())
 }
 
+// New instantiates a GitLab repository from group, subgroup and name arguments
+func NewWithGroup(group, namespace, repo, hostname string) Interface {
+	owner := fmt.Sprintf("%s/%s", group, namespace)
+	if hostname == "" {
+		return New(owner, repo)
+	}
+	return NewWithHost(owner, repo, hostname)
+}
+
 // NewWithHost is like New with an explicit host name
 func NewWithHost(owner, repo, hostname string) Interface {
 	rp := &glRepo{
@@ -104,6 +115,8 @@ func NewWithHost(owner, repo, hostname string) Interface {
 // FromFullName extracts the GitLab repository information from the following
 // formats: "OWNER/REPO", "HOST/OWNER/REPO", "HOST/GROUP/NAMESPACE/REPO", and a full URL.
 func FromFullName(nwo string) (Interface, error) {
+	nwo = strings.TrimSpace(nwo)
+	// check if it's a valid git URL and parse it
 	if git.IsValidURL(nwo) {
 		u, err := git.ParseURL(nwo)
 		if err != nil {
@@ -111,17 +124,53 @@ func FromFullName(nwo string) (Interface, error) {
 		}
 		return FromURL(u)
 	}
+	// check if it is valid URL and parse it
+	if utils.IsValidURL(nwo) {
+		u, _ := url.Parse(nwo)
+		return FromURL(u)
+	}
 
-	parts := strings.SplitN(nwo, "/", 3)
+	parts := strings.SplitN(nwo, "/", 4)
 	for _, p := range parts {
 		if p == "" {
 			return nil, fmt.Errorf(`expected the "[HOST/]OWNER/[NAMESPACE/]REPO" format, got %q`, nwo)
 		}
 	}
 	switch len(parts) {
-	case 3:
-		return NewWithHost(parts[1], parts[2], normalizeHostname(parts[0])), nil
-	case 2:
+	case 4: // HOST/GROUP/NAMESPACE/REPO
+		return NewWithGroup(parts[1], parts[2], parts[3], parts[0]), nil
+	case 3: // GROUP/NAMESPACE/REPO or HOST/OWNER/REPO
+		// First, checks if the first part matches the default instance host (i.e. gitlab.com) or the
+		// overridden default host (mostly from the GITLAB_HOST env variable)
+		if parts[0] == glinstance.Default() || parts[0] == glinstance.OverridableDefault() {
+			return NewWithHost(parts[1], parts[2], normalizeHostname(parts[0])), nil
+		}
+		// Dots (.) are allowed in group names by GitLab.
+		// So we check if if the first part contains a dot.
+		// However, it could be that the user is specifying a hostname but we can't be sure of that
+		// So we check in the list of authenticated hosts and see if it matches any
+		// if not, we assume it is a group name that contains a dot
+		if strings.ContainsRune(parts[0], '.') {
+			var rI Interface
+			cfg, err := config.Init()
+			if err == nil {
+				hosts, _ := cfg.Hosts()
+				for _, host := range hosts {
+					if host == parts[0] {
+						rI = NewWithHost(parts[1], parts[2], normalizeHostname(parts[0]))
+						break
+					}
+				}
+				if rI != nil {
+					return rI, nil
+				}
+			}
+		}
+		// if the first part is not a valid URL, and does not match an
+		// authenticated hostname then we assume it is in
+		// the format GROUP/NAMESPACE/REPO
+		return NewWithGroup(parts[0], parts[1], parts[2], ""), nil
+	case 2: // OWNER/REPO
 		return New(parts[0], parts[1]), nil
 	default:
 		return nil, fmt.Errorf(`expected the "[HOST/]OWNER/[NAMESPACE/]REPO" format, got %q`, nwo)
@@ -134,11 +183,14 @@ func FromURL(u *url.URL) (Interface, error) {
 		return nil, fmt.Errorf("no hostname detected")
 	}
 
-	parts := strings.SplitN(strings.Trim(u.Path, "/"), "/", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid path: %s", u.Path)
+	parts := strings.SplitN(strings.Trim(u.Path, "/"), "/", 4)
+	if len(parts) == 2 {
+		return NewWithHost(parts[0], strings.TrimSuffix(parts[1], ".git"), u.Hostname()), nil
 	}
-	return NewWithHost(parts[0], strings.TrimSuffix(parts[1], ".git"), u.Hostname()), nil
+	if len(parts) == 3 {
+		return NewWithGroup(parts[0], parts[1], strings.TrimSuffix(parts[2], ".git"), u.Hostname()), nil
+	}
+	return nil, fmt.Errorf("invalid path: %s", u.Path)
 }
 
 func normalizeHostname(h string) string {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -150,3 +150,18 @@ func CommonElementsInStringSlice(s1 []string, s2 []string) (arr []string) {
 	}
 	return arr
 }
+
+// isValidUrl tests a string to determine if it is a well-structured url or not.
+func IsValidURL(toTest string) bool {
+	_, err := url.ParseRequestURI(toTest)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.Parse(toTest)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
**Description**

1. Ensures repo override supports HOST/GROUP/NAMESPACE/REPO.

2. **Support for GROUP/NAMESPACE/REPO**

    First, checks if the first part matches the default instance host (i.e. gitlab.com) or the overridden default host (mostly from the GITLAB_HOST env variable).

    Dots (.) are allowed in group names by GitLab. So we check if the first part contains a dot.
However, it could be that the user is specifying a hostname but we can't be sure of that. So we check in the list of authenticated hosts and see if it matches any. if not, we assume it is a group name that contains a dot.

    if the first part is not a valid URL and does not match an authenticated hostname then we assume it is in the format GROUP/NAMESPACE/REPO

3. Removes support for project ID
4. Use PersistentPreRunE instead of PersistentPreRun to ensure errors are printed

**Related Issue**
Closes #589 
