### PR TITLE
Fix segfault on ci list

### DIFF
--- a/commands/ci/ciutils/utils.go
+++ b/commands/ci/ciutils/utils.go
@@ -30,7 +30,11 @@ func DisplayMultiplePipelines(c *iostreams.ColorPalette, p []*gitlab.PipelineInf
 	if len(p) > 0 {
 
 		for _, pipeline := range p {
-			duration := utils.TimeToPrettyTimeAgo(*pipeline.CreatedAt)
+			duration := ""
+
+			if pipeline.CreatedAt != nil {
+				duration = c.Magenta("(" + utils.TimeToPrettyTimeAgo(*pipeline.CreatedAt) + ")")
+			}
 			var pipeState string
 			if pipeline.Status == "success" {
 				pipeState = c.Green(fmt.Sprintf("(%s) • #%d", pipeline.Status, pipeline.ID))
@@ -40,7 +44,7 @@ func DisplayMultiplePipelines(c *iostreams.ColorPalette, p []*gitlab.PipelineInf
 				pipeState = c.Gray(fmt.Sprintf("(%s) • #%d", pipeline.Status, pipeline.ID))
 			}
 
-			table.AddRow(pipeState, pipeline.Ref, c.Magenta("("+duration+")"))
+			table.AddRow(pipeState, pipeline.Ref, duration)
 		}
 
 		return table.Render()


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
For gitlab instances running on versions <= 11, the pipeline list api does not return the `created_at` field causing `glab` to panic.
This commit checks if the created_at field is available before using it

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #688 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
