### PR TITLE
Fix method not allowed when merging MR

### DIFF
--- a/commands/ci/status/status.go
+++ b/commands/ci/status/status.go
@@ -97,7 +97,7 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 						}
 						//fmt.Println(job.Tag)
 						if compact {
-							fmt.Fprintf(writer, "(%s) • %s [%s]\n", status, job.Name,job.Stage)
+							fmt.Fprintf(writer, "(%s) • %s [%s]\n", status, job.Name, job.Stage)
 						} else {
 							fmt.Fprintf(writer, "(%s) • %s\t%s\t\t%s\n", status, c.Gray(duration), job.Stage, job.Name)
 						}


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
When merging MR, the --when-pipeline-succeeds flag is by default set to true.
Due to that, if a project does not have any pipeline set, results in error `method not allowed`.

This PR fixes this issue by checking if the merge request has a pipeline set.
Also, on TTYs, users are prompted to confirm whether to merge when pipeline succeeds or not, if the MR has a pipeline set.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #674 
Resolves #268 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
