### PR TITLE
feat(mr create): add --reviewer parameter

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -33,6 +33,7 @@ type CreateOpts struct {
 	TargetTrackingBranch  string
 	Labels                []string
 	Assignees             []string
+	Reviewers             []string
 	MileStone             int
 	MilestoneFlag         string
 	MRCreateTargetProject string
@@ -149,6 +150,7 @@ func NewCmdCreate(f *cmdutils.Factory, runE func(opts *CreateOpts) error) *cobra
 	mrCreateCmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Supply a description for merge request")
 	mrCreateCmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", []string{}, "Add label by name. Multiple labels should be comma separated")
 	mrCreateCmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", []string{}, "Assign merge request to people by their `usernames`")
+	mrCreateCmd.Flags().StringSliceVarP(&opts.Reviewers, "reviewer", "", []string{}, "Request review from users by their `usernames`")
 	mrCreateCmd.Flags().StringVarP(&opts.SourceBranch, "source-branch", "s", "", "The Branch you are creating the merge request. Default is the current branch.")
 	mrCreateCmd.Flags().StringVarP(&opts.TargetBranch, "target-branch", "b", "", "The target or base branch into which you want your code merged")
 	mrCreateCmd.Flags().BoolVarP(&opts.CreateSourceBranch, "create-source-branch", "", false, "Create source branch if it does not exist")
@@ -442,6 +444,14 @@ func createRun(opts *CreateOpts) error {
 			return err
 		}
 		mrCreateOpts.AssigneeIDs = cmdutils.IDsFromUsers(users)
+	}
+
+	if len(opts.Reviewers) > 0 {
+		users, err := api.UsersByNames(labClient, opts.Reviewers)
+		if err != nil {
+			return err
+		}
+		mrCreateOpts.ReviewerIDs = cmdutils.IDsFromUsers(users)
 	}
 
 	if opts.MileStone != 0 {

--- a/docs/source/mr/create.rst
+++ b/docs/source/mr/create.rst
@@ -45,6 +45,7 @@ Options
       --no-editor              Don't open editor to enter description. If set to true, uses prompt. Default is false
       --push                   Push committed changes after creating merge request. Make sure you have committed changes
       --remove-source-branch   Remove Source Branch on merge
+      --reviewer usernames     Request review from users by their usernames
   -s, --source-branch string   The Branch you are creating the merge request. Default is the current branch.
   -b, --target-branch string   The target or base branch into which you want your code merged
   -t, --title string           Supply a title for merge request

--- a/docs/source/mr/create.rst
+++ b/docs/source/mr/create.rst
@@ -45,7 +45,6 @@ Options
       --no-editor              Don't open editor to enter description. If set to true, uses prompt. Default is false
       --push                   Push committed changes after creating merge request. Make sure you have committed changes
       --remove-source-branch   Remove Source Branch on merge
-      --reviewer usernames     Request review from users by their usernames
   -s, --source-branch string   The Branch you are creating the merge request. Default is the current branch.
   -b, --target-branch string   The target or base branch into which you want your code merged
   -t, --title string           Supply a title for merge request


### PR DESCRIPTION
**Description**
This adds the --reviewer parameter to mr create. Which allows reviewers to be set on create. See: https://docs.gitlab.com/ee/api/merge_requests.html#create-mr

**Related Issue**
**How Has This Been Tested?**
I've used the binary built from this fork against a private Gitlab instance. Worked as expected. 


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
