### PR TITLE
Fix: Allow for override of repo using OWNER/REPO

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -45,9 +45,7 @@ func main() {
 
 	cmdFactory := cmdutils.NewFactory()
 
-	if glHostFromEnv := config.GetFromEnv("host"); glHostFromEnv != "" {
-		glinstance.OverrideDefault(glHostFromEnv)
-	}
+	maybeOverrideDefaultHost(cmdFactory)
 
 	if !cmdFactory.IO.ColorEnabled() {
 		surveyCore.DisableColor = true
@@ -177,5 +175,15 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 			_, _ = fmt.Fprintln(out)
 		}
 		_, _ = fmt.Fprintln(out, cmd.UsageString())
+	}
+}
+
+func maybeOverrideDefaultHost(f *cmdutils.Factory) {
+	baseRepo, err := f.BaseRepo()
+	if err == nil {
+		glinstance.OverrideDefault(baseRepo.RepoHost())
+	}
+	if glHostFromEnv := config.GetFromEnv("host"); glHostFromEnv != "" {
+		glinstance.OverrideDefault(glHostFromEnv)
 	}
 }


### PR DESCRIPTION
**Description**
When using flags/commands that override the repo, but don't supply
hostname, we allways fallback to `gitlab.com`. This is a problem for
commands like `mr checkout 12 -R OWNER/REPO` that should use API host
`self-hosted`, but actually use `gitlab.com`.

Now we override default host, from the base repo, if one is found.
Environment values still override repo host.

**Related Issue**
Resolves #383

**How Has This Been Tested?**
Locally tried to checkout mr using `mr checkout 12 -R ONWER/REPO`, on self hosted instance and everything worked.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
