### PR TITLE
feat(mr/view): show reviewers of the merge request

### DIFF
--- a/commands/mr/view/mr_view.go
+++ b/commands/mr/view/mr_view.go
@@ -116,6 +116,14 @@ func assigneesList(mr *gitlab.MergeRequest) string {
 	return strings.Trim(assignees, ", ")
 }
 
+func reviewersList(mr *gitlab.MergeRequest) string {
+	var reviewers string
+	for _, a := range mr.Reviewers {
+		reviewers += " " + a.Username + ","
+	}
+	return strings.Trim(reviewers, ", ")
+}
+
 func mrState(c *iostreams.ColorPalette, mr *gitlab.MergeRequest) (mrState string) {
 	if mr.State == "opened" {
 		mrState = c.Green("open")
@@ -155,6 +163,10 @@ func printTTYMRPreview(opts *ViewOpts, mr *gitlab.MergeRequest, notes []*gitlab.
 	if assignees := assigneesList(mr); assignees != "" {
 		fmt.Fprint(out, c.Bold("Assignees: "))
 		fmt.Fprintln(out, assignees)
+	}
+	if reviewers := reviewersList(mr); reviewers != "" {
+		fmt.Fprint(out, c.Bold("Reviewers: "))
+		fmt.Fprintln(out, reviewers)
 	}
 	if mr.Milestone != nil {
 		fmt.Fprint(out, c.Bold("Milestone: "))
@@ -228,6 +240,7 @@ func printTTYMRPreview(opts *ViewOpts, mr *gitlab.MergeRequest, notes []*gitlab.
 func printRawMRPreview(opts *ViewOpts, mr *gitlab.MergeRequest) error {
 	out := opts.IO.StdOut
 	assignees := assigneesList(mr)
+	reviewers := reviewersList(mr)
 	labels := labelsList(mr)
 
 	fmt.Fprintf(out, "title:\t%s\n", mr.Title)
@@ -235,6 +248,7 @@ func printRawMRPreview(opts *ViewOpts, mr *gitlab.MergeRequest) error {
 	fmt.Fprintf(out, "author:\t%s\n", mr.Author.Username)
 	fmt.Fprintf(out, "labels:\t%s\n", labels)
 	fmt.Fprintf(out, "assignees:\t%s\n", assignees)
+	fmt.Fprintf(out, "reviewers:\t%s\n", reviewers)
 	fmt.Fprintf(out, "comments:\t%d\n", mr.UserNotesCount)
 	if mr.Milestone != nil {
 		fmt.Fprintf(out, "milestone:\t%s\n", mr.Milestone.Title)

--- a/commands/mr/view/mr_view_test.go
+++ b/commands/mr/view/mr_view_test.go
@@ -73,6 +73,14 @@ hosts:
 					Username: "lisa",
 				},
 			},
+			Reviewers: []*gitlab.BasicUser{
+				{
+					Username: "lisa",
+				},
+				{
+					Username: "mona",
+				},
+			},
 			WebURL:         fmt.Sprintf("https://%s/%s/-/merge_requests/%d", repo.RepoHost(), repo.FullName(), mrID),
 			CreatedAt:      &timer,
 			UserNotesCount: 2,
@@ -189,6 +197,7 @@ func TestMRView(t *testing.T) {
 		expectedOutputs := []string{
 			`title:\tmrTitle`,
 			`assignees:\tmona, lisa`,
+			`reviewers:\tlisa, mona`,
 			`author:\tjdwick`,
 			`state:\topen`,
 			`comments:\t2`,


### PR DESCRIPTION
**Description**
It enables `mr view` to show list of reviewers for a merge request

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Delivers #692

**How Has This Been Tested?**
Added test case.

Locally tested with
`glab mr view`
`glab mr view <id>`
`glab mr view <branch>`

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
