### PR TITLE
added dynamic completion

### DIFF
--- a/api/branch.go
+++ b/api/branch.go
@@ -13,3 +13,15 @@ var CreateBranch = func(client *gitlab.Client, projectID interface{}, opts *gitl
 
 	return branch, nil
 }
+
+var ListBranches = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListBranchesOptions) ([]*gitlab.Branch, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	branches, _, err := client.Branches.ListBranches(projectID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return branches, nil
+}

--- a/api/group.go
+++ b/api/group.go
@@ -1,0 +1,36 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+var GetGroup = func(client *gitlab.Client, groupID interface{}) (*gitlab.Group, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	group, _, err := client.Groups.GetGroup(groupID)
+	if err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+var ListGroups = func(client *gitlab.Client, opts *gitlab.ListGroupsOptions) ([]*gitlab.Group, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	groups, _, err := client.Groups.ListGroups(opts)
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
+var ListSubgroups = func(client *gitlab.Client, groupId interface{}, opts *gitlab.ListSubgroupsOptions) ([]*gitlab.Group, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	groups, _, err := client.Groups.ListSubgroups(groupId, opts)
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
+}

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -1,0 +1,14 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+var ListNamespaces = func(client *gitlab.Client, opts *gitlab.ListNamespacesOptions) ([]*gitlab.Namespace, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	namespaces, _, err := client.Namespaces.ListNamespaces(opts)
+	if err != nil {
+		return nil, err
+	}
+	return namespaces, nil
+}

--- a/api/project.go
+++ b/api/project.go
@@ -51,15 +51,15 @@ var ForkProject = func(client *gitlab.Client, projectID interface{}, opts *gitla
 	return project, nil
 }
 
-var GetGroup = func(client *gitlab.Client, groupID interface{}) (*gitlab.Group, error) {
+var ListUserProjects = func(client *gitlab.Client, userID interface{}, opts *gitlab.ListProjectsOptions) ([]*gitlab.Project, error) {
 	if client == nil {
 		client = apiClient.Lab()
 	}
-	group, _, err := client.Groups.GetGroup(groupID)
+	project, _, err := client.Projects.ListUserProjects(userID, opts)
 	if err != nil {
 		return nil, err
 	}
-	return group, nil
+	return project, nil
 }
 
 var ListGroupProjects = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupProjectsOptions) ([]*gitlab.Project, error) {

--- a/api/tag.go
+++ b/api/tag.go
@@ -1,0 +1,15 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+var ListTags = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListTagsOptions) ([]*gitlab.Tag, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	tags, _, err := client.Tags.ListTags(projectID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return tags, nil
+}

--- a/api/user.go
+++ b/api/user.go
@@ -57,3 +57,14 @@ var UsersByNames = func(client *gitlab.Client, names []string) ([]*gitlab.User, 
 	}
 	return users, nil
 }
+
+var ListUsers = func(client *gitlab.Client, opts *gitlab.ListUsersOptions) ([]*gitlab.User, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	users, _, err := client.Users.ListUsers(opts)
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}

--- a/commands/alias/delete/alias_delete.go
+++ b/commands/alias/delete/alias_delete.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 
 	"github.com/profclems/glab/internal/config"
 	"github.com/spf13/cobra"
@@ -36,6 +38,11 @@ func NewCmdDelete(f *cmdutils.Factory, runF func(*DeleteOptions) error) *cobra.C
 			return deleteRun(cmd, opts)
 		},
 	}
+
+	carapace.Gen(aliasDeleteCmd).PositionalCompletion(
+		action.ActionConfigAliases(),
+	)
+
 	return aliasDeleteCmd
 }
 

--- a/commands/alias/set/alias_set.go
+++ b/commands/alias/set/alias_set.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/google/shlex"
@@ -74,6 +76,11 @@ func NewCmdSet(f *cmdutils.Factory, runF func(*SetOptions) error) *cobra.Command
 		},
 	}
 	aliasSetCmd.Flags().BoolVarP(&opts.IsShell, "shell", "s", false, "Declare an alias to be passed through a shell interpreter")
+
+	carapace.Gen(aliasSetCmd).PositionalCompletion(
+		action.ActionConfigAliases(),
+	)
+
 	return aliasSetCmd
 }
 

--- a/commands/auth/login/login.go
+++ b/commands/auth/login/login.go
@@ -11,11 +11,13 @@ import (
 	"github.com/profclems/glab/commands/auth/authutils"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/glinstance"
 	"github.com/spf13/cobra"
@@ -99,6 +101,10 @@ func NewCmdLogin(f *cmdutils.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "The hostname of the GitLab instance to authenticate with")
 	cmd.Flags().StringVarP(&opts.Token, "token", "t", "", "Your GitLab access token")
 	cmd.Flags().BoolVar(&tokenStdin, "stdin", false, "Read token from standard input")
+
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"hostname": action.ActionConfigHosts(),
+	})
 
 	return cmd
 }

--- a/commands/auth/status/status.go
+++ b/commands/auth/status/status.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/glinstance"
 	"github.com/spf13/cobra"
