### PR TITLE
fix(commands/api): replace `:id` placeholder with project ID

### DIFF
--- a/commands/api/api.go
+++ b/commands/api/api.go
@@ -357,7 +357,15 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 
 	filled := placeholderRE.ReplaceAllStringFunc(value, func(m string) string {
 		switch m {
-		case ":group/:namespace/:repo", ":fullpath", ":id":
+		case ":id":
+			h, _ := opts.HttpClient()
+			baseProject, e := api.GetProject(h, baseRepo.FullName())
+			if e == nil && baseProject != nil {
+				return string(rune(baseProject.ID))
+			}
+			err = e
+			return ""
+		case ":group/:namespace/:repo", ":fullpath":
 			return url.PathEscape(baseRepo.FullName())
 		case ":namespace/:repo":
 			return url.PathEscape(baseRepo.RepoNamespace() + "/" + baseRepo.RepoName())


### PR DESCRIPTION
**Description**
The `:id` placeholder in the api command is replaced by the project ID which makes sense instead of the URL encoded path.

**Related Issue**
Closes #657

**How Has This Been Tested?**

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
