### PR TITLE
fix(mr): Look for all MRs with `mr` commands

### DIFF
--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -146,7 +146,7 @@ func MRFromArgsWithOpts(f *cmdutils.Factory, args []string, opts *gitlab.GetMerg
 	}
 
 	if mrID == 0 {
-		mr, err = GetOpenMRForBranch(apiClient, baseRepo, branch)
+		mr, err = GetMRForBranch(apiClient, baseRepo, branch)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -204,7 +204,7 @@ func MRsFromArgs(f *cmdutils.Factory, args []string) ([]*gitlab.MergeRequest, gl
 
 }
 
-var GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
+var GetMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
 	currentBranch := arg // Assume the user is using only 'branch', not 'OWNER:branch'
 	var owner string
 
@@ -219,14 +219,13 @@ var GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interfac
 
 	mrs, err := api.ListMRs(apiClient, baseRepo.FullName(), &gitlab.ListProjectMergeRequestsOptions{
 		SourceBranch: gitlab.String(currentBranch),
-		State:        gitlab.String("opened"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get open merge request for %q: %w", currentBranch, err)
 	}
 
 	if len(mrs) == 0 {
-		return nil, fmt.Errorf("no open merge request available for %q", currentBranch)
+		return nil, fmt.Errorf("no merge request available for %q", currentBranch)
 	}
 
 	// The user gave us an 'OWNER:' so try to match the merge request with it
@@ -238,7 +237,7 @@ var GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interfac
 			}
 		}
 		// No match, error out, tell the user which branch and which username we looked for
-		return nil, fmt.Errorf("no open merge request available for %q owned by @%s", currentBranch, owner)
+		return nil, fmt.Errorf("no merge request available for %q owned by @%s", currentBranch, owner)
 	}
 
 	// This is done after the 'OWNER:' check because we don't want to give the wrong MR

--- a/commands/mr/mrutils/mrutils_test.go
+++ b/commands/mr/mrutils/mrutils_test.go
@@ -189,7 +189,7 @@ func Test_MRCheckErrors(t *testing.T) {
 	})
 }
 
-func Test_GetOpenMRForBranchFails(t *testing.T) {
+func Test_GetMRForBranchFails(t *testing.T) {
 	baseRepo := glrepo.NewWithHost("foo", "bar", "gitlab.com")
 
 	t.Run("API-call-failed", func(t *testing.T) {
@@ -197,7 +197,7 @@ func Test_GetOpenMRForBranchFails(t *testing.T) {
 			return nil, errors.New("API call failed")
 		}
 
-		got, err := GetOpenMRForBranch(&gitlab.Client{}, baseRepo, "foo")
+		got, err := GetMRForBranch(&gitlab.Client{}, baseRepo, "foo")
 		assert.Nil(t, got)
 		assert.EqualError(t, err, `failed to get open merge request for "foo": API call failed`)
 	})
@@ -207,9 +207,9 @@ func Test_GetOpenMRForBranchFails(t *testing.T) {
 			return []*gitlab.MergeRequest{}, nil
 		}
 
-		got, err := GetOpenMRForBranch(&gitlab.Client{}, baseRepo, "foo")
+		got, err := GetMRForBranch(&gitlab.Client{}, baseRepo, "foo")
 		assert.Nil(t, got)
-		assert.EqualError(t, err, `no open merge request available for "foo"`)
+		assert.EqualError(t, err, `no merge request available for "foo"`)
 	})
 
 	t.Run("owner-no-match", func(t *testing.T) {
@@ -230,13 +230,13 @@ func Test_GetOpenMRForBranchFails(t *testing.T) {
 			}, nil
 		}
 
-		got, err := GetOpenMRForBranch(&gitlab.Client{}, baseRepo, "zemzale:foo")
+		got, err := GetMRForBranch(&gitlab.Client{}, baseRepo, "zemzale:foo")
 		assert.Nil(t, got)
-		assert.EqualError(t, err, `no open merge request available for "foo" owned by @zemzale`)
+		assert.EqualError(t, err, `no merge request available for "foo" owned by @zemzale`)
 	})
 }
 
