### PR TITLE
Draft: allow searching MRs by a state when it makes sense

### DIFF
--- a/commands/mr/approve/mr_approve.go
+++ b/commands/mr/approve/mr_approve.go
@@ -32,7 +32,7 @@ func NewCmdApprove(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "opened")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/approvers/mr_approvers.go
+++ b/commands/mr/approvers/mr_approvers.go
@@ -26,7 +26,7 @@ func NewCmdApprovers(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "opened")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/checkout/mr_checkout.go
+++ b/commands/mr/checkout/mr_checkout.go
@@ -66,7 +66,7 @@ func NewCmdCheckout(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -33,7 +33,7 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "opened")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/delete/mr_delete.go
+++ b/commands/mr/delete/mr_delete.go
@@ -31,7 +31,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/diff/diff.go
+++ b/commands/mr/diff/diff.go
@@ -79,7 +79,7 @@ func diffRun(opts *DiffOptions) error {
 	if err != nil {
 		return err
 	}
-	mr, baseRepo, err := mrutils.MRFromArgs(opts.factory, opts.Args)
+	mr, baseRepo, err := mrutils.MRFromArgs(opts.factory, opts.Args, "any")
 	if err != nil {
 		return err
 	}

--- a/commands/mr/issues/mr_issues.go
+++ b/commands/mr/issues/mr_issues.go
@@ -34,7 +34,7 @@ func NewCmdIssues(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/merge/mr_merge.go
+++ b/commands/mr/merge/mr_merge.go
@@ -33,7 +33,7 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "opened")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -173,7 +173,7 @@ func MRsFromArgs(f *cmdutils.Factory, args []string, state string) ([]*gitlab.Me
 		}
 		if len(arrIDs) <= 1 {
 			// If there are no args then try to auto-detect from the branch name
-			mr, baseRepo, err := MRFromArgs(f, args)
+			mr, baseRepo, err := MRFromArgs(f, args, state)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -112,12 +112,17 @@ func DisplayAllMRs(c *iostreams.ColorPalette, mrs []*gitlab.MergeRequest, projec
 }
 
 //MRFromArgs is wrapper around MRFromArgsWithOpts without any custom options
-func MRFromArgs(f *cmdutils.Factory, args []string) (*gitlab.MergeRequest, glrepo.Interface, error) {
-	return MRFromArgsWithOpts(f, args, &gitlab.GetMergeRequestsOptions{})
+func MRFromArgs(f *cmdutils.Factory, args []string, state string) (*gitlab.MergeRequest, glrepo.Interface, error) {
+	return MRFromArgsWithOpts(f, args, &gitlab.GetMergeRequestsOptions{}, state)
 }
 
 //MRFromArgsWithOpts gets MR with custom request options passed down to it
-func MRFromArgsWithOpts(f *cmdutils.Factory, args []string, opts *gitlab.GetMergeRequestsOptions) (*gitlab.MergeRequest, glrepo.Interface, error) {
+func MRFromArgsWithOpts(
+	f *cmdutils.Factory,
+	args []string,
+	opts *gitlab.GetMergeRequestsOptions,
+	state string,
+) (*gitlab.MergeRequest, glrepo.Interface, error) {
 	var mrID int
 	var mr *gitlab.MergeRequest
 
@@ -146,7 +151,7 @@ func MRFromArgsWithOpts(f *cmdutils.Factory, args []string, opts *gitlab.GetMerg
 	}
 
 	if mrID == 0 {
-		mr, err = GetOpenMRForBranch(apiClient, baseRepo, branch)
+		mr, err = getMRForBranch(apiClient, baseRepo, branch, state)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -160,7 +165,7 @@ func MRFromArgsWithOpts(f *cmdutils.Factory, args []string, opts *gitlab.GetMerg
 	return mr, baseRepo, nil
 }
 
-func MRsFromArgs(f *cmdutils.Factory, args []string) ([]*gitlab.MergeRequest, glrepo.Interface, error) {
+func MRsFromArgs(f *cmdutils.Factory, args []string, state string) ([]*gitlab.MergeRequest, glrepo.Interface, error) {
 	if len(args) <= 1 {
 		var arrIDs []string
 		if len(args) == 1 {
@@ -189,7 +194,7 @@ func MRsFromArgs(f *cmdutils.Factory, args []string) ([]*gitlab.MergeRequest, gl
 		errGroup.Go(func() error {
 			// fetching multiple MRs does not return many major params in the payload
 			// so we fetch again using the single mr endpoint
-			mr, _, err := MRFromArgs(f, []string{arg})
+			mr, _, err := MRFromArgs(f, []string{arg}, state)
 			if err != nil {
 				return err
 			}
@@ -204,7 +209,7 @@ func MRsFromArgs(f *cmdutils.Factory, args []string) ([]*gitlab.MergeRequest, gl
 
 }
 
-var GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
+var getMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string, state string) (*gitlab.MergeRequest, error) {
 	currentBranch := arg // Assume the user is using only 'branch', not 'OWNER:branch'
 	var owner string
 
@@ -217,10 +222,18 @@ var GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interfac
 		currentBranch = t[1]
 	}
 
-	mrs, err := api.ListMRs(apiClient, baseRepo.FullName(), &gitlab.ListProjectMergeRequestsOptions{
+	opts := gitlab.ListProjectMergeRequestsOptions{
 		SourceBranch: gitlab.String(currentBranch),
-		State:        gitlab.String("opened"),
-	})
+	}
+
+	// Set the state value if it is not empty, if it is empty then it will look at all possible
+	// values, 'any' is also a descriptive keyword used in the source code that is equivalent to
+	// passing nothing on
+	if state != "" && state != "any" {
+		opts.State = gitlab.String(state)
+	}
+
+	mrs, err := api.ListMRs(apiClient, baseRepo.FullName(), &opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get open merge request for %q: %w", currentBranch, err)
 	}

--- a/commands/mr/note/mr_note_create.go
+++ b/commands/mr/note/mr_note_create.go
@@ -26,7 +26,7 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/rebase/mr_rebase.go
+++ b/commands/mr/rebase/mr_rebase.go
@@ -32,7 +32,7 @@ func NewCmdRebase(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "opened")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -30,7 +30,7 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "closed")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/revoke/mr_revoke.go
+++ b/commands/mr/revoke/mr_revoke.go
@@ -33,7 +33,7 @@ func NewCmdRevoke(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "opened")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/subscribe/mr_subscribe.go
+++ b/commands/mr/subscribe/mr_subscribe.go
@@ -32,7 +32,7 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/todo/mr_todo.go
+++ b/commands/mr/todo/mr_todo.go
@@ -27,7 +27,7 @@ func NewCmdTodo(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/unsubscribe/mr_unsubscribe.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe.go
@@ -32,7 +32,7 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mrs, repo, err := mrutils.MRsFromArgs(f, args)
+			mrs, repo, err := mrutils.MRsFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -58,7 +58,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			mr, repo, err := mrutils.MRFromArgs(f, args)
+			mr, repo, err := mrutils.MRFromArgs(f, args, "any")
 			if err != nil {
 				return err
 			}

--- a/commands/mr/view/mr_view.go
+++ b/commands/mr/view/mr_view.go
@@ -47,7 +47,7 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				IncludeDivergedCommitsCount: gitlab.Bool(true),
 				RenderHTML:                  gitlab.Bool(true),
 				IncludeRebaseInProgress:     gitlab.Bool(true),
-			})
+			}, "any")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This allows us to filter branch names by their state, allowing us to do certain things:

- Search only "opened" merge requests for `mr close`, `mr merge`, `mr rebase` and others
- Search only "closed" merge requests for `mr reopen`
- Search merge requests in any state if they do not have a compelling reason to be able to restrict the state

This change will increase the amount of prompt that `glab` does, if lots of people in your project submits merge requests via the name `master` or `main` (or whatever people use these days) and you want to interact with a specific one you will be endlessly prompted.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #620 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See screenshots

**Screenshots (if appropriate):**
![image](https://user-images.githubusercontent.com/30738253/108291028-50c07c80-7170-11eb-9419-167d926e96b8.png)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