@@ -47,6 +49,10 @@ func NewCmdStatus(f *cmdutils.Factory, runE func(*StatusOpts) error) *cobra.Comm
 
 	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Check a specific instance's authentication status")
 	cmd.Flags().BoolVarP(&opts.ShowToken, "show-token", "t", false, "Display the auth token")
+
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"hostname": action.ActionConfigHosts(),
+	})
 
 	return cmd
 }

--- a/commands/ci/ci.go
+++ b/commands/ci/ci.go
@@ -10,6 +10,7 @@ import (
 	ciTraceCmd "github.com/profclems/glab/commands/ci/trace"
 	ciViewCmd "github.com/profclems/glab/commands/ci/view"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,7 @@ func NewCmdCI(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(ciCmd, f)
+	action.EnableRepoOverride(ciCmd, f)
 
 	ciCmd.AddCommand(legacyCICmd.NewCmdCI(f))
 	ciCmd.AddCommand(ciTraceCmd.NewCmdTrace(f, nil))

--- a/commands/ci/lint/lint.go
+++ b/commands/ci/lint/lint.go
@@ -11,6 +11,7 @@ import (
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/pkg/git"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -37,6 +38,10 @@ func NewCmdLint(f *cmdutils.Factory) *cobra.Command {
 			return lintRun(f, path)
 		},
 	}
+
+	carapace.Gen(pipelineCILintCmd).PositionalCompletion(
+		carapace.ActionFiles(".gitlab-ci.yml"),
+	)
 
 	return pipelineCILintCmd
 }

--- a/commands/ci/list/list.go
+++ b/commands/ci/list/list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/profclems/glab/commands/ci/ciutils"
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/pkg/utils"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -77,6 +78,12 @@ func NewCmdList(f *cmdutils.Factory) *cobra.Command {
 	pipelineListCmd.Flags().StringP("sort", "", "desc", "Sort pipeline by {asc|desc}. (Defaults to desc)")
 	pipelineListCmd.Flags().IntP("page", "p", 1, "Page number")
 	pipelineListCmd.Flags().IntP("per-page", "P", 30, "Number of items to list per page. (default 30)")
+
+	carapace.Gen(pipelineListCmd).FlagCompletion(carapace.ActionMap{
+		"orderBy": carapace.ActionValues("id", "status", "ref", "updated_at", "user_id"),
+		"sort":    carapace.ActionValues("asc", "desc"),
+		"status":  carapace.ActionValues("running", "pending", "success", "failed", "canceled", "skipped", "created", "manual"),
+	})
 
 	return pipelineListCmd
 }

--- a/commands/ci/run/run.go
+++ b/commands/ci/run/run.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/pkg/git"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -100,6 +102,10 @@ func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
 	}
 	pipelineRunCmd.Flags().StringP("branch", "b", "", "Create pipeline on branch/ref <string>")
 	pipelineRunCmd.Flags().StringSliceP("variables", "", []string{}, "Pass variables to pipeline")
+
+	carapace.Gen(pipelineRunCmd).FlagCompletion(carapace.ActionMap{
+		"branch": action.ActionBranches(pipelineRunCmd, f, &gitlab.ListBranchesOptions{}),
+	})
 
 	return pipelineRunCmd
 }

--- a/commands/ci/status/status.go
+++ b/commands/ci/status/status.go
@@ -7,8 +7,11 @@ import (
 	"github.com/profclems/glab/api"
 	ciTraceCmd "github.com/profclems/glab/commands/ci/trace"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/pkg/git"
 	"github.com/profclems/glab/pkg/utils"
+	"github.com/rsteube/carapace"
+	"github.com/xanzy/go-gitlab"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
@@ -164,6 +167,10 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 	pipelineStatusCmd.Flags().BoolP("live", "l", false, "Show status in real-time till pipeline ends")
 	pipelineStatusCmd.Flags().BoolP("compact", "c", false, "Show status in compact format")
 	pipelineStatusCmd.Flags().StringP("branch", "b", "", "Check pipeline status for a branch. (Default is current branch)")
+
+	carapace.Gen(pipelineStatusCmd).FlagCompletion(carapace.ActionMap{
+		"branch": action.ActionBranches(pipelineStatusCmd, f, &gitlab.ListBranchesOptions{}),
+	})
 
 	return pipelineStatusCmd
 }

--- a/commands/ci/trace/trace.go
+++ b/commands/ci/trace/trace.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/pkg/prompt"
@@ -13,6 +14,7 @@ import (
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/ci/ciutils"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/pkg/git"
 	"github.com/profclems/glab/pkg/utils"
 
@@ -73,6 +75,13 @@ func NewCmdTrace(f *cmdutils.Factory, runE func(traceOpts *TraceOpts) error) *co
 	}
 
 	pipelineCITraceCmd.Flags().StringVarP(&opts.Branch, "branch", "b", "", "Check pipeline status for a branch. (Default is the current branch)")
+
+	carapace.Gen(pipelineCITraceCmd).FlagCompletion(carapace.ActionMap{
+		"branch": action.ActionBranches(pipelineCITraceCmd, f, &gitlab.ListBranchesOptions{}),
+	})
+
+	// TODO complete pipeline jobs
+
 	return pipelineCITraceCmd
 }
 

