### PR TITLE
Add prompt to git init on repo create. Fixes #569

### DIFF
--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -210,7 +210,7 @@ func initGit() error {
 		return nil
 	}
 	var doInit bool
-	err := prompt.Confirm(&doInit, fmt.Sprintf("Directory not git initialized. Run `git init`?"), true)
+	err := prompt.Confirm(&doInit, "Directory not git initialized. Run `git init`?", true)
 	if err != nil || !doInit {
 		return err
 	}

--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -67,6 +67,12 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 		namespace   string
 	)
 	c := f.IO.Color()
+
+	err = initGit()
+	if err != nil {
+		return err
+	}
+
 	if len(args) == 1 {
 		projectPath = args[0]
 		if strings.Contains(projectPath, "/") {
@@ -197,6 +203,22 @@ func runCreateProject(cmd *cobra.Command, args []string, f *cmdutils.Factory) er
 		return fmt.Errorf("error creating project: %v", err)
 	}
 	return err
+}
+
+func initGit() error {
+	if stat, err := os.Stat(".git"); err == nil && stat.IsDir() {
+		return nil
+	}
+	var doInit bool
+	err := prompt.Confirm(&doInit, fmt.Sprintf("Directory not git initialized. Run `git init`?"), true)
+	if err != nil || !doInit {
+		return err
+	}
+
+	gitInit := git.GitCommand("init")
+	gitInit.Stdout = os.Stdout
+	gitInit.Stderr = os.Stderr
+	return run.PrepareCmd(gitInit).Run()
 }
 
 func initialiseRepo(projectPath, remoteURL string) error {


### PR DESCRIPTION
**Description**
Adds a prompt to run `git init` if the directory is not initialized before running `glab repo create`.

**Related Issue**
Resolves #569 

**How Has This Been Tested?**
- Created an empty directory without running `git init` and running `glab repo create` directly. -> Prompt for git init shown
- Created an empty directory and ran `git init` before running `glab repo create`. -> No prompt shown

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
