### PR TITLE
fix(glrepo): Remove side effect from RemoteURL

### DIFF
--- a/internal/glrepo/repo.go
+++ b/internal/glrepo/repo.go
@@ -25,20 +25,24 @@ type RemoteArgs struct {
 // based on the user's git_protocol preference
 func RemoteURL(project *gitlab.Project, a *RemoteArgs) (string, error) {
 	if a.Protocol == "https" {
+		var (
+			username = "oauth2"
+			protocol = "https://"
+			url      = a.Url
+		)
 
-		if a.Username == "" {
-			a.Username = "oauth2"
+		if a.Username != "" {
+			username = a.Username
 		}
 
-		a.Protocol = "https://"
 		if strings.Contains(a.Url, "https://") {
-			a.Url = strings.TrimPrefix(a.Url, "https://")
-		} else if strings.HasPrefix(a.Url, "http://") {
-			a.Url = strings.TrimPrefix(a.Url, "http://")
-			a.Protocol = "http://"
+			url = strings.TrimPrefix(url, "https://")
+		} else if strings.HasPrefix(url, "http://") {
+			url = strings.TrimPrefix(url, "http://")
+			protocol = "http://"
 		}
 		return fmt.Sprintf("%s%s:%s@%s/%s.git",
-			a.Protocol, a.Username, a.Token, a.Url, project.PathWithNamespace), nil
+			protocol, username, a.Token, url, project.PathWithNamespace), nil
 	}
 	return project.SSHURLToRepo, nil
 }


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
RemoteURL was changing one if it's passed in variables. This introduced
problems with subsequent calls to the function, because member
`RemoteArgs.Protocol` was changed to from `https` to `https://`. This
made every other call to the function skip over the protocol and just
return ssh URL.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #710

**How Has This Been Tested?**
Localy tested and unit tests passed

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