--- a/commands/ci/view/view.go
+++ b/commands/ci/view/view.go
@@ -14,8 +14,10 @@ import (
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/ci/ciutils"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/pkg/git"
 	"github.com/profclems/glab/pkg/utils"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/gdamore/tcell/v2"
@@ -100,6 +102,11 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	pipelineCIView.Flags().StringVarP(&opts.RefName, "branch", "b", "", "Check pipeline status for a branch/tag. (Default is the current branch)")
+
+	carapace.Gen(pipelineCIView).FlagCompletion(carapace.ActionMap{
+		"branch": action.ActionBranches(pipelineCIView, f, &gitlab.ListBranchesOptions{}),
+	})
+
 	return pipelineCIView
 }
 

--- a/commands/cmdutils/action/branch.go
+++ b/commands/cmdutils/action/branch.go
@@ -1,0 +1,31 @@
+package action
+
+import (
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionBranches(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListBranchesOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if branches, err := api.ListBranches(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(branches)*2)
+			for _, branch := range branches {
+				vals = append(vals, branch.Name, branch.Commit.Title)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/config.go
+++ b/commands/cmdutils/action/config.go
@@ -1,0 +1,65 @@
+package action
+
+import (
+	"github.com/profclems/glab/internal/config"
+	"github.com/rsteube/carapace"
+)
+
+func ActionConfigAliases() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		config, err := config.Init()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+		configAliases, err := config.Aliases()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		vals := make([]string, 0)
+		for alias, desc := range configAliases.All() {
+			vals = append(vals, alias, desc)
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}
+
+func ActionConfigHosts() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		config, err := config.Init()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+		configHosts, err := config.Hosts()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+		return carapace.ActionValues(configHosts...)
+	})
+}
+
+func ActionConfigKeys() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"token", "Your gitlab access token, defaults to environment variables",
+		"gitlab_uri", "if unset, defaults to https://gitlab.com",
+		"browser", "if unset, defaults to environment variables",
+		"editor", "if unset, defaults to environment variables.",
+		"visual", "alternative for editor. if unset, defaults to environment variables.",
+		"glamour_style", "Your desired markdown renderer style.",
+	)
+}
+
+func ActionConfigValues(key string) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		actions := map[string]carapace.Action{
+			"token":         carapace.ActionValues(),
+			"gitlab_uri":    carapace.ActionValues(),
+			"browser":       carapace.ActionFiles(),
+			"editor":        carapace.ActionFiles(),
+			"visual":        carapace.ActionFiles(),
+			"glamour_style": carapace.ActionValues("dark", "light", "notty"),
+		}
+
+		return actions[key]
+	})
+}

--- a/commands/cmdutils/action/group.go
+++ b/commands/cmdutils/action/group.go
@@ -1,0 +1,48 @@
+package action
+
+import (
+	"strings"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionGroups(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListGroupsOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if groups, err := api.ListGroups(client, opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(groups)*2)
+			for _, group := range groups {
+				vals = append(vals, group.Path, group.Description)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}
+
+func ActionSubgroups(cmd *cobra.Command, f *cmdutils.Factory, groupID string, opts *gitlab.ListSubgroupsOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if groups, err := api.ListSubgroups(client, groupID, opts); err != nil {
+			if strings.Contains(err.Error(), "404 Group Not Found") {
+				return carapace.ActionValues() // fail silently for repo completion
+			}
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(groups)*2)
+			for _, group := range groups {
+				vals = append(vals, group.Path, group.Description)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/issue.go
+++ b/commands/cmdutils/action/issue.go
@@ -1,0 +1,34 @@
+package action
+
+import (
+	"strconv"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionIssues(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListProjectIssuesOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.OrderBy = gitlab.String("updated_at")
+		opts.PerPage = 100
+
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		if issues, err := api.ListIssues(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(issues)*2)
+			for _, issue := range issues {
+				vals = append(vals, strconv.Itoa(issue.IID), issue.Title)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+
+	})
+}

--- a/commands/cmdutils/action/label.go
+++ b/commands/cmdutils/action/label.go
@@ -1,0 +1,32 @@
+package action
+
+import (
+	"time"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/rsteube/carapace/pkg/cache"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionLabels(cmd *cobra.Command, f *cmdutils.Factory) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if labels, err := api.ListLabels(client, repo.FullName(), &gitlab.ListLabelsOptions{}); err != nil {
+				return carapace.ActionMessage(err.Error())
+			} else {
+				vals := make([]string, 0, len(labels)*2)
+				for _, label := range labels {
+					vals = append(vals, label.Name, label.Description)
+				}
+				return carapace.ActionValuesDescribed(vals...)
+			}
+		}).Cache(1*time.Hour, cache.String(repo.FullName()))
+	})
+}

