### PR TITLE
scriptability: Avoid truncating columns of tables/lists on non-TTYs

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -128,10 +128,12 @@ func main() {
 		}
 	}
 
-	// Override the default column separator of tableprinter
-	tableprinter.SetSeparator("  ")
+	// Override the default column separator of tableprinter to double spaces
+	tableprinter.SetTTYSeparator("  ")
 	// Override the default terminal width of tableprinter
 	tableprinter.SetTerminalWidth(cmdFactory.IO.TerminalWidth())
+	// set whether terminal is a TTY or non-TTY
+	tableprinter.SetIsTTY(cmdFactory.IO.IsOutputTTY())
 
 	rootCmd.SetArgs(expandedArgs)
 

--- a/commands/alias/list/alias_list_test.go
+++ b/commands/alias/list/alias_list_test.go
@@ -37,7 +37,7 @@ func TestAliasList(t *testing.T) {
 				  co: mr checkout
 				  gc: "!glab mr create -f \"$@\" | pbcopy"
 			`),
-			wantStdout: "co\tmr checkout                     \ngc\t!glab mr create -f \"$@\" | pbcopy\n",
+			wantStdout: "co\tmr checkout\ngc\t!glab mr create -f \"$@\" | pbcopy\n",
 			wantStderr: "",
 			isaTTy:     true,
 		},

--- a/commands/issue/issueutils/utils.go
+++ b/commands/issue/issueutils/utils.go
@@ -21,8 +21,10 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func DisplayIssueList(c *iostreams.ColorPalette, issues []*gitlab.Issue, projectID string) string {
+func DisplayIssueList(streams *iostreams.IOStreams, issues []*gitlab.Issue, projectID string) string {
+	c := streams.Color()
 	table := tableprinter.NewTablePrinter()
+	table.SetIsTTY(streams.IsOutputTTY())
 	for _, issue := range issues {
 		table.AddCell(IssueState(c, issue))
 		table.AddCell(issue.Title)

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -137,7 +137,6 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 }
 
 func listRun(opts *ListOptions) error {
-	c := opts.IO.Color()
 	apiClient, err := opts.HTTPClient()
 	if err != nil {
 		return err
@@ -231,6 +230,6 @@ func listRun(opts *ListOptions) error {
 	}
 	defer opts.IO.StopPager()
 
-	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(c, issues, repo.FullName()))
+	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(opts.IO, issues, repo.FullName()))
 	return nil
 }

--- a/commands/mr/issues/mr_issues.go
+++ b/commands/mr/issues/mr_issues.go
@@ -52,7 +52,7 @@ func NewCmdIssues(f *cmdutils.Factory) *cobra.Command {
 			title.ListActionType = "search"
 			title.CurrentPageTotal = len(mrIssues)
 
-			fmt.Fprintf(f.IO.StdOut, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(f.IO.Color(), mrIssues, repo.FullName()))
+			fmt.Fprintf(f.IO.StdOut, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(f.IO, mrIssues, repo.FullName()))
 			return nil
 		},
 	}

--- a/commands/mr/list/mr_list.go
+++ b/commands/mr/list/mr_list.go
@@ -244,7 +244,7 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 	defer opts.IO.StopPager()
-	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title.Describe(), mrutils.DisplayAllMRs(opts.IO.Color(), mergeRequests, repo.FullName()))
+	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title.Describe(), mrutils.DisplayAllMRs(opts.IO, mergeRequests, repo.FullName()))
 
 	return nil
 }

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -100,8 +100,10 @@ func MRState(c *iostreams.ColorPalette, m *gitlab.MergeRequest) string {
 	}
 }
 
-func DisplayAllMRs(c *iostreams.ColorPalette, mrs []*gitlab.MergeRequest, projectID string) string {
+func DisplayAllMRs(streams *iostreams.IOStreams, mrs []*gitlab.MergeRequest, projectID string) string {
+	c := streams.Color()
 	table := tableprinter.NewTablePrinter()
+	table.SetIsTTY(streams.IsOutputTTY())
 	for _, m := range mrs {
 		table.AddCell(MRState(c, m))
 		table.AddCell(m.Title)

--- a/commands/mr/mrutils/mrutils_test.go
+++ b/commands/mr/mrutils/mrutils_test.go
@@ -519,11 +519,11 @@ func Test_DisplayAllMRs(t *testing.T) {
 		},
 	}
 
-	expected := `!1	add tests      	(trunk) ← (new-tests)  
-!2	fix bug        	(trunk) ← (new-feature)
-!1	add new feature	(trunk) ← (new-tests)  
+	expected := `!1	add tests	(trunk) ← (new-tests)
+!2	fix bug	(trunk) ← (new-feature)
+!1	add new feature	(trunk) ← (new-tests)
 `
 
-	got := DisplayAllMRs(streams.Color(), mrs, "unused")
+	got := DisplayAllMRs(streams, mrs, "unused")
 	assert.Equal(t, expected, got)
 }

--- a/pkg/tableprinter/table_printer_test.go
+++ b/pkg/tableprinter/table_printer_test.go
@@ -8,8 +8,9 @@ import (
 func Test_ttyTablePrinter_truncate(t *testing.T) {
 	buf := bytes.Buffer{}
 	tp := NewTablePrinter()
-	tp.SetSeparator(" ")
+	tp.SetTTYSeparator(" ")
 	tp.SetTerminalWidth(5)
+	tp.SetIsTTY(true)
 
 	tp.AddCell("1")
 	tp.AddCell("hello")
@@ -21,6 +22,27 @@ func Test_ttyTablePrinter_truncate(t *testing.T) {
 	buf.Write(tp.Bytes())
 
 	expected := "1 h...\n2 w...\n"
+	if buf.String() != expected {
+		t.Errorf("expected: %q, got: %q", expected, buf.Bytes())
+	}
+}
+
+func Test_nonTTYTablePrinter_truncate(t *testing.T) {
+	buf := bytes.Buffer{}
+	tp := NewTablePrinter()
+	tp.SetTerminalWidth(5)
+	tp.SetIsTTY(false)
+
+	tp.AddCell("1")
+	tp.AddCell("hello")
+	tp.EndRow()
+	tp.AddCell("2")
+	tp.AddCell("world")
+	tp.EndRow()
+
+	buf.Write(tp.Bytes())
+
+	expected := "1\thello\n2\tworld\n"
 	if buf.String() != expected {
 		t.Errorf("expected: %q, got: %q", expected, buf.Bytes())
 	}


### PR DESCRIPTION
This is a hot fix to solve where glab still truncates lines with length longer that the specified column width on non-TTYs to improve scriptability

Resolves #706
