### PR TITLE
fix(pipeline): allow pipeline parameters to use colons in the values

### DIFF
--- a/commands/ci/run/run.go
+++ b/commands/ci/run/run.go
@@ -70,7 +70,7 @@ func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
 					if !re.MatchString(v) {
 						return fmt.Errorf("Bad pipeline variable : \"%s\" should be of format KEY:VALUE", v)
 					}
-					s := strings.Split(v, ":")
+					s := strings.SplitN(v, ":", 2)
 					pipelineVars = append(pipelineVars, &gitlab.PipelineVariable{
 						Key:          s[0],
 						Value:        s[1],


### PR DESCRIPTION
    Fixes #829

**Description**
Currently if you try to pass in a pipeline variable which includes colons, the input is not passed through correctly. Anything beyond the first colon is thrown away.

This fix will only split the input at the first colon (:) and keep the rest of the value intact.

**Related Issue**
Resolves #829 

**How Has This Been Tested?**
The following example is representative of one I have had to use at my company. 
I have compiled the code with this fix in and have used it successfully in a private Gitlab instance.

```
glab ci run --variables GROUP_NAME:test-group,DAY_OF_WEEK:Wednesday,START_TIME:05:50pm
```

GitLab version is 13.12.8 Enterprise Edition

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