--- a/commands/cmdutils/action/mergeRequest.go
+++ b/commands/cmdutils/action/mergeRequest.go
@@ -1,0 +1,33 @@
+package action
+
+import (
+	"strconv"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionMergeRequests(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListProjectMergeRequestsOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.OrderBy = gitlab.String("updated_at")
+		opts.PerPage = 100
+
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		if mergeRequests, err := api.ListMRs(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(mergeRequests)*2)
+			for _, mr := range mergeRequests {
+				vals = append(vals, strconv.Itoa(mr.IID), mr.Title)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/milestone.go
+++ b/commands/cmdutils/action/milestone.go
@@ -1,0 +1,28 @@
+package action
+
+import (
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionMilestones(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListMilestonesOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		if milestones, err := api.ListMilestones(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(milestones)*2)
+			for _, milestone := range milestones {
+				vals = append(vals, milestone.Title, milestone.Description)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/pipeline.go
+++ b/commands/cmdutils/action/pipeline.go
@@ -1,0 +1,39 @@
+package action
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/pkg/utils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionPipelines(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListProjectPipelinesOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.OrderBy = gitlab.String("updated_at")
+		opts.PerPage = 100
+
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		if pipelines, err := api.ListProjectPipelines(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(pipelines)*2)
+			for _, pipeline := range pipelines {
+				description := pipeline.Ref
+				if pipeline.CreatedAt != nil {
+					description = fmt.Sprintf("%v (%v)", pipeline.Ref, utils.TimeToPrettyTimeAgo(*pipeline.CreatedAt))
+				}
+				vals = append(vals, strconv.Itoa(pipeline.ID), description)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/project.go
+++ b/commands/cmdutils/action/project.go
@@ -1,0 +1,53 @@
+package action
+
+import (
+	"strings"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionGroupProjects(cmd *cobra.Command, f *cmdutils.Factory, groupID string, opts *gitlab.ListGroupProjectsOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.OrderBy = gitlab.String("updated_at")
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if projects, err := api.ListGroupProjects(client, groupID, opts); err != nil {
+			if strings.Contains(err.Error(), "404 Group Not Found") {
+				return carapace.ActionValues() // fail silently for repo completion
+			}
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(projects)*2)
+			for _, project := range projects {
+				vals = append(vals, project.Path, project.Description)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}
+
+func ActionUserProjects(cmd *cobra.Command, f *cmdutils.Factory, userID string, opts *gitlab.ListProjectsOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.OrderBy = gitlab.String("updated_at")
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if projects, err := api.ListUserProjects(client, userID, opts); err != nil {
+			if strings.Contains(err.Error(), "404 User Not Found") {
+				return carapace.ActionValues() // fail silently for repo completion
+			}
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(projects)*2)
+			for _, project := range projects {
+				vals = append(vals, project.Path, project.Description)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/repoOverride.go
+++ b/commands/cmdutils/action/repoOverride.go
@@ -1,0 +1,86 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/config"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func EnableRepoOverride(cmd *cobra.Command, f *cmdutils.Factory) { // TODO factory would cause circular dependency in cmdutils
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"repo": ActionRepo(cmd, f),
+	})
+}
+
+func ActionRepo(cmd *cobra.Command, f *cmdutils.Factory) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		config, err := config.Init()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+		configHosts, err := config.Hosts()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		if strings.Contains(c.CallbackValue, "/") {
+			isKnownHost := false
+			for _, host := range configHosts {
+				if strings.HasPrefix(c.CallbackValue, host) {
+					isKnownHost = true
+					break
+				}
+			}
+			if !isKnownHost {
+				return carapace.ActionValues() // only complete full host style for simplicity
+			}
+		}
+
+		return carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
+			if len(c.Parts) > 0 {
+				if err := f.RepoOverride(fmt.Sprintf("%v/fake/repo", c.Parts[0])); err != nil {
+					return carapace.ActionMessage(err.Error())
+				}
+			}
+
+			switch len(c.Parts) {
+			case 0:
+				return carapace.ActionValues(configHosts...).Invoke(c).Suffix("/").ToA()
+			case 1:
+				users := ActionUsers(cmd, f, &gitlab.ListUsersOptions{}).Invoke(c).Suffix("/")
+				groups := ActionGroups(cmd, f, &gitlab.ListGroupsOptions{}).Invoke(c).Suffix("/")
+				return users.Merge(groups).ToA()
+			case 2:
+				subgroups := ActionSubgroups(cmd, f, c.Parts[1], &gitlab.ListSubgroupsOptions{}).Invoke(c).Suffix("/")
+				groupProjects := ActionGroupProjects(cmd, f, c.Parts[1], &gitlab.ListGroupProjectsOptions{}).Invoke(c)
+				userProjects := ActionUserProjects(cmd, f, c.Parts[1], &gitlab.ListProjectsOptions{}).Invoke(c)
+				return subgroups.Merge(groupProjects, userProjects).ToA()
+			case 3:
+				groupProjects := ActionGroupProjects(cmd, f, strings.Join(c.Parts[1:], "/"), &gitlab.ListGroupProjectsOptions{}).Invoke(c)
+				return groupProjects.ToA()
+			default:
+				return carapace.ActionValues()
+			}
+		})
+	})
+}
+
+func ActionApiCallback(cmd *cobra.Command, f *cmdutils.Factory, callback func(client *gitlab.Client, c carapace.Context) carapace.Action) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if repoFlag := cmd.Flag("repo"); repoFlag != nil && repoFlag.Changed {
+			f.RepoOverride("https://" + repoFlag.Value.String())
+		}
+
+		client, err := f.HttpClient()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		return callback(client, c)
+	})
+}

--- a/commands/cmdutils/action/tag.go
+++ b/commands/cmdutils/action/tag.go
@@ -1,0 +1,31 @@
+package action
+
+import (
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionTags(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListTagsOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if tags, err := api.ListTags(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(tags)*2)
+			for _, tag := range tags {
+				vals = append(vals, tag.Name, tag.Commit.Title)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/cmdutils/action/user.go
+++ b/commands/cmdutils/action/user.go
@@ -1,0 +1,48 @@
+package action
+
+import (
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/rsteube/carapace"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func ActionUsers(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListUsersOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.Search = &c.CallbackValue
+		opts.PerPage = 100
+
+		if users, err := api.ListUsers(client, opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(users)*2)
+			for _, user := range users {
+				vals = append(vals, user.Username, user.Name)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}
+
+func ActionProjectMembers(cmd *cobra.Command, f *cmdutils.Factory, opts *gitlab.ListProjectMembersOptions) carapace.Action {
+	return ActionApiCallback(cmd, f, func(client *gitlab.Client, c carapace.Context) carapace.Action {
+		opts.Query = &c.CallbackValue
+		opts.PerPage = 100
+
+		repo, err := f.BaseRepo()
+		if err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		if members, err := api.ListProjectMembers(client, repo.FullName(), opts); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			vals := make([]string, 0, len(members)*2)
+			for _, member := range members {
+				vals = append(vals, member.Username, member.Name)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}
+	})
+}

--- a/commands/completion/completion.go
+++ b/commands/completion/completion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/spf13/cobra"
 )
@@ -47,5 +48,10 @@ For Homebrew, see <https://docs.brew.sh/Shell-Completion>
 	}
 
 	completionCmd.Flags().StringVarP(&shellType, "shell", "s", "bash", "Shell type: {bash|zsh|fish|powershell}")
+
+	carapace.Gen(completionCmd).FlagCompletion(carapace.ActionMap{
+		"shell": carapace.ActionValues("bash", "fish", "powershell", "zsh"),
+	})
+
 	return completionCmd
 }

--- a/commands/config/config.go
+++ b/commands/config/config.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/glinstance"
+	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 )
 
@@ -77,6 +79,14 @@ func NewCmdConfigGet(f *cmdutils.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&hostname, "host", "h", "", "Get per-host setting")
 	cmd.Flags().BoolP("global", "g", false, "Read from global config file (~/.config/glab-cli/config.yml). [Default: looks through Environment variables → Local → Global]")
 
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"host": action.ActionConfigHosts(),
+	})
+
+	carapace.Gen(cmd).PositionalCompletion(
+		action.ActionConfigKeys(),
+	)
+
 	return cmd
 }
 
