### PR TITLE
fix: `:id` placeholder in `api` command

### DIFF
--- a/commands/api/api.go
+++ b/commands/api/api.go
@@ -359,9 +359,9 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 		switch m {
 		case ":id":
 			h, _ := opts.HttpClient()
-			baseProject, e := api.GetProject(h, baseRepo.FullName())
-			if e == nil && baseProject != nil {
-				return string(rune(baseProject.ID))
+			project, e := baseRepo.Project(h)
+			if e == nil && project != nil {
+				return strconv.Itoa(project.ID)
 			}
 			err = e
 			return ""


### PR DESCRIPTION
Using `:id` placeholder in api command fails with `Project Not Found`. 
This is caused by directly converting the int to rune before converting to string producing an ascii character (`�`)

This PR fixes this issue.

Related to #657 #663 