### PR TITLE
Fix MR operations for detached heads

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Please avoid:
 Prerequisites:
 - Go 1.13+
 
-Build with: `make` or `go build -o bin/glab ./cmd/main.go`
+Build with: `make` or `go build -o bin/glab ./cmd/glab/main.go`
 
 Run the new binary as: `./bin/glab`
 

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -150,7 +150,7 @@ func MRFromArgsWithOpts(
 		}
 	}
 
-	if branch == "" {
+	if branch == "" && mrID == 0 {
 		branch, err = f.Branch()
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
**Description**
This fixes a problem with detached heads, where glab tries to find a branch even though an MR ID was given and a branch is not necessary to execute the command.

(also fixes a minor documentation issue I found while trying to setup things to get started)

**Related Issue**
I can't reopen the issue #735 but as stated there, it was not fixed with the latest release
Resolves #735 

**How Has This Been Tested?**
Manually executing `glab mr diff` with an ID on a git setup with a detached head

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