@@ -129,6 +139,18 @@ Specifying the --hostname flag also saves in the global config file
 
 	cmd.Flags().StringVarP(&hostname, "host", "h", "", "Set per-host setting")
 	cmd.Flags().BoolVarP(&isGlobal, "global", "g", false, "write to global ~/.config/glab-cli/config.yml file rather than the repository .glab-cli/config/config")
+
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"host": action.ActionConfigHosts(),
+	})
+
+	carapace.Gen(cmd).PositionalCompletion(
+		action.ActionConfigKeys(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return action.ActionConfigValues(c.Args[0])
+		}),
+	)
+
 	return cmd
 }
 

--- a/commands/issue/close/issue_close.go
+++ b/commands/issue/close/issue_close.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
@@ -51,5 +53,10 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(issueCloseCmd).PositionalCompletion(
+		action.ActionIssues(issueCloseCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("opened")}),
+	)
+
 	return issueCloseCmd
 }

--- a/commands/issue/delete/issue_delete.go
+++ b/commands/issue/delete/issue_delete.go
@@ -6,7 +6,10 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/rsteube/carapace"
+	"github.com/xanzy/go-gitlab"
 
 	"github.com/spf13/cobra"
 )
@@ -52,5 +55,10 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(issueDeleteCmd).PositionalCompletion(
+		action.ActionIssues(issueDeleteCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("all")}),
+	)
+
 	return issueDeleteCmd
 }

--- a/commands/issue/issue.go
+++ b/commands/issue/issue.go
@@ -3,6 +3,7 @@ package issue
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	issueBoardCmd "github.com/profclems/glab/commands/issue/board"
 	issueCloseCmd "github.com/profclems/glab/commands/issue/close"
 	issueCreateCmd "github.com/profclems/glab/commands/issue/create"
@@ -39,6 +40,7 @@ func NewCmdIssue(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(issueCmd, f)
+	action.EnableRepoOverride(issueCmd, f)
 
 	issueCmd.AddCommand(issueCloseCmd.NewCmdClose(f))
 	issueCmd.AddCommand(issueBoardCmd.NewCmdBoard(f))

--- a/commands/issue/note/issue_note_create.go
+++ b/commands/issue/note/issue_note_create.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
@@ -61,6 +63,10 @@ func NewCmdNote(f *cmdutils.Factory) *cobra.Command {
 		},
 	}
 	issueNoteCreateCmd.Flags().StringP("message", "m", "", "Comment/Note message")
+
+	carapace.Gen(issueNoteCreateCmd).PositionalCompletion(
+		action.ActionIssues(issueNoteCreateCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("opened")}),
+	)
 
 	return issueNoteCreateCmd
 }

