### PR TITLE
commands/ssh-key: fix wrong usage description in `ssh-key add`

### DIFF
--- a/commands/ssh-key/add/add.go
+++ b/commands/ssh-key/add/add.go
@@ -31,7 +31,7 @@ func NewCmdAdd(f *cmdutils.Factory, runE func(*AddOpts) error) *cobra.Command {
 		IO: f.IO,
 	}
 	cmd := &cobra.Command{
-		Use:   "add <title> [key-file]",
+		Use:   "add [key-file]",
 		Short: "Add an SSH key to your GitLab account",
 		Long: heredoc.Doc(`
 		Creates a new SSH key owned by the currently authenticated user.


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #814 

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
