### PR TITLE
fix(issue): Open issue web view instantly if, URL provided

### DIFF
--- a/commands/issue/issueutils/utils.go
+++ b/commands/issue/issueutils/utils.go
@@ -98,7 +98,7 @@ func IssuesFromArgs(apiClient *gitlab.Client, baseRepoFn func() (glrepo.Interfac
 }
 
 func IssueFromArg(apiClient *gitlab.Client, baseRepoFn func() (glrepo.Interface, error), arg string) (*gitlab.Issue, glrepo.Interface, error) {
-	issueIID, baseRepo := issueMetadataFromURL(arg)
+	issueIID, baseRepo := IssueMetadataFromURL(arg)
 	if issueIID == 0 {
 		var err error
 		issueIID, err = strconv.Atoi(strings.TrimPrefix(arg, "#"))
@@ -135,7 +135,7 @@ func IssueFromArg(apiClient *gitlab.Client, baseRepoFn func() (glrepo.Interface,
 var issueURLPersonalRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/issues/(\d+)`)
 var issueURLGroupRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/([^/]+)/issues/(\d+)`)
 
-func issueMetadataFromURL(s string) (int, glrepo.Interface) {
+func IssueMetadataFromURL(s string) (int, glrepo.Interface) {
 	u, err := url.Parse(s)
 	if err != nil {
 		return 0, nil


### PR DESCRIPTION
**Description**
When opening issue from URL, we should skip all the API calls, and just instantly open up.


**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #556

Note: Issue mentions the same thing for `mr` command, but that command simply doesn't open URLs to begin with. That should be implemented on it's own issue.

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Before :
```sh
glab issue view --web https://gitlab.com/smth/backend/-/issues/2  0.13s user 0.05s system 18% cpu 0.949 total
```
Now:
```sh
glab issue view --web https://gitlab.com/smth/backend/-/issues/2  0.07s user 0.03s system 68% cpu 0.146 total
```
**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
