### PR TITLE
feat(mr create): add `--squash-before-merge` parameter

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -40,6 +40,7 @@ type CreateOpts struct {
 	CreateSourceBranch bool
 	RemoveSourceBranch bool
 	AllowCollaboration bool
+	Squash bool
 
 	Autofill       bool
 	FillCommitBody bool
@@ -155,6 +156,7 @@ func NewCmdCreate(f *cmdutils.Factory, runE func(opts *CreateOpts) error) *cobra
 	mrCreateCmd.Flags().StringVarP(&opts.MilestoneFlag, "milestone", "m", "", "The global ID or title of a milestone to assign")
 	mrCreateCmd.Flags().BoolVarP(&opts.AllowCollaboration, "allow-collaboration", "", false, "Allow commits from other members")
 	mrCreateCmd.Flags().BoolVarP(&opts.RemoveSourceBranch, "remove-source-branch", "", false, "Remove Source Branch on merge")
+	mrCreateCmd.Flags().BoolVarP(&opts.Squash, "squash", "", false, "Squash commits into a single commit when merging")
 	mrCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 	mrCreateCmd.Flags().StringP("head", "H", "", "Select another head repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
 	mrCreateCmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip submission confirmation prompt, with --fill it skips all optional prompts")
@@ -352,12 +354,19 @@ func createRun(opts *CreateOpts) error {
 	mrCreateOpts.Description = gitlab.String(opts.Description)
 	mrCreateOpts.SourceBranch = gitlab.String(opts.SourceBranch)
 	mrCreateOpts.TargetBranch = gitlab.String(opts.TargetBranch)
+
 	if opts.AllowCollaboration {
 		mrCreateOpts.AllowCollaboration = gitlab.Bool(true)
 	}
+
 	if opts.RemoveSourceBranch {
 		mrCreateOpts.RemoveSourceBranch = gitlab.Bool(true)
 	}
+
+	if opts.Squash {
+		mrCreateOpts.Squash = gitlab.Bool(true)
+	}
+
 	if opts.TargetProject != nil {
 		mrCreateOpts.TargetProjectID = gitlab.Int(opts.TargetProject.ID)
 	}

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -40,7 +40,7 @@ type CreateOpts struct {
 	CreateSourceBranch bool
 	RemoveSourceBranch bool
 	AllowCollaboration bool
-	Squash bool
+	SquashBeforeMerge bool
 
 	Autofill       bool
 	FillCommitBody bool
@@ -156,7 +156,7 @@ func NewCmdCreate(f *cmdutils.Factory, runE func(opts *CreateOpts) error) *cobra
 	mrCreateCmd.Flags().StringVarP(&opts.MilestoneFlag, "milestone", "m", "", "The global ID or title of a milestone to assign")
 	mrCreateCmd.Flags().BoolVarP(&opts.AllowCollaboration, "allow-collaboration", "", false, "Allow commits from other members")
 	mrCreateCmd.Flags().BoolVarP(&opts.RemoveSourceBranch, "remove-source-branch", "", false, "Remove Source Branch on merge")
-	mrCreateCmd.Flags().BoolVarP(&opts.Squash, "squash", "", false, "Squash commits into a single commit when merging")
+	mrCreateCmd.Flags().BoolVarP(&opts.SquashBeforeMerge, "squash-before-merge", "", false, "Squash commits into a single commit when merging")
 	mrCreateCmd.Flags().BoolVarP(&opts.NoEditor, "no-editor", "", false, "Don't open editor to enter description. If set to true, uses prompt. Default is false")
 	mrCreateCmd.Flags().StringP("head", "H", "", "Select another head repository using the `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format or the project ID or full URL")
 	mrCreateCmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip submission confirmation prompt, with --fill it skips all optional prompts")
@@ -363,7 +363,7 @@ func createRun(opts *CreateOpts) error {
 		mrCreateOpts.RemoveSourceBranch = gitlab.Bool(true)
 	}
 
-	if opts.Squash {
+	if opts.SquashBeforeMerge {
 		mrCreateOpts.Squash = gitlab.Bool(true)
 	}
 


### PR DESCRIPTION
**Description**
This adds the `--squash-before-merge` parameter to mr create. Which allows the merge request the be squashed by default. See: https://docs.gitlab.com/ee/api/merge_requests.html#create-mr

**Related Issue**
**How Has This Been Tested?**
I've used the binary built from this fork against a private Gitlab instance. Worked as expected. 


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
