### PR TITLE
feat(cmdutils): Add project and group milestone prompt

### DIFF
--- a/api/milestone.go
+++ b/api/milestone.go
@@ -4,9 +4,87 @@ import (
 	"fmt"
 
 	"github.com/xanzy/go-gitlab"
+	"golang.org/x/sync/errgroup"
 )
 
-var ListMilestones = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, error) {
+// Describe namespace kinds which is either group or user
+// See docs: https://docs.gitlab.com/ee/api/namespaces.html
+const (
+	NamespaceKindUser  = "user"
+	NamespaceKindGroup = "group"
+)
+
+type Milestone struct {
+	ID    int
+	Title string
+}
+
+func NewProjectMilestone(m *gitlab.Milestone) *Milestone {
+	return &Milestone{
+		ID:    m.ID,
+		Title: m.Title,
+	}
+}
+
+func NewGroupMilestone(m *gitlab.GroupMilestone) *Milestone {
+	return &Milestone{
+		ID:    m.ID,
+		Title: m.Title,
+	}
+}
+
+type ListMilestonesOptions struct {
+	IIDs                    []int
+	State                   *string
+	Title                   *string
+	Search                  *string
+	IncludeParentMilestones *bool
+	PerPage                 int
+	Page                    int
+}
+
+func (opts *ListMilestonesOptions) ListProjectMilestonesOptions() *gitlab.ListMilestonesOptions {
+	projectOpts := &gitlab.ListMilestonesOptions{
+		IIDs:   opts.IIDs,
+		State:  opts.State,
+		Title:  opts.Title,
+		Search: opts.Search,
+	}
+	projectOpts.PerPage = opts.PerPage
+	projectOpts.Page = opts.Page
+	return projectOpts
+}
+
+func (opts *ListMilestonesOptions) ListGroupMilestonesOptions() *gitlab.ListGroupMilestonesOptions {
+	groupOpts := &gitlab.ListGroupMilestonesOptions{
+		IIDs:                    opts.IIDs,
+		State:                   opts.State,
+		Title:                   opts.Title,
+		Search:                  opts.Search,
+		IncludeParentMilestones: opts.IncludeParentMilestones,
+	}
+	groupOpts.PerPage = opts.PerPage
+	groupOpts.Page = opts.Page
+	return groupOpts
+}
+
+var ListGroupMilestones = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupMilestonesOptions) ([]*gitlab.GroupMilestone, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	if opts.PerPage == 0 {
+		opts.PerPage = DefaultListLimit
+	}
+
+	milestone, _, err := client.GroupMilestones.ListGroupMilestones(groupID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return milestone, nil
+}
+
+var ListProjectMilestones = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, error) {
 	if client == nil {
 		client = apiClient.Lab()
 	}
@@ -22,7 +100,7 @@ var ListMilestones = func(client *gitlab.Client, projectID interface{}, opts *gi
 	return milestone, nil
 }
 
-var MilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
+var ProjectMilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
 	opts := &gitlab.ListMilestonesOptions{Title: gitlab.String(name)}
 
 	if client == nil {
@@ -43,4 +121,44 @@ var MilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name s
 	}
 
 	return milestones[0], nil
+}
+
+var ListAllMilestones = func(client *gitlab.Client, projectID interface{}, opts *ListMilestonesOptions) ([]*Milestone, error) {
+	project, err := GetProject(client, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	errGroup := &errgroup.Group{}
+	projectMilestones := []*gitlab.Milestone{}
+	groupMilestones := []*gitlab.GroupMilestone{}
+
+	errGroup.Go(func() error {
+		var err error
+		projectMilestones, err = ListProjectMilestones(client, projectID, opts.ListProjectMilestonesOptions())
+		return err
+	})
+
+	if project.Namespace.Kind == NamespaceKindGroup {
+		errGroup.Go(func() error {
+			var err error
+			groupMilestones, err = ListGroupMilestones(client, project.Namespace.ID, opts.ListGroupMilestonesOptions())
+			return err
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to get all project related milestones. %w", err)
+	}
+
+	milestones := make([]*Milestone, 0, len(projectMilestones)+len(groupMilestones))
+	for _, v := range projectMilestones {
+		milestones = append(milestones, NewProjectMilestone(v))
+	}
+
+	for _, v := range groupMilestones {
+		milestones = append(milestones, NewGroupMilestone(v))
+	}
+
+	return milestones, nil
 }

--- a/commands/cmdutils/cmdutils_test.go
+++ b/commands/cmdutils/cmdutils_test.go
@@ -479,7 +479,7 @@ func Test_ParseMilestoneTitleIsID(t *testing.T) {
 	expectedMilestoneID := 1
 
 	// Override function to return an error, it should never reach this
-	api.MilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
+	api.ProjectMilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
 		return nil, fmt.Errorf("We shouldn't have reached here")
 	}
 
@@ -497,7 +497,7 @@ func Test_ParseMilestoneAPIFail(t *testing.T) {
 	want := "api call failed in api.MilestoneByTitle()"
 
 	// Override function to return an error simulating an API call failure
-	api.MilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
+	api.ProjectMilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
 		return nil, fmt.Errorf("api call failed in api.MilestoneByTitle()")
 	}
 
@@ -515,7 +515,7 @@ func Test_ParseMilestoneTitleToID(t *testing.T) {
 	expectedID := 3
 
 	// Override function so it returns the correct milestone
-	api.MilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
+	api.ProjectMilestoneByTitle = func(client *gitlab.Client, projectID interface{}, name string) (*gitlab.Milestone, error) {
 		return &gitlab.Milestone{
 				Title: "kind: testing",
 				ID:    3,
@@ -817,7 +817,7 @@ func Test_AssigneesPrompt(t *testing.T) {
 }
 
 func Test_MilestonesPrompt(t *testing.T) {
-	mockMilestones := []*gitlab.Milestone{
+	mockMilestones := []*api.Milestone{
 		{
 			Title: "New Release",
 			ID:    5,
@@ -833,7 +833,7 @@ func Test_MilestonesPrompt(t *testing.T) {
 	}
 
 	// Override API.ListMilestones so it doesn't make any network calls
-	api.ListMilestones = func(_ *gitlab.Client, _ interface{}, _ *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, error) {
+	api.ListAllMilestones = func(_ *gitlab.Client, _ interface{}, _ *api.ListMilestonesOptions) ([]*api.Milestone, error) {
 		return mockMilestones, nil
 	}
 
@@ -908,8 +908,8 @@ func Test_MilestonesPromptNoPrompts(t *testing.T) {
 	// Override api.ListMilestones so it returns an empty slice, we are testing if MilestonesPrompt()
 	// will print the correct message to `stderr` when it tries to get the list of Milestones in a
 	// project but the project has no milestones
-	api.ListMilestones = func(_ *gitlab.Client, _ interface{}, _ *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, error) {
-		return []*gitlab.Milestone{}, nil
+	api.ListAllMilestones = func(_ *gitlab.Client, _ interface{}, _ *api.ListMilestonesOptions) ([]*api.Milestone, error) {
+		return []*api.Milestone{}, nil
 	}
 
 	// mock glrepo.Remote object
@@ -936,7 +936,7 @@ func Test_MilestonesPromptNoPrompts(t *testing.T) {
 func TestMilestonesPromptFailures(t *testing.T) {
 	// Override api.ListMilestones so it returns an error, we are testing to see if error
 	// handling from the usage of api.ListMilestones is correct
-	api.ListMilestones = func(_ *gitlab.Client, _ interface{}, _ *gitlab.ListMilestonesOptions) ([]*gitlab.Milestone, error) {
+	api.ListAllMilestones = func(_ *gitlab.Client, _ interface{}, _ *api.ListMilestonesOptions) ([]*api.Milestone, error) {
 		return nil, errors.New("api.ListMilestones() failed")
 	}
 


### PR DESCRIPTION
**Description**

When creating issues we prompted only project milestones. This would break workflows where group milestones were used.

This PR adds listing of all project related milestones in the prompt. That includes group and parent group milestones. I had to somehow normalize the milestone APIs because they are two different APIs. I didn't look into if the responses are identical(lack of time) but if it's needed we can always expand the current normalized structs to have all the needed attributes.
For this, we only need the title and ID so that is all I added. 

Request to the group API only happens if the project namespace is group, otherwise the API would 404 with no group found error. 

I also made fetching of milestones concurrent to improve the performance a bit.

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #698

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and testing against all kinds of group user configurations on Gitlab.com

**Screenshots (if appropriate):**

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
