### PR TITLE
fix(mr): Use default branch on mr create

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -677,18 +677,6 @@ func repoRemote(labClient *gitlab.Client, opts *CreateOpts, repo glrepo.Interfac
 }
 
 func getTargetBranch(baseRepoRemote *glrepo.Remote, sourceBranch string) string {
-	branchConfig := git.ReadBranchConfig(sourceBranch)
-	// Check if our given git.BranchConfig{} is not empty, otherwise it will fail
-	// if try to access the fields, this is needed because the ReadBranchConfig
-	// function can return an empty struct
-	if branchConfig != (git.BranchConfig{}) {
-		if branchConfig.RemoteName != "" && branchConfig.MergeRef != "" {
-			// The MergeRef takes the form of refs/head/BRANCH_NAME, so split it
-			// by '/' and get the last element
-			branchName := strings.Split(branchConfig.MergeRef, "/")
-			return branchName[len(branchName)-1]
-		}
-	}
 	br, _ := git.GetDefaultBranch(baseRepoRemote.PushURL.String())
 	// we ignore the error since git.GetDefaultBranch returns master and an error
 	// if the default branch cannot be determined

--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -143,7 +143,6 @@ func TestNewCmdCreate_tty(t *testing.T) {
 
 	cs, csTeardown := test.InitCmdStubber()
 	defer csTeardown()
-	cs.Stub("")
 	cs.Stub("HEAD branch: master\n")
 	cs.Stub(heredoc.Doc(`
 		deadbeef HEAD


### PR DESCRIPTION
**Description**
When branch is pushed to remote, the target branch came out to be the
remote traking branch, which would become target == source. That can't
work so this needs to be removed.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #619

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
