### PR TITLE
goreleaser: fix nfpms install dir to use /usr/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,7 +119,7 @@ nfpms:
     vendor: Clement Sam
     homepage: https://github.com/profclems/glab
     maintainer: Clement Sam <clementsam75@gmail.com>
-    description: An open source gitlab cli tool
+    description: An open source GitLab CLI tool
     license: MIT
     formats:
       - apk
@@ -127,9 +127,7 @@ nfpms:
       - rpm
     dependencies:
       - git
-    # Override default /usr/local/bin destination for binaries
-    # Since glab is already archived in the bin directory it would install in /usr/bin/glab
-    bindir: /usr
+    bindir: /usr/bin
     contents:
       - src: "./share/man/man1/glab*.1"
         dst: "/usr/share/man/man1"


### PR DESCRIPTION
Closes #816
