### PR TITLE
docs: remove --autofill references

### DIFF
--- a/commands/mr/mr.go
+++ b/commands/mr/mr.go
@@ -33,7 +33,7 @@ func NewCmdMR(f *cmdutils.Factory) *cobra.Command {
 		Short: `Create, view and manage merge requests`,
 		Long:  ``,
 		Example: heredoc.Doc(`
-			$ glab mr create --autofill --labels bugfix
+			$ glab mr create --fill --labels bugfix
 			$ glab mr merge 123
 			$ glab mr note -m "needs to do X before it can be merged" branch-foo
 		`),

--- a/docs/source/mr/index.rst
+++ b/docs/source/mr/index.rst
@@ -16,7 +16,7 @@ Examples
 
 ::
 
-  $ glab mr create --autofill --labels bugfix
+  $ glab mr create --fill --labels bugfix
   $ glab mr merge 123
   $ glab mr note -m "needs to do X before it can be merged" branch-foo
   


### PR DESCRIPTION
It appears the --autofill option to ``glab mr create`` was removed, but references remained in examples & docs.

(on glab v 1.16.0):

```bash
$ glab mr create --help
Create new merge request

USAGE
  glab mr create [flags]

ALIASES
  [...]

EXAMPLES
  $ glab mr new
  $ glab mr create -a username -t "fix annoying bug"
  $ glab mr create -f --draft --label RFC
  $ glab mr create --autofill --yes --web

$ glab mr create --autofill
unknown flag: --autofill

Usage:  glab mr create [flags]

Flags:
      [...]
```