### PR TITLE
feat(mr update): add `--squash-before-merge` parameter

### DIFF
--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -192,6 +192,17 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				l.RemoveSourceBranch = gitlab.Bool(true)
 			}
 
+			if squash, _ := cmd.Flags().GetBool("squash"); squash {
+
+				if(mr.Squash){
+					actions = append(actions, "disabled squashing of commits on merge")
+				} else {
+					actions = append(actions, "enabled squashing of commits on merge")
+				}
+
+				l.Squash = gitlab.Bool(!mr.Squash)
+			}
+
 			fmt.Fprintf(f.IO.StdOut, "- Updating merge request !%d\n", mr.IID)
 
 			mr, err = api.UpdateMR(apiClient, repo.FullName(), mr.IID, l)
@@ -220,6 +231,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().StringSliceP("assignee", "a", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing assignees, '+' to add, otherwise replace existing assignees with given users")
 	mrUpdateCmd.Flags().StringSliceP("reviewer", "", []string{}, "request review from users by their usernames, prefix with '!' or '-' to remove from existing reviewers, '+' to add, otherwise replace existing reviewers with given users")
 	mrUpdateCmd.Flags().Bool("unassign", false, "unassign all users")
+	mrUpdateCmd.Flags().BoolP("squash", "", false, "Toggles the option to squash commits into a single commit when merging")
 	mrUpdateCmd.Flags().BoolP("remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")
 	mrUpdateCmd.Flags().String("target-branch", "", "set target branch")

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -192,12 +192,12 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				l.RemoveSourceBranch = gitlab.Bool(true)
 			}
 
-			if squash, _ := cmd.Flags().GetBool("squash"); squash {
+			if squashBeforeMerge, _ := cmd.Flags().GetBool("squash-before-merge"); squashBeforeMerge {
 
-				if(mr.Squash){
-					actions = append(actions, "disabled squashing of commits on merge")
+				if mr.Squash {
+					actions = append(actions, "disabled squashing of commits before merge")
 				} else {
-					actions = append(actions, "enabled squashing of commits on merge")
+					actions = append(actions, "enabled squashing of commits before merge")
 				}
 
 				l.Squash = gitlab.Bool(!mr.Squash)
@@ -231,7 +231,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 	mrUpdateCmd.Flags().StringSliceP("assignee", "a", []string{}, "assign users via username, prefix with '!' or '-' to remove from existing assignees, '+' to add, otherwise replace existing assignees with given users")
 	mrUpdateCmd.Flags().StringSliceP("reviewer", "", []string{}, "request review from users by their usernames, prefix with '!' or '-' to remove from existing reviewers, '+' to add, otherwise replace existing reviewers with given users")
 	mrUpdateCmd.Flags().Bool("unassign", false, "unassign all users")
-	mrUpdateCmd.Flags().BoolP("squash", "", false, "Toggles the option to squash commits into a single commit when merging")
+	mrUpdateCmd.Flags().BoolP("squash-before-merge", "", false, "Toggles the option to squash commits into a single commit when merging")
 	mrUpdateCmd.Flags().BoolP("remove-source-branch", "", false, "Remove Source Branch on merge")
 	mrUpdateCmd.Flags().StringP("milestone", "m", "", "title of the milestone to assign, pass \"\" or 0 to unassign")
 	mrUpdateCmd.Flags().String("target-branch", "", "set target branch")


### PR DESCRIPTION
## Description
This adds the `--squash-before-merge` parameter to mr update. Which allows the merge request the be squashed by default. 

A point of discussion: I thought it would be practical that this would toggle the option to squash. Not sure what your preference has, @profclems. If you'd like it differently, please let me know!

See: docs.gitlab.com/ee/api/merge_requests.html#update-mr

## How Has This Been Tested?
I've used the binary built from this fork against a private Gitlab instance. Worked as expected.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)