### PR TITLE
feat: fill MR desc with all commit bodies

### DIFF
--- a/commands/mr/create/mr_create_test.go
+++ b/commands/mr/create/mr_create_test.go
@@ -278,4 +278,37 @@ like this
 resolves #1
 `, opts.Description)
 	})
+	t.Run("given-fill-commit-body", func(t *testing.T) {
+		opts = &CreateOpts{
+			SourceBranch:         "mr-autofill-test-br",
+			TargetBranch:         "master",
+			TargetTrackingBranch: "origin/master",
+		}
+		cs, csTeardown := test.InitCmdStubber()
+		defer csTeardown()
+
+		cs.Stub("d1sd2e,chore: some tidying\nd2asa3,docs: more changes to more things")
+		cs.Stub("Here, I am adding some commit body.\nLittle longer\n\nResolves #1\n")
+		cs.Stub("another body for another commit\ncloses 1234\n")
+
+		opts := *opts
+		opts.FillCommitBody = true
+
+		if err := mrBodyAndTitle(&opts); err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+
+		assert.Equal(t, "mr autofill test br", opts.Title)
+		assert.Equal(t, `- docs: more changes to more things  
+Here, I am adding some commit body.
+Little longer  
+Resolves #1
+
+- chore: some tidying  
+another body for another commit
+closes 1234
+
+`, opts.Description)
+	})
 }


### PR DESCRIPTION
**Description**
adds --fill-commit-body flag to add all the commit bodies to the MR description
when creating an my with --fill

closes #795

**Related Issue**
Resolves #795


**How Has This Been Tested?**
Wrote tests for this and tested on personal gitlab account

**Screenshots (if appropriate):**
@profclems @zemzale not sure how I feel about the formatting, ends up looking kinda weird because of the indentation

![2021-08-12_005937](https://user-images.githubusercontent.com/1794071/129118856-34ebcb27-cf05-4516-8e96-4a9ffe8c466a.png)


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