--- a/commands/issue/reopen/issue_reopen.go
+++ b/commands/issue/reopen/issue_reopen.go
@@ -6,7 +6,9 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/rsteube/carapace"
 
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
@@ -59,6 +61,10 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(issueReopenCmd).PositionalCompletion(
+		action.ActionIssues(issueReopenCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("closed")}),
+	)
 
 	return issueReopenCmd
 }

--- a/commands/issue/subscribe/issue_subscribe.go
+++ b/commands/issue/subscribe/issue_subscribe.go
@@ -6,8 +6,11 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
 )
 
 func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
@@ -50,6 +53,10 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(issueSubscribeCmd).PositionalCompletion(
+		action.ActionIssues(issueSubscribeCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("opened")}),
+	)
 
 	return issueSubscribeCmd
 }

--- a/commands/issue/unsubscribe/issue_unsubscribe.go
+++ b/commands/issue/unsubscribe/issue_unsubscribe.go
@@ -6,7 +6,10 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
+	"github.com/rsteube/carapace"
+	"github.com/xanzy/go-gitlab"
 
 	"github.com/spf13/cobra"
 )
@@ -51,6 +54,10 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(issueUnsubscribeCmd).PositionalCompletion(
+		action.ActionIssues(issueUnsubscribeCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("opened")}),
+	)
 
 	return issueUnsubscribeCmd
 }

--- a/commands/issue/view/issue_view.go
+++ b/commands/issue/view/issue_view.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/issue/issueutils"
 
 	"github.com/profclems/glab/api"
@@ -109,6 +111,10 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 	issueViewCmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open mr in a browser. Uses default browser or browser specified in BROWSER variable")
 	issueViewCmd.Flags().IntVarP(&opts.CommentPageNumber, "page", "p", 1, "Page number")
 	issueViewCmd.Flags().IntVarP(&opts.CommentLimit, "per-page", "P", 20, "Number of items to list per page")
+
+	carapace.Gen(issueViewCmd).PositionalCompletion(
+		action.ActionIssues(issueViewCmd, f, &gitlab.ListProjectIssuesOptions{State: gitlab.String("opened")}),
+	)
 
 	return issueViewCmd
 }

--- a/commands/label/create/label_create.go
+++ b/commands/label/create/label_create.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
@@ -62,6 +64,10 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	_ = labelCreateCmd.MarkFlagRequired("name")
 	labelCreateCmd.Flags().StringP("color", "c", "#428BCA", "Color of label in plain or HEX code. (Default: #428BCA)")
 	labelCreateCmd.Flags().StringP("description", "d", "", "Label description")
+
+	carapace.Gen(labelCreateCmd).FlagCompletion(carapace.ActionMap{
+		"name": action.ActionLabels(labelCreateCmd, f),
+	})
 
 	return labelCreateCmd
 }

--- a/commands/label/label.go
+++ b/commands/label/label.go
@@ -2,6 +2,7 @@ package label
 
 import (
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	labelCreateCmd "github.com/profclems/glab/commands/label/create"
 	labelListCmd "github.com/profclems/glab/commands/label/list"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ func NewCmdLabel(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(labelCmd, f)
+	action.EnableRepoOverride(labelCmd, f)
 
 	labelCmd.AddCommand(labelListCmd.NewCmdList(f))
 	labelCmd.AddCommand(labelCreateCmd.NewCmdCreate(f))

--- a/commands/mr/approvers/mr_approvers.go
+++ b/commands/mr/approvers/mr_approvers.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/pkg/tableprinter"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/spf13/cobra"
@@ -77,6 +79,14 @@ func NewCmdApprovers(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(mrApproversCmd).PositionalCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			branches := action.ActionBranches(mrApproversCmd, f, &gitlab.ListBranchesOptions{}).Invoke(c)
+			mergeRequests := action.ActionMergeRequests(mrApproversCmd, f, &gitlab.ListProjectMergeRequestsOptions{}).Invoke(c)
+			return branches.Merge(mergeRequests).ToA()
+		}),
+	)
 
 	return mrApproversCmd
 }

--- a/commands/mr/mr.go
+++ b/commands/mr/mr.go
@@ -3,6 +3,7 @@ package mr
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	mrApproveCmd "github.com/profclems/glab/commands/mr/approve"
 	mrApproversCmd "github.com/profclems/glab/commands/mr/approvers"
 	mrCheckoutCmd "github.com/profclems/glab/commands/mr/checkout"
@@ -47,6 +48,7 @@ func NewCmdMR(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(mrCmd, f)
+	action.EnableRepoOverride(mrCmd, f)
 
 	mrCmd.AddCommand(mrApproveCmd.NewCmdApprove(f))
 	mrCmd.AddCommand(mrApproversCmd.NewCmdApprovers(f))

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -6,7 +6,9 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/mr/mrutils"
+	"github.com/rsteube/carapace"
 
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
@@ -58,6 +60,10 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 			return nil
 		},
 	}
+
+	carapace.Gen(mrReopenCmd).PositionalCompletion(
+		action.ActionMergeRequests(mrReopenCmd, f, &gitlab.ListProjectMergeRequestsOptions{State: gitlab.String("closed")}),
+	)
 
 	return mrReopenCmd
 }

