### PR TITLE
Respect job ID when passing it to the trace command

### DIFF
--- a/api/pipeline.go
+++ b/api/pipeline.go
@@ -232,13 +232,13 @@ var GetPipelineFromBranch = func(client *gitlab.Client, ref, repo string) ([]*gi
 	return jobs, nil
 }
 
-var PipelineJobTraceWithSha = func(client *gitlab.Client, pid interface{}, sha, name string) (io.Reader, *gitlab.Job, error) {
+var PipelineJobWithSha = func(client *gitlab.Client, pid interface{}, sha, name string) (*gitlab.Job, error) {
 	if client == nil {
 		client = apiClient.Lab()
 	}
 	jobs, err := PipelineJobsWithSha(client, pid, sha)
 	if len(jobs) == 0 || err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	var (
 		job          *gitlab.Job
@@ -267,12 +267,7 @@ var PipelineJobTraceWithSha = func(client *gitlab.Client, pid interface{}, sha, 
 	if job == nil {
 		job = jobs[len(jobs)-1]
 	}
-	r, _, err := client.Jobs.GetTraceFile(pid, job.ID)
-	if err != nil {
-		return nil, job, err
-	}
-
-	return r, job, err
+	return job, err
 }
 
 type JobSort struct {

--- a/commands/ci/trace/trace.go
+++ b/commands/ci/trace/trace.go
@@ -156,7 +156,7 @@ func TraceRun(opts *TraceOpts) error {
 	}
 	fmt.Fprintln(opts.IO.StdOut)
 
-	err = ciutils.RunTrace(context.Background(), apiClient, opts.IO.StdOut, repo.FullName(), job.Pipeline.Sha, job.Name)
+	err = ciutils.RunTrace(context.Background(), apiClient, opts.IO.StdOut, repo.FullName(), job, job.Name)
 	if err != nil {
 		return err
 	}

--- a/commands/ci/view/view.go
+++ b/commands/ci/view/view.go
@@ -247,7 +247,7 @@ func inputCapture(app *tview.Application, root *tview.Pages, navi navigator, inp
 			app.Suspend(func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
-					err := ciutils.RunTrace(ctx, opts.ApiClient, opts.Output, opts.ProjectID, opts.CommitSHA, curJob.Name)
+					err := ciutils.RunTraceSha(ctx, opts.ApiClient, opts.Output, opts.ProjectID, opts.CommitSHA, curJob.Name)
 					if err != nil {
 						app.Stop()
 						log.Fatal(err)
@@ -410,7 +410,7 @@ func jobsView(app *tview.Application, jobsCh chan []*gitlab.Job, inputCh chan st
 			tv.SetBorderPadding(0, 0, 1, 1).SetBorder(true)
 
 			go func() {
-				err := ciutils.RunTrace(context.Background(), opts.ApiClient, vtclean.NewWriter(tview.ANSIWriter(tv), true), opts.ProjectID, opts.CommitSHA, curJob.Name)
+				err := ciutils.RunTraceSha(context.Background(), opts.ApiClient, vtclean.NewWriter(tview.ANSIWriter(tv), true), opts.ProjectID, opts.CommitSHA, curJob.Name)
 				if err != nil {
 					app.Stop()
 					log.Fatal(err)


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
Reworked the RunTrace command so it takes a job instead of an SHA. It then respects that. View that passes in an SHA runs through RunTraceSha which then passes it the result onto RunTrace.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #766 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Thought I'd wait on feedback from this change first. If it's approved I'll take a punt at tests.

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Chore (Related to CI or Packaging to platforms)
