### PR TITLE
Revert "Add config-git descriptive interface reference "

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ brew upgrade glab
 Make sure you have snap installed on your Linux Distro (https://snapcraft.io/docs/installing-snapd).
 1. `sudo snap install --edge glab`
 1. `sudo snap connect glab:ssh-keys` to grant ssh access
-1. `sudo snap connect glab:config-git` to grant read access to `/etc/gitconfig`. See https://github.com/profclems/glab/issues/597
 
 #### Arch Linux
 `glab` is available through the [gitlab-glab-bin](https://aur.archlinux.org/packages/gitlab-glab-bin/) package on the AUR or download and install an archive from the [releases page](https://github.com/profclems/glab/releases/latest). Arch Linux also supports [snap](https://snapcraft.io/docs/installing-snap-on-arch-linux).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,11 +35,6 @@ parts:
       LDFLAGS='' make -j2
       cp bin/glab $SNAPCRAFT_PART_INSTALL/
       bin/glab completion -s bash > $SNAPCRAFT_PART_INSTALL/completion.sh
-plugs:
-  config-git:
-    interface: system-files
-    read:
-    - /etc/gitconfig
 apps:
   glab:
     command: glab
@@ -49,7 +44,6 @@ apps:
     - network-bind
     - desktop
     - ssh-keys
-    - config-git
     completer: completion.sh
     environment:
       GIT_EDITOR: nano


### PR DESCRIPTION
Reverts profclems/glab#599

Snap is unable to build the package currently due to some restrictions:
```
Version 1.14.0-43-gb2daa17 (1053) upload for glab to the Snap Store has been rejected.

The reviewer provided the following feedback:

Use of the system-files interface is reserved for vetted publishers. If your snap legitimately requires this access, please make a request in the forum using the 'store-requests' category (https://forum.snapcraft.io/), or if you would prefer to keep this private, the 'sensitive' category.

To check review details, go to https://dashboard.snapcraft.io/snaps/glab/revisions/1053/review/


Upload status: Rejected
```