### PR TITLE
Fix triggered jobs duration

### DIFF
--- a/commands/ci/status/status.go
+++ b/commands/ci/status/status.go
@@ -85,7 +85,12 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 						if job.FinishedAt != nil {
 							end = *job.FinishedAt
 						}
-						duration := utils.FmtDuration(end.Sub(*job.StartedAt))
+						var duration string
+						if job.StartedAt != nil {
+							duration = utils.FmtDuration(end.Sub(*job.StartedAt))
+						} else {
+							duration = "not started"
+						}
 						var status string
 						switch s := job.Status; s {
 						case "failed":


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
This commit fixes a bug where a `glab ci status` would panic if there is
a job within that CI pipeline that is not triggered yet. In such a case,
the StartedAt field is not populated, which triggered a panic.

To fix this, we use `time.Now()` if `StartedAt` is nil, which means that
the job will be displayed with a duration of 0.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #727

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally to a private gitlab instance which has triggered jobs.

**Screenshots (if appropriate):**
```
(failed) • 03m 47s      test            test
(success) • 01m 00s     test            my
(success) • 09m 37s     test            super
(success) • 00m 23s     test            jobs
(manual) • not started  test            triggered

https://privateinstance.com/myproject/-/pipelines/1
SHA: ...
Pipeline State: failed

? Choose an action:  [Use arrows to move, type to filter]
  View Logs
  Retry
> Exit
```

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
