### PR TITLE
allow more than one merge request to be defined for certain `mr` commands

### DIFF
--- a/commands/mr/approve/mr_approve.go
+++ b/commands/mr/approve/mr_approve.go
@@ -18,6 +18,7 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 		Long:  ``,
 		Example: heredoc.Doc(`
 			$ glab mr approve 235
+			$ glab mr approve branch-1
 			$ glab mr approve    # Finds open merge request from current branch
 		`),
 		Args: cobra.MaximumNArgs(1),

--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -17,9 +17,9 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 		Use:   "close [<id> | <branch>]",
 		Short: `Close merge requests`,
 		Long:  ``,
-		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`
 			$ glab mr close 1
+			$ glab mr close 1 2 3 4  # close multiple branches at once
 			$ glab mr close  # use checked out branch
 			$ glab mr close branch
 			$ glab mr close username:branch

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -16,10 +16,11 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		Use:     "delete [<id> | <branch>]",
 		Short:   `Delete merge requests`,
 		Long:    ``,
-		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"del"},
 		Example: heredoc.Doc(`
 			$ glab mr delete 123
+			$ glab mr delete 123 branch-name 789  # close multiple branches
+			$ glab mr delete 1,2,branch-related-to-mr-3,4,5  # close MRs !1,!2,!3,!4,!5
 			$ glab mr del 123
 			$ glab mr delete branch
 		`),

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -152,8 +152,6 @@ func MRFromArgsWithOpts(f *cmdutils.Factory, args []string, opts *gitlab.GetMerg
 		}
 		mrID = mr.IID
 	}
-	// fetching multiple MRs does not return many major params in the payload
-	// so we fetch again using the single mr endpoint
 	mr, err = api.GetMR(apiClient, baseRepo.FullName(), mrID, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get merge request %d: %w", mrID, err)

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -3,6 +3,7 @@ package reopen
 import (
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/commands/mr/mrutils"
@@ -13,10 +14,14 @@ import (
 
 func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 	var mrReopenCmd = &cobra.Command{
-		Use:     "reopen [<id> | <branch>]",
-		Short:   `Reopen merge requests`,
-		Long:    ``,
-		Args:    cobra.MaximumNArgs(1),
+		Use:   "reopen [<id>... | <branch>...]",
+		Short: `Reopen merge requests`,
+		Example: heredoc.Doc(`
+			$ glab mr reopen 123
+			$ glab mr reopen 123 456 789
+			$ glab mr reopen branch-1 branch-2
+			$ glab mr reopen  # use checked out branch
+		`),
 		Aliases: []string{"open"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := f.IO.Color()


### PR DESCRIPTION
**Description**
Certain commands from `mr` now support passing multiple merge request via multiple args like:

```console
foo@bar:~$ glab mr close 1 branch-that-maps-to-mr-2 3
[closes MRs !1 !2 !3]
```

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by approving multiple merge requests and then revoking them on gitlab.alpinelinux.org

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
