### PR TITLE
docs(template): use different header styles for the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Resolves #[issue_number]
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
 
-## Screenshots (if appropriate):
+## Screenshots (if appropriate)
 
 ## Types of changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,20 @@
-**Description**
+## Description
 <!--- Describe your changes in detail -->
 
-**Related Issue**
+## Related Issue
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
 Resolves #[issue_number]
 
-**How Has This Been Tested?**
+## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
 
-**Screenshots (if appropriate):**
+## Screenshots (if appropriate):
 
-**Types of changes**
+## Types of changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)


### PR DESCRIPTION
## Description
The header types of this template have been altered. This way the sections are indicated more clearly.

## How Has This Been Tested?
I've tried this template in the markdown editor of Github. (This PR description is made with the new template)

## Screenshots:

In perspective, the old template:

![image](https://user-images.githubusercontent.com/3403851/135767162-bc450887-a6d5-4a99-8314-2ec6dcf9f025.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
