### PR TITLE
feat(commands/api): add a reviewer filter to the mr list command

### DIFF
--- a/api/merge_request.go
+++ b/api/merge_request.go
@@ -56,7 +56,7 @@ var ListMRs = func(client *gitlab.Client, projectID interface{}, opts *gitlab.Li
 	return mrs, nil
 }
 
-var ListMRsWithAssignees = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectMergeRequestsOptions, assigneeIds []int) ([]*gitlab.MergeRequest, error) {
+var ListMRsWithAssigneesOrReviewers = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectMergeRequestsOptions, assigneeIds []int, reviewerIds []int) ([]*gitlab.MergeRequest, error) {
 	if client == nil {
 		client = apiClient.Lab()
 	}
@@ -72,6 +72,15 @@ var ListMRsWithAssignees = func(client *gitlab.Client, projectID interface{}, op
 			return nil, err
 		}
 		mrs = append(mrs, assingeMrs...)
+	}
+	opts.AssigneeID = nil // reset because it's Assignee OR Reviewer
+	for _, id := range reviewerIds {
+		opts.ReviewerID = gitlab.Int(id)
+		reviewerMrs, err := ListMRs(client, projectID, opts)
+		if err != nil {
+			return nil, err
+		}
+		mrs = append(mrs, reviewerMrs...)
 	}
 	return mrs, nil
 }


### PR DESCRIPTION
**Description**
Currently, it's not possible to filter the merge requests list by its reviewers.
So, this MR adds a new optional parameter (`--reviewer`) to the `mr list` command to enable filtering merge requests by its reviewers.

Note: this implementation uses the same flow of assignee filtering and applies an OR operation between Assignee and Reviewer, so it does not break any previous behavior.

**Related Issue**
Delivers #680

**How Has This Been Tested?**
Locally tried to list merge requests for different combinations of parameters, on a self-hosted instance and everything worked. Some tested cases:

- ` mr list --reviewer=@me`
- ` mr list --reviewer=@me,OtherUserName`
- ` mr list --reviewer=@me --assignee=OtherUserName`

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
