### PR TITLE
fix(ci trace): exit normally when prompts are interrupted

### DIFF
--- a/commands/ci/trace/trace.go
+++ b/commands/ci/trace/trace.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/profclems/glab/pkg/utils"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
@@ -114,7 +116,14 @@ func TraceRun(opts *TraceOpts) error {
 			Options: jobOptions,
 		}
 
-		_ = prompt.AskOne(promptOpts, &selectedJob)
+		err = prompt.AskOne(promptOpts, &selectedJob)
+		if err != nil {
+			if errors.Is(err, terminal.InterruptErr) {
+				return nil
+			}
+
+			return err
+		}
 
 		if selectedJob != "" {
 			re := regexp.MustCompile(`(?s)\((.*)\)`)


### PR DESCRIPTION
…specifically, interrupted via SIGINT (CTRL-C).  Otherwise,
the first job is chosen, which isn't a huge deal, but isn't really
consistent with the user's wish to exit the program early

**Description**

I noticed that if I do `glab ci trace` and CTRL-C to exit, the first job gets chosen, rather than exiting.

**Related Issue**

(none to my knowledge)

**How Has This Been Tested?**

I've only done manual testing so far; I'd run the automatic test suite but I don't want to blow my configuration away :grimacing: 

**Screenshots (if appropriate):**

N/A

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
