### PR TITLE
Add project view command

### DIFF
--- a/api/repository_files.go
+++ b/api/repository_files.go
@@ -1,0 +1,21 @@
+package api
+
+import "github.com/xanzy/go-gitlab"
+
+// GetFile retrieves a file from repository. Note that file content is Base64 encoded.
+var GetFile = func(client *gitlab.Client, projectID interface{}, path string, ref string) (*gitlab.File, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	fileOpts := &gitlab.GetFileOptions{
+		Ref: &ref,
+	}
+	file, _, err := client.RepositoryFiles.GetFile(projectID, path, fileOpts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/commands/project/repo.go
+++ b/commands/project/repo.go
@@ -9,6 +9,7 @@ import (
 	repoCmdDelete "github.com/profclems/glab/commands/project/delete"
 	repoCmdFork "github.com/profclems/glab/commands/project/fork"
 	repoCmdSearch "github.com/profclems/glab/commands/project/search"
+	repoCmdView "github.com/profclems/glab/commands/project/view"
 
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,7 @@ func NewCmdRepo(f *cmdutils.Factory) *cobra.Command {
 	repoCmd.AddCommand(repoCmdDelete.NewCmdDelete(f))
 	repoCmd.AddCommand(repoCmdFork.NewCmdFork(f, nil))
 	repoCmd.AddCommand(repoCmdSearch.NewCmdSearch(f))
+	repoCmd.AddCommand(repoCmdView.NewCmdView(f))
 
 	return repoCmd
 }

--- a/commands/project/view/project_view.go
+++ b/commands/project/view/project_view.go
@@ -198,10 +198,11 @@ func printProjectContentTTY(opts *ViewOptions, project *gitlab.Project, readme *
 	fmt.Fprint(opts.IO.StdOut, c.Bold(fullName))
 	fmt.Fprint(opts.IO.StdOut, c.Gray(description))
 
+	// Readme
 	if readme != nil {
 		fmt.Fprint(opts.IO.StdOut, readmeContent)
 	} else {
-		fmt.Fprint(opts.IO.StdOut, c.Gray("This repository does not have a README file"))
+		fmt.Fprintln(opts.IO.StdOut, c.Gray("(This repository does not have a README file)"))
 	}
 
 	fmt.Fprintln(opts.IO.StdOut)

--- a/commands/project/view/project_view.go
+++ b/commands/project/view/project_view.go
@@ -1,0 +1,224 @@
+package view
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/pkg/git"
+	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/profclems/glab/pkg/utils"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+	"strings"
+)
+
+type ViewOptions struct {
+	ProjectID    string
+	ApiClient    *gitlab.Client
+	Web          bool
+	Branch       string
+	Browser      string
+	GlamourStyle string
+
+	IO *iostreams.IOStreams
+}
+
+func NewCmdView(f *cmdutils.Factory) *cobra.Command {
+	opts := ViewOptions{
+		IO: f.IO,
+	}
+
+	var projectViewCmd = &cobra.Command{
+		Use:   "view [repository] [flags]",
+		Short: "View a project/repository",
+		Long:  `Display the description and README of a project or open it in the browser.`,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+
+			if opts.ProjectID == "" {
+				if len(args) == 1 {
+					opts.ProjectID = args[0]
+				} else {
+					opts.ProjectID = repo.FullName()
+				}
+			}
+
+			if opts.Branch == "" {
+				opts.Branch, err = git.CurrentBranch()
+				if err != nil {
+					return err
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			browser, _ := cfg.Get(repo.RepoHost(), "browser")
+			opts.Browser = browser
+
+			opts.GlamourStyle, _ = cfg.Get(repo.RepoHost(), "glamour_style")
+
+			apiClient, err := f.HttpClient()
+			if err != nil {
+				return err
+			}
+
+			opts.ApiClient = apiClient
+
+			return runViewProject(&opts)
+		},
+		Example: heredoc.Doc(`
+			# view project information for the current directory
+			$ glab repo view
+
+			# view project information of specified name
+			$ glab repo view my-project
+		`),
+	}
+
+	projectViewCmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a project in the browser")
+	projectViewCmd.Flags().StringVarP(&opts.Branch, "branch", "b", "", "View a specific branch of the repository")
+
+	return projectViewCmd
+}
+
+func runViewProject(opts *ViewOptions) error {
+	repoPath := opts.ProjectID
+
+	if !strings.Contains(repoPath, "/") {
+		currentUser, err := api.CurrentUser(opts.ApiClient)
+
+		if err != nil {
+			fmt.Fprintf(opts.IO.StdErr, "Failed to retrieve your current user: %s", err)
+
+			return err
+		}
+
+		repoPath = currentUser.Username + "/" + repoPath
+	}
+
+	project, err := api.GetProject(opts.ApiClient, repoPath)
+	if err != nil {
+		fmt.Fprintf(opts.IO.StdErr, "Failed to access project API: %s", err)
+
+		return err
+	}
+
+	readmeFile := getReadmeFile(opts, project)
+
+	if opts.Web {
+		openURL := generateProjectURL(project, opts.Branch)
+
+		if opts.IO.IsaTTY {
+			fmt.Fprintf(opts.IO.StdOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
+		}
+
+		return utils.OpenInBrowser(openURL, opts.Browser)
+	} else {
+		if opts.IO.IsaTTY {
+			printProjectContentTTY(opts, project, readmeFile)
+		} else {
+			printProjectContentRaw(opts, project, readmeFile)
+		}
+	}
+
+	return nil
+}
+
+func getReadmeFile(opts *ViewOptions, project *gitlab.Project) *gitlab.File {
+	if project.ReadmeURL == "" {
+		return nil
+	}
+
+	readmePath := strings.Replace(project.ReadmeURL, project.WebURL+"/-/blob/", "", 1)
+	readmePathComponents := strings.Split(readmePath, "/")
+	readmeRef := readmePathComponents[0]
+	readmeFileName := readmePathComponents[1]
+	readmeFile, err := api.GetFile(opts.ApiClient, project.PathWithNamespace, readmeFileName, readmeRef)
+
+	if err != nil {
+		fmt.Fprintf(opts.IO.StdErr, "Failed to retrieve README file: %s", err)
+
+		return nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(readmeFile.Content)
+	if err != nil {
+		fmt.Fprintf(opts.IO.StdErr, "Failed to decode README file: %s", err)
+
+		return nil
+	}
+
+	readmeFile.Content = string(decoded)
+
+	return readmeFile
+}
+
+func generateProjectURL(project *gitlab.Project, branch string) string {
+	if project.DefaultBranch != branch {
+		return project.WebURL + "/-/tree/" + branch
+	}
+
+	return project.WebURL
+}
+
+func printProjectContentTTY(opts *ViewOptions, project *gitlab.Project, readme *gitlab.File) {
+	var description string
+	var readmeContent string
+	var err error
+
+	fullName := project.NameWithNamespace
+	if project.Description != "" {
+		description, err = utils.RenderMarkdownWithoutIndentations(project.Description, opts.GlamourStyle)
+
+		if err != nil {
+			description = project.Description
+		}
+	} else {
+		description = "(No description provided)"
+	}
+
+	if readme != nil {
+		readmeContent, err = utils.RenderMarkdown(readme.Content, opts.GlamourStyle)
+
+		if err != nil {
+			readmeContent = readme.Content
+		}
+	}
+
+	c := opts.IO.Color()
+	// Header
+	fmt.Fprint(opts.IO.StdOut, c.Bold(fullName))
+	fmt.Fprint(opts.IO.StdOut, c.Gray(description))
+
+	if readme != nil {
+		fmt.Fprint(opts.IO.StdOut, readmeContent)
+	} else {
+		fmt.Fprint(opts.IO.StdOut, c.Gray("This repository does not have a README file"))
+	}
+
+	fmt.Fprintln(opts.IO.StdOut)
+	fmt.Fprintf(opts.IO.StdOut, c.Gray("View this project on GitLab: %s\n"), project.WebURL)
+}
+
+func printProjectContentRaw(opts *ViewOptions, project *gitlab.Project, readme *gitlab.File) {
+	fullName := project.NameWithNamespace
+	description := project.Description
+
+	fmt.Fprintf(opts.IO.StdOut, "name:\t%s\n", fullName)
+	fmt.Fprintf(opts.IO.StdOut, "description:\t%s\n", description)
+
+	if readme != nil {
+		fmt.Fprintln(opts.IO.StdOut, "---")
+		fmt.Fprintf(opts.IO.StdOut, readme.Content)
+		fmt.Fprintln(opts.IO.StdOut)
+	}
+}

--- a/commands/project/view/project_view.go
+++ b/commands/project/view/project_view.go
@@ -34,6 +34,17 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 		Short: "View a project/repository",
 		Long:  `Display the description and README of a project or open it in the browser.`,
 		Args:  cobra.MaximumNArgs(1),
+		Example: heredoc.Doc(`
+			# view project information for the current directory
+			$ glab repo view
+
+			# view project information of specified name
+			$ glab repo view my-project
+
+			$ glab repo view user/repo
+
+			$ glab repo view group/namespace/repo
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			repo, _ := f.BaseRepo()
@@ -73,13 +84,6 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 
 			return runViewProject(&opts)
 		},
-		Example: heredoc.Doc(`
-			# view project information for the current directory
-			$ glab repo view
-
-			# view project information of specified name
-			$ glab repo view my-project
-		`),
 	}
 
 	projectViewCmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a project in the browser")

--- a/commands/project/view/project_view.go
+++ b/commands/project/view/project_view.go
@@ -182,7 +182,7 @@ func printProjectContentTTY(opts *ViewOptions, project *gitlab.Project, readme *
 			description = project.Description
 		}
 	} else {
-		description = "(No description provided)"
+		description = "\n(No description provided)\n\n"
 	}
 
 	if readme != nil {

--- a/commands/project/view/project_view.go
+++ b/commands/project/view/project_view.go
@@ -35,24 +35,19 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 		Long:  `Display the description and README of a project or open it in the browser.`,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			repo, err := f.BaseRepo()
-			if err != nil {
-				return err
-			}
+			var err error
+			repo, _ := f.BaseRepo()
 
 			if opts.ProjectID == "" {
 				if len(args) == 1 {
 					opts.ProjectID = args[0]
-				} else {
+				} else if repo != nil {
 					opts.ProjectID = repo.FullName()
 				}
 			}
 
 			if opts.Branch == "" {
-				opts.Branch, err = f.Branch()
-				if err != nil {
-					return err
-				}
+				opts.Branch, _ = f.Branch()
 			}
 
 			cfg, err := f.Config()
@@ -60,16 +55,20 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			browser, _ := cfg.Get(repo.RepoHost(), "browser")
+			var repoHost string
+			if repo != nil {
+				repoHost = repo.RepoHost()
+			}
+
+			browser, _ := cfg.Get(repoHost, "browser")
 			opts.Browser = browser
 
-			opts.GlamourStyle, _ = cfg.Get(repo.RepoHost(), "glamour_style")
+			opts.GlamourStyle, _ = cfg.Get(repoHost, "glamour_style")
 
 			apiClient, err := f.HttpClient()
 			if err != nil {
 				return err
 			}
-
 			opts.APIClient = apiClient
 
 			return runViewProject(&opts)

--- a/internal/glrepo/repo.go
+++ b/internal/glrepo/repo.go
@@ -190,8 +190,10 @@ func normalizeHostname(h string) string {
 
 // IsSame compares two GitLab repositories
 func IsSame(a, b Interface) bool {
-	return strings.EqualFold(a.RepoOwner(), b.RepoOwner()) &&
-		strings.EqualFold(a.RepoName(), b.RepoName()) &&
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.EqualFold(a.FullName(), b.FullName()) &&
 		normalizeHostname(a.RepoHost()) == normalizeHostname(b.RepoHost())
 }
 


### PR DESCRIPTION
**Description**
Adds `glab project view [repository] [flags]` command.

View, will render project name, description and README. Optionally you can pass `--web` and it will open the project in your default browser instead.

If you don't pass a `repository` path, it will try to infer based on current git repository. If it finds, it will also use current branch to retrieve the README from, or to open the browser project page within that branch.

It also accepts just a repository name without a namespace, in which it will use your own username as the namespace.

Ex: `glab project view glab` will open the `brodock/glab` in my case.

**Related Issue**
Resolves #777 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've only tested this manually. Will work on adding go tests.

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
