### PR TITLE
fix(commands/mr/close): fix color used for a MR that was just closed

### DIFF
--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -52,6 +52,10 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 				if err != nil {
 					return err
 				}
+				// Update the value of the merge request to closed so that mrutils.DisplayMR
+				// prints it as red
+				mr.State = "closed"
+
 				fmt.Fprintf(f.IO.StdOut, "%s Closed Merge request !%d\n", c.RedCheck(), mr.IID)
 				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr))
 			}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
this changes the 'State' of the MR after closing it successfully, so
that the later call to mrutils.DisplayMR which calls mrutils.MRState
returns the red color

Before it prints green because `mr` is still open as far as `glab` is concerned, we change it to `closed` so that it will print in red.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
