### PR TITLE
Update incorrect parameters

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -83,7 +83,7 @@ func NewCmdCreate(f *cmdutils.Factory, runE func(opts *CreateOpts) error) *cobra
 			$ glab mr new
 			$ glab mr create -a username -t "fix annoying bug"
 			$ glab mr create -f --draft --label RFC
-			$ glab mr create --autofill --yes --web
+			$ glab mr create --fill --yes --web
 		`),
 		Args: cobra.ExactArgs(0),
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -112,7 +112,7 @@ func NewCmdCreate(f *cmdutils.Factory, runE func(opts *CreateOpts) error) *cobra
 
 			if hasTitle && hasDescription && opts.Autofill {
 				return &cmdutils.FlagError{
-					Err: errors.New("usage of --title and --description completely override --autofill"),
+					Err: errors.New("usage of --title and --description completely override --fill"),
 				}
 			}
 			if opts.IsInteractive && !opts.IO.PromptEnabled() && !opts.Autofill {


### PR DESCRIPTION
**Description**
`--autofill` was used. This option isn't in use anymore.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
