### PR TITLE
fix(ci/status): adding list of external jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _test
 
 # VsCode
 .vscode/
+.devcontainer
 
 # Dist binaries created at build with make rt
 /dist

--- a/api/commit.go
+++ b/api/commit.go
@@ -1,0 +1,19 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+var GetCommitStatuses = func(client *gitlab.Client, pid interface{}, sha string) ([]*gitlab.CommitStatus, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	opt := &gitlab.GetCommitStatusesOptions{
+		All: gitlab.Bool(true),
+	}
+
+	statuses, _, err := client.Commits.GetCommitStatuses(pid, sha, opt, nil)
+	if err != nil {
+		return nil, err
+	}
+	return statuses, nil
+}

--- a/commands/ci/ciutils/utils.go
+++ b/commands/ci/ciutils/utils.go
@@ -35,6 +35,7 @@ func DisplayMultiplePipelines(c *iostreams.ColorPalette, p []*gitlab.PipelineInf
 			if pipeline.CreatedAt != nil {
 				duration = c.Magenta("(" + utils.TimeToPrettyTimeAgo(*pipeline.CreatedAt) + ")")
 			}
+
 			var pipeState string
 			if pipeline.Status == "success" {
 				pipeState = c.Green(fmt.Sprintf("(%s) • #%d", pipeline.Status, pipeline.ID))


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
I use GitLab on my work but the CI is not configured in the GitLab, the status/link is attached to the commit, so when using the command `glab ci status` I got this error:

<img width="1584" alt="Screenshot 2021-06-05 at 22 42 50" src="https://user-images.githubusercontent.com/18292879/120909027-6480e780-c668-11eb-9b11-bf4df28acf51.png">

This pull request adds one more verification and when no job is found for the pipeline, it tries to list the commit statuses.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #751 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests were made on a local instance of GitLab.

**Screenshots (if appropriate):**

<img width="1323" alt="Screenshot 2021-06-06 at 01 29 34" src="https://user-images.githubusercontent.com/18292879/120909062-d5c09a80-c668-11eb-9824-1c7765c08793.png">

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
