### PR TITLE
fix job viewing with detached pipelines

### DIFF
--- a/commands/ci/trace/trace.go
+++ b/commands/ci/trace/trace.go
@@ -88,27 +88,13 @@ func TraceRun(opts *TraceOpts) error {
 	}
 
 	if opts.JobID < 1 {
-		l := &gitlab.ListProjectPipelinesOptions{
-			Ref:  gitlab.String(opts.Branch),
-			Sort: gitlab.String("desc"),
-		}
-
-		l.Page = 1
-		l.PerPage = 1
-
 		fmt.Fprintf(opts.IO.StdOut, "\nSearching for latest pipeline on %s...\n", opts.Branch)
 
-		pipes, err := api.GetPipelines(apiClient, l, repo.FullName())
+		pipeline, err := api.GetLastPipeline(apiClient, repo.FullName(), opts.Branch)
 		if err != nil {
 			return err
 		}
 
-		if len(pipes) == 0 {
-			fmt.Fprintln(opts.IO.StdOut, "No pipeline running or available on "+opts.Branch+"branch")
-			return nil
-		}
-
-		pipeline := pipes[0]
 		fmt.Fprintf(opts.IO.StdOut, "Getting jobs for pipeline %d...\n\n", pipeline.ID)
 
 		jobs, err := api.GetPipelineJobs(apiClient, pipeline.ID, repo.FullName())


### PR DESCRIPTION
**Description**
For `ci trace` and `ci status`, the `GetPipelines` function has been
used. However, `GetPipelines` does not with [detached pipelines](https://docs.gitlab.com/ee/ci/merge_request_pipelines/).

To fix this, we're now using a new function `GetLastPipeline`, which
first tries to get the last pipeline through the `GetCommit` API and if
that should not return any results, it falls back to the old
`GetPipelines` function.

Some parts of the codes have been refactored to use this new function
instead of listing all pipelines and then grabbing the first elementt of
that list.

`GetPipelines` is now only used within the `api` package itself, but I
kept it public for compatibility reasons.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #721

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally to a private instance that has a detached pipeline on a Merge Request.


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
