### PR TITLE
fix: allow token or stdin in non interactive shells

### DIFF
--- a/commands/auth/login/login.go
+++ b/commands/auth/login/login.go
@@ -59,7 +59,7 @@ func NewCmdLogin(f *cmdutils.Factory) *cobra.Command {
 			$ glab auth login --hostname salsa.debian.org
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.IO.PromptEnabled() && !(tokenStdin || opts.Token == "") {
+			if !opts.IO.PromptEnabled() && (!tokenStdin || opts.Token == "") {
 				return &cmdutils.FlagError{Err: errors.New("--stdin or --token required when not running interactively")}
 			}
 


### PR DESCRIPTION
Signed-off-by: Seena Fallah <seenafallah@gmail.com>

**Description**
Condition for checking login args in noninteractive mode was wrong and should check if one of stdin or token is provided is ok

**Related Issue**
Resolves #822

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
