### PR TITLE
feat mr: remove prefix in ID of MR just like Issue

### DIFF
--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -142,7 +142,7 @@ func MRFromArgsWithOpts(
 	var branch string
 
 	if len(args) > 0 {
-		mrID, err = strconv.Atoi(args[0])
+		mrID, err = strconv.Atoi(strings.TrimPrefix(args[0], "!"))
 		if err != nil {
 			branch = args[0]
 		} else if mrID == 0 { // to check for cases where the user explicitly specified mrID to be zero


### PR DESCRIPTION
This change

- improves consistency of APIs.
- is copied from: https://github.com/profclems/glab/blob/0232a0c0791374ef5c1fa2072582a7127126b078/commands/issue/issueutils/utils.go#L106
- makes pipes easier
    - e.g., `glab mr list | fzf | grep -oE "^\S+" | glab mr view`
    - this is what atusy/gh-fzf internally does

**Description**

This change adds support for a prefix in MR ID like below.

```bash
glab mr view \!1
```

**Related Issue**

Resolves #789 

**How Has This Been Tested?**

Run below on manjaro linux.

```bash
glab repo clone gitlab-org/gitlab-foss -- --depth 1
glab mr view "\!1"
```

**Screenshots (if appropriate):**

![image](https://user-images.githubusercontent.com/30277794/125441356-0be5b431-bb32-41f2-8d85-22d01c87d353.png)


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
