### PR TITLE
feat(mr/view): update mr reviewers

### DIFF
--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -29,6 +29,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 			var err error
 			var actions []string
 			var ua *cmdutils.UserAssignments
+			var ur *cmdutils.UserAssignments
 			c := f.IO.Color()
 
 			if cmd.Flags().Changed("unassign") && cmd.Flags().Changed("assignee") {
@@ -46,6 +47,19 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				err = ua.VerifyAssignees()
 				if err != nil {
 					return &cmdutils.FlagError{Err: fmt.Errorf("--assignee: %w", err)}
+				}
+			}
+
+			if cmd.Flags().Changed("reviewer") {
+				givenReviewers, err := cmd.Flags().GetStringSlice("reviewer")
+				if err != nil {
+					return err
+				}
+				ur = cmdutils.ParseAssignees(givenReviewers)
+
+				err = ur.VerifyAssignees()
+				if err != nil {
+					return &cmdutils.FlagError{Err: fmt.Errorf("--reviewer: %w", err)}
 				}
 			}
 
@@ -158,6 +172,20 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				}
 			}
 
+			if ur != nil {
+				if len(ur.ToReplace) != 0 {
+					l.ReviewerIDs, actions, err = ur.UsersFromReplaces(apiClient, actions)
+					if err != nil {
+						return err
+					}
+				} else if len(ur.ToAdd) != 0 || len(ur.ToRemove) != 0 {
+					l.ReviewerIDs, actions, err = ur.UsersFromAddRemove(nil, mr.Reviewers, apiClient, actions)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
 			if removeSource, _ := cmd.Flags().GetBool("remove-source-branch"); removeSource {
 				actions = append(actions, "enabled removal of source branch on merge")
 				l.RemoveSourceBranch = gitlab.Bool(true)
@@ -189,6 +217,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().StringSliceP("label", "l", []string{}, "add labels")
 	mrUpdateCmd.Flags().StringSliceP("unlabel", "u", []string{}, "remove labels")
 	mrUpdateCmd.Flags().StringSliceP("assignee", "a", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing assignees, '+' to add, otherwise replace existing assignees with given users")
+	mrUpdateCmd.Flags().StringSliceP("reviewer", "", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing reviewers, '+' to add, otherwise replace existing reviewers with given users")
 	mrUpdateCmd.Flags().Bool("unassign", false, "unassign all users")
 	mrUpdateCmd.Flags().BoolP("remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -28,8 +28,8 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var actions []string
-			var ua *cmdutils.UserAssignments
-			var ur *cmdutils.UserAssignments
+			var ua *cmdutils.UserAssignments // assignees
+			var ur *cmdutils.UserAssignments // reviewers
 			c := f.IO.Color()
 
 			if cmd.Flags().Changed("unassign") && cmd.Flags().Changed("assignee") {
@@ -56,6 +56,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 					return err
 				}
 				ur = cmdutils.ParseAssignees(givenReviewers)
+				ur.AssignmentType = cmdutils.ReviewerAssignment
 
 				err = ur.VerifyAssignees()
 				if err != nil {
@@ -217,7 +218,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().StringSliceP("label", "l", []string{}, "add labels")
 	mrUpdateCmd.Flags().StringSliceP("unlabel", "u", []string{}, "remove labels")
 	mrUpdateCmd.Flags().StringSliceP("assignee", "a", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing assignees, '+' to add, otherwise replace existing assignees with given users")
-	mrUpdateCmd.Flags().StringSliceP("reviewer", "", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing reviewers, '+' to add, otherwise replace existing reviewers with given users")
+	mrUpdateCmd.Flags().StringSliceP("reviewer", "", []string{}, "request review from users by their usernames, prefix with '!' or '-' to remove from existing reviewers, '+' to add, otherwise replace existing reviewers with given users")
 	mrUpdateCmd.Flags().Bool("unassign", false, "unassign all users")
 	mrUpdateCmd.Flags().BoolP("remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")


### PR DESCRIPTION
**Description**
It allowes `mr update` to update reviewers with a new flag `--reviewer`. The behaviour of `--reviewer` is same as `--assignee` flag but instead it updates reviewers of the merge request.

Note: I have made the flag as `--reviewer` instead of `--reviewers` to keep consistency with `--assignee`

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #562 

**How Has This Been Tested?**
Locally tested with
`glab mr update --reviewer +name`
`glab mr update --reviewer -name`
`glab mr update --reviewer name`
`glab mr update --reviewer +name --assignee +name`

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
