### PR TITLE
Override survey's choice of color for default values

### DIFF
--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -3,6 +3,7 @@ package iostreams
 import (
 	"io"
 	"os"
+	"strings"
 
 	"github.com/mattn/go-colorable"
 	"github.com/mgutz/ansi"
@@ -74,4 +75,16 @@ func isColorEnabled() bool {
 		checkedNoColor = true
 	}
 	return _isColorEnabled
+}
+
+func Is256ColorSupported() bool {
+	term := os.Getenv("TERM")
+	colorterm := os.Getenv("COLORTERM")
+
+	return strings.Contains(term, "256") ||
+		strings.Contains(term, "24bit") ||
+		strings.Contains(term, "truecolor") ||
+		strings.Contains(colorterm, "256") ||
+		strings.Contains(colorterm, "24bit") ||
+		strings.Contains(colorterm, "truecolor")
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -23,6 +23,8 @@ type IOStreams struct {
 	IsInTTY        bool //stdin is a tty
 	promptDisabled bool //disable prompting for input
 
+	is256ColorEnabled bool
+
 	pagerCommand string
 	pagerProcess *os.Process
 
@@ -41,12 +43,13 @@ func Init() *IOStreams {
 	}
 
 	ioStream := &IOStreams{
-		In:           os.Stdin,
-		StdOut:       NewColorable(os.Stdout),
-		StdErr:       NewColorable(os.Stderr),
-		pagerCommand: pagerCommand,
-		IsaTTY:       stdoutIsTTY,
-		IsErrTTY:     stderrIsTTY,
+		In:                os.Stdin,
+		StdOut:            NewColorable(os.Stdout),
+		StdErr:            NewColorable(os.Stderr),
+		pagerCommand:      pagerCommand,
+		IsaTTY:            stdoutIsTTY,
+		IsErrTTY:          stderrIsTTY,
+		is256ColorEnabled: Is256ColorSupported(),
 	}
 
 	if stdin, ok := ioStream.In.(*os.File); ok {
@@ -67,6 +70,10 @@ func (s *IOStreams) PromptEnabled() bool {
 
 func (s *IOStreams) ColorEnabled() bool {
 	return isColorEnabled() && s.IsaTTY && s.IsErrTTY
+}
+
+func (s *IOStreams) Is256ColorSupported() bool {
+	return s.is256ColorEnabled
 }
 
 func (s *IOStreams) SetPrompt(promptDisabled string) {
@@ -126,7 +133,7 @@ func (s *IOStreams) StopPager() {
 		return
 	}
 
-	s.StdOut.(io.ReadCloser).Close()
+	_ = s.StdOut.(io.ReadCloser).Close()
 	_, _ = s.pagerProcess.Wait()
 	s.pagerProcess = nil
 }


### PR DESCRIPTION
For default values for e.g.  prompts, Survey uses the literal white color, which makes no sense on dark terminals and is literally invisible on light backgrounds.

This overrides Survey to output a gray color for 256-color terminals and default for basic terminals.
