### PR TITLE
fix(board): Don't display closed issues in columns

### DIFF
--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -76,19 +76,12 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			}
 
 			root := tview.NewFlex()
-			/*
-				AddItem(tview.NewBox().SetBorder(true).SetTitle("Left (1/2 x width of Top)"), 0, 1, false).
-				AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-					AddItem(tview.NewBox().SetBorder(true).SetTitle("Top"), 0, 1, false).
-					AddItem(tview.NewBox().SetBorder(true).SetTitle("Middle (3 x height of Top)"), 0, 3, false).
-					AddItem(tview.NewBox().SetBorder(true).SetTitle("Bottom (5 rows)"), 5, 1, false), 0, 2, false).
-				AddItem(tview.NewBox().SetBorder(true).SetTitle("Right (20 cols)"), 20, 1, false)
-			*/
 			var issues []*gitlab.Issue
 			// TODO: add `open` and `closed` board list. Both are not returned in the List API response payload
 			for _, list := range boadLists {
 				var boardIssues string
 				issues, err = api.ListIssues(apiClient, repo.FullName(), &gitlab.ListProjectIssuesOptions{
+					State:  gitlab.String("opened"),
 					Labels: gitlab.Labels{list.Label.Name},
 				})
 				if err != nil {
@@ -96,8 +89,6 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				}
 				bx := tview.NewTextView().SetDynamicColors(true)
 				for _, issue := range issues {
-					//label, _ := issue.Labels.MarshalJSON()
-					//labelPrint := strings.Split(string(label), ", ")
 					var labelPrint string
 					var assignee string
 					totalLables := len(issue.Labels)


### PR DESCRIPTION
**Description**
In web UI issues that are closed are moved into their own column. They
shouldn't belong in the main columns, if they are closed.

There is the thing that issues that don't belong in any of user
made boards, should be in their own boards.

Issue for adding the extra columns #665

**Related Issue**
Resolves #664

**How Has This Been Tested?**
Tested localy with board that showed closed issues, and now doesn't.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