--- a/commands/mr/view/mr_view.go
+++ b/commands/mr/view/mr_view.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/commands/mr/mrutils"
 	"github.com/profclems/glab/pkg/utils"
 
@@ -96,6 +98,10 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 	mrViewCmd.Flags().BoolVarP(&opts.OpenInBrowser, "web", "w", false, "Open mr in a browser. Uses default browser or browser specified in BROWSER variable")
 	mrViewCmd.Flags().IntVarP(&opts.CommentPageNumber, "page", "p", 0, "Page number")
 	mrViewCmd.Flags().IntVarP(&opts.CommentLimit, "per-page", "P", 20, "Number of items to list per page")
+
+	carapace.Gen(mrViewCmd).PositionalCompletion(
+		action.ActionMergeRequests(mrViewCmd, f, &gitlab.ListProjectMergeRequestsOptions{State: gitlab.String("opened")}),
+	)
 
 	return mrViewCmd
 }

--- a/commands/project/clone/repo_clone.go
+++ b/commands/project/clone/repo_clone.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/glinstance"
 	"github.com/profclems/glab/internal/glrepo"
@@ -145,6 +147,15 @@ Clone a GitLab repository/project
 		}
 		return &cmdutils.FlagError{Err: fmt.Errorf("%w\nSeparate git clone flags with '--'.", err)}
 	})
+
+	carapace.Gen(repoCloneCmd).FlagCompletion(carapace.ActionMap{
+		"group":      action.ActionGroups(repoCloneCmd, f, &gitlab.ListGroupsOptions{}),
+		"visibility": carapace.ActionValues("public", "internal", "private"),
+	})
+
+	carapace.Gen(repoCloneCmd).PositionalCompletion(
+		action.ActionRepo(repoCloneCmd, f),
+	)
 
 	return repoCloneCmd
 }

--- a/commands/project/contributors/repo_contributors.go
+++ b/commands/project/contributors/repo_contributors.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/pkg/tableprinter"
 	"github.com/profclems/glab/pkg/utils"
@@ -50,11 +52,18 @@ func NewCmdContributors(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(repoContributorsCmd, f)
+	action.EnableRepoOverride(repoContributorsCmd, f)
 
 	repoContributorsCmd.Flags().StringVarP(&opts.OrderBy, "order", "o", "commits", "Return contributors ordered by name, email, or commits (orders by commit date) fields")
 	repoContributorsCmd.Flags().StringVarP(&opts.Sort, "sort", "s", "", "Return contributors sorted in asc or desc order")
 	repoContributorsCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
 	repoContributorsCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page.")
+
+	carapace.Gen(repoContributorsCmd).FlagCompletion(carapace.ActionMap{
+		"order": carapace.ActionValues("name", "email", "commits"),
+		"sort":  carapace.ActionValues("asc", "desc"),
+	})
+
 	return repoContributorsCmd
 }
 

--- a/commands/project/create/project_create.go
+++ b/commands/project/create/project_create.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/prompt"
+	"github.com/rsteube/carapace"
 
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/internal/glrepo"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/run"
 	"github.com/profclems/glab/pkg/git"
 	"github.com/spf13/cobra"
@@ -53,6 +55,14 @@ func NewCmdCreate(f *cmdutils.Factory) *cobra.Command {
 	projectCreateCmd.Flags().BoolP("private", "p", false, "Make project private: visible only to project members")
 	projectCreateCmd.Flags().BoolP("public", "P", false, "Make project public: visible without any authentication")
 	projectCreateCmd.Flags().Bool("readme", false, "Initialize project with README.md")
+
+	carapace.Gen(projectCreateCmd).FlagCompletion(carapace.ActionMap{
+		"group": action.ActionGroups(projectCreateCmd, f, &gitlab.ListGroupsOptions{}),
+	})
+
+	carapace.Gen(projectCreateCmd).PositionalCompletion(
+		action.ActionRepo(projectCreateCmd, f),
+	)
 
 	return projectCreateCmd
 }

--- a/commands/project/delete/delete.go
+++ b/commands/project/delete/delete.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/pkg/prompt"
 	"github.com/spf13/cobra"
@@ -32,7 +34,7 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 		BaseRepo: f.BaseRepo,
 	}
 
