### PR TITLE
Apply --no-desc to every shell for completion

### DIFF
--- a/commands/completion/completion.go
+++ b/commands/completion/completion.go
@@ -48,9 +48,15 @@ For Homebrew, see <https://docs.brew.sh/Shell-Completion>
 			case "bash":
 				return rootCmd.GenBashCompletionV2(out, !excludeDesc)
 			case "zsh":
+				if excludeDesc {
+					return rootCmd.GenZshCompletionNoDesc(out)
+				}
 				return rootCmd.GenZshCompletion(out)
 			case "powershell":
-				return rootCmd.GenPowerShellCompletion(out)
+				if excludeDesc {
+					return rootCmd.GenPowerShellCompletion(out)
+				}
+				return rootCmd.GenPowerShellCompletionWithDesc(out)
 			case "fish":
 				return rootCmd.GenFishCompletion(out, !excludeDesc)
 			default:
@@ -60,6 +66,6 @@ For Homebrew, see <https://docs.brew.sh/Shell-Completion>
 	}
 
 	completionCmd.Flags().StringVarP(&shellType, "shell", "s", "bash", "Shell type: {bash|zsh|fish|powershell}")
-	completionCmd.Flags().BoolVarP(&excludeDesc, "no-desc", "", false, "Do not include shell completion description. Only for bash and fish")
+	completionCmd.Flags().BoolVarP(&excludeDesc, "no-desc", "", false, "Do not include shell completion description")
 	return completionCmd
 }


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->

This PR enables completion descriptions for `powershell` (including the `--no-desc` flag).
It also applies the `--no-desc` flag for `zsh` completion.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #800

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested for both powershell and zsh.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
