### PR TITLE
chore: use errors.Is instead of error equality

### DIFF
--- a/cmd/glab/main.go
+++ b/cmd/glab/main.go
@@ -156,7 +156,7 @@ func main() {
 }
 
 func printError(streams *iostreams.IOStreams, err error, cmd *cobra.Command, debug, shouldExit bool) {
-	if err == cmdutils.SilentError {
+	if errors.Is(err, cmdutils.SilentError) {
 		return
 	}
 	color := streams.Color()

--- a/commands/api/pagination.go
+++ b/commands/api/pagination.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,7 +39,7 @@ func findEndCursor(r io.Reader) string {
 loop:
 	for {
 		t, err := dec.Token()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/commands/project/clone/repo_clone.go
+++ b/commands/project/clone/repo_clone.go
@@ -1,6 +1,7 @@
 package clone
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -140,7 +141,7 @@ Clone a GitLab repository/project
 
 	repoCloneCmd.Flags().SortFlags = false
 	repoCloneCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		if err == pflag.ErrHelp {
+		if errors.Is(err, pflag.ErrHelp) {
 			return err
 		}
 		return &cmdutils.FlagError{Err: fmt.Errorf("%w\nSeparate git clone flags with '--'.", err)}

--- a/commands/root.go
+++ b/commands/root.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"errors"
+
 	"github.com/MakeNowJust/heredoc"
 	aliasCmd "github.com/profclems/glab/commands/alias"
 	apiCmd "github.com/profclems/glab/commands/api"
@@ -75,7 +77,7 @@ func NewCmdRoot(f *cmdutils.Factory, version, buildDate string) *cobra.Command {
 	})
 	rootCmd.SetUsageFunc(help.RootUsageFunc)
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		if err == pflag.ErrHelp {
+		if errors.Is(err, pflag.ErrHelp) {
 			return err
 		}
 		return &cmdutils.FlagError{Err: err}


### PR DESCRIPTION
This might be needlessly pedantic, but it insulates against potential
future changes in error wrapping

**Description**
Removes all of the checks I could find that directly compare error values, rather than using `errors.Is`

**Related Issue**
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
N/A

**How Has This Been Tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I just made sure the code compiles, plus I did a few one-off manual tests.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Chore (Related to CI or Packaging to platforms)