-	var projectCreateCmd = &cobra.Command{
+	var projectDeleteCmd = &cobra.Command{
 		Use:   "delete [<NAMESPACE>/]<NAME>",
 		Short: `Delete an existing repository on GitLab`,
 		Long:  `Delete an existing repository on GitLab`,
@@ -52,9 +54,13 @@ func NewCmdDelete(f *cmdutils.Factory) *cobra.Command {
 	  `),
 	}
 
-	projectCreateCmd.Flags().BoolVarP(&opts.ForceDelete, "yes", "y", false, "Skip the confirmation prompt and immediately delete the repository.")
+	projectDeleteCmd.Flags().BoolVarP(&opts.ForceDelete, "yes", "y", false, "Skip the confirmation prompt and immediately delete the repository.")
 
-	return projectCreateCmd
+	carapace.Gen(projectDeleteCmd).PositionalCompletion(
+		action.ActionRepo(projectDeleteCmd, f),
+	)
+
+	return projectDeleteCmd
 }
 
 func deleteRun(opts *DeleteOpts) error {

--- a/commands/project/fork/fork.go
+++ b/commands/project/fork/fork.go
@@ -6,10 +6,12 @@ import (
 	"net/url"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/config"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/internal/run"
@@ -90,6 +92,10 @@ func NewCmdFork(f *cmdutils.Factory, runE func(*cmdutils.Factory) error) *cobra.
 	forkCmd.Flags().StringVarP(&opts.Path, "path", "p", "", "The path assigned to the resultant project after forking")
 	forkCmd.Flags().BoolVarP(&opts.Clone, "clone", "c", false, "Clone the fork {true|false}")
 	forkCmd.Flags().BoolVar(&opts.AddRemote, "remote", false, "Add remote for fork {true|false}")
+
+	carapace.Gen(forkCmd).PositionalCompletion(
+		action.ActionRepo(forkCmd, f),
+	)
 
 	return forkCmd
 }

--- a/commands/release/release.go
+++ b/commands/release/release.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	releaseListCmd "github.com/profclems/glab/commands/release/list"
 
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ func NewCmdRelease(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(releaseCmd, f)
+	action.EnableRepoOverride(releaseCmd, f)
 	releaseCmd.AddCommand(releaseListCmd.NewCmdReleaseList(f))
 
 	return releaseCmd

--- a/commands/root.go
+++ b/commands/root.go
@@ -20,6 +20,7 @@ import (
 	variableCmd "github.com/profclems/glab/commands/variable"
 	versionCmd "github.com/profclems/glab/commands/version"
 	"github.com/profclems/glab/internal/glrepo"
+	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -107,6 +108,9 @@ func NewCmdRoot(f *cmdutils.Factory, version, buildDate string) *cobra.Command {
 	rootCmd.AddCommand(apiCmd.NewCmdApi(f, nil))
 
 	rootCmd.Flags().BoolP("version", "v", false, "show glab version information")
+
+	carapace.Gen(rootCmd)
+
 	return rootCmd
 }
 

--- a/commands/variable/set/set.go
+++ b/commands/variable/set/set.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 
 	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/rsteube/carapace"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
@@ -107,6 +109,12 @@ func NewCmdSet(f *cmdutils.Factory, runE func(opts *SetOpts) error) *cobra.Comma
 	cmd.Flags().StringVarP(&opts.Group, "group", "g", "", "Set variable for a group")
 	cmd.Flags().BoolVarP(&opts.Masked, "masked", "m", false, "Whether the variable is masked")
 	cmd.Flags().BoolVarP(&opts.Protected, "protected", "p", false, "Whether the variable is protected")
+
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"type":  carapace.ActionValues("env_var", "file"),
+		"group": action.ActionGroups(cmd, f, &gitlab.ListGroupsOptions{}),
+	})
+
 	return cmd
 }
 

--- a/commands/variable/variable.go
+++ b/commands/variable/variable.go
@@ -2,6 +2,7 @@ package variable
 
 import (
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/cmdutils/action"
 	setCmd "github.com/profclems/glab/commands/variable/set"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func NewVariableCmd(f *cmdutils.Factory) *cobra.Command {
 	}
 
 	cmdutils.EnableRepoOverride(cmd, f)
+	action.EnableRepoOverride(cmd, f)
 
 	cmd.AddCommand(setCmd.NewCmdSet(f, nil))
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/otiai10/copy v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/tview v0.0.0-20210117162420-745e4ceeb711
+	github.com/rsteube/carapace v0.6.2
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
@@ -256,6 +258,8 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rsteube/carapace v0.6.2 h1:wNaHxugG2iA6nMUG+VLT2Ppw01yslWvE4YAacOhdKzs=
+github.com/rsteube/carapace v0.6.2/go.mod h1:Vo7qSmFjuOTjB3cEyyat0+ANvVHlS0HR4NhIdAN07vM=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -273,6 +277,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -378,8 +383,9 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
 golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -453,6 +459,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
**Description**
Added dynamic completion using [carapace](https://github.com/rsteube/carapace). 

**Related Issue**
Resolves #724

**How Has This Been Tested?**
Testing is still limited and i expect some small issues regaring the values being completed (e.g it seems the repo clone command currently ignores the host prefix and tries to use `gitlab.com`).
There might also be some small issues regarding different environments (os/shell) regarding carapace itself - works fine in tests and there haven't been any issues with [lab](https://github.com/zaquestion/lab) so far though.
Personally using [elvish](https://elv.sh/) on linux.
Does not affect current completion provided by cobra itself, so these can be used in parallel.

**Screenshots (if appropriate):**
[![asciicast](https://asciinema.org/a/414156.svg)](https://asciinema.org/a/414156)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)

**Usage**
```sh
#bash
source <(glab _carapace)

# elvish
eval (glab _carapace|slurp)

# fish
glab _carapace | source

# oil
source <(glab _carapace)

# powershell
Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
glab _carapace | Out-String | Invoke-Expression

# xonsh
COMPLETIONS_CONFIRM=True
exec($(glab _carapace))

# zsh
source <(glab _carapace)
```