-func Test_GetOpenMRForBranch(t *testing.T) {
+func Test_GetMRForBranch(t *testing.T) {
 	baseRepo := glrepo.NewWithHost("foo", "bar", "gitlab.com")
 
 	testCases := []struct {
@@ -293,7 +293,7 @@ func Test_GetOpenMRForBranch(t *testing.T) {
 				return tC.mrs, nil
 			}
 
-			got, err := GetOpenMRForBranch(&gitlab.Client{}, baseRepo, tC.input)
+			got, err := GetMRForBranch(&gitlab.Client{}, baseRepo, tC.input)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tC.expect.IID, got.IID)
@@ -302,7 +302,7 @@ func Test_GetOpenMRForBranch(t *testing.T) {
 	}
 }
 
-func Test_GetOpenMRForBranchPrompt(t *testing.T) {
+func Test_GetMRForBranchPrompt(t *testing.T) {
 	baseRepo := glrepo.NewWithHost("foo", "bar", "gitlab.com")
 
 	api.ListMRs = func(_ *gitlab.Client, _ interface{}, _ *gitlab.ListProjectMergeRequestsOptions) ([]*gitlab.MergeRequest, error) {
@@ -333,7 +333,7 @@ func Test_GetOpenMRForBranchPrompt(t *testing.T) {
 			},
 		})
 
-		got, err := GetOpenMRForBranch(&gitlab.Client{}, baseRepo, "foo")
+		got, err := GetMRForBranch(&gitlab.Client{}, baseRepo, "foo")
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, got.IID)
@@ -351,7 +351,7 @@ func Test_GetOpenMRForBranchPrompt(t *testing.T) {
 			},
 		})
 
-		got, err := GetOpenMRForBranch(&gitlab.Client{}, baseRepo, "foo")
+		got, err := GetMRForBranch(&gitlab.Client{}, baseRepo, "foo")
 		assert.Nil(t, got)
 		assert.EqualError(t, err, "a merge request must be picked: prompt failed")
 	})
@@ -394,7 +394,7 @@ func Test_MRFromArgsWithOpts(t *testing.T) {
 		t.Run("via-name", func(t *testing.T) {
 			f := *f
 
-			GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
+			GetMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
 				return &gitlab.MergeRequest{
 					IID:          2,
 					Title:        "test mr",
@@ -468,7 +468,7 @@ func Test_MRFromArgsWithOpts(t *testing.T) {
 		t.Run("invalid-name", func(t *testing.T) {
 			f := *f
 
-			GetOpenMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
+			GetMRForBranch = func(apiClient *gitlab.Client, baseRepo glrepo.Interface, arg string) (*gitlab.MergeRequest, error) {
 				return nil, fmt.Errorf("no merge requests from branch %q", arg)
 			}
 

--- a/commands/mr/rebase/mr_rebase.go
+++ b/commands/mr/rebase/mr_rebase.go
@@ -37,6 +37,12 @@ func NewCmdRebase(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
+			if err := mrutils.MRCheckErrors(mr, mrutils.MRCheckErrOptions{
+				Closed: true,
+			}); err != nil {
+				return err
+			}
+
 			fmt.Fprintln(f.IO.StdOut, "- Sending request...")
 			err = api.RebaseMR(apiClient, repo.FullName(), mr.IID)
 			if err != nil {


### PR DESCRIPTION
**Description**

This fixes issues with `mr reopen <branch>`

When looking for MR from arguments, we where looking only for open merge
requests. 

In reality it didn't allow any commands to run on closed MRs using
branch names.

The only thing that is needed to consider that some commands can't run
on closed MRs like rebase or merge. There were checks for that in some
places, but not other.


**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #620

**How Has This Been Tested?**
Went through all `mr` commands. The only thing that failed with a closed branch was rebase, which I fixed.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
