### PR TITLE
ci: fix the linter by targeting the pr instead of the pr target

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
       - "**.go"
       - go.mod
       - go.sum
-  pull_request_target:
+  pull_request:
     paths:
       - "**.go"
       - go.mod

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -41,7 +41,7 @@ type CreateOpts struct {
 	CreateSourceBranch bool
 	RemoveSourceBranch bool
 	AllowCollaboration bool
-	SquashBeforeMerge bool
+	SquashBeforeMerge  bool
 
 	Autofill       bool
 	FillCommitBody bool

--- a/internal/config/writefile.go
+++ b/internal/config/writefile.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package config

--- a/pkg/execext/lp.go
+++ b/pkg/execext/lp.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package execext


### PR DESCRIPTION
## Description
The linter was targeting the target branch of a pull request, instead of the pull request itself. This way, lint errors would only occur after merging.

## Screenshots:
![image](https://user-images.githubusercontent.com/3403851/135899398-415eef66-3867-419a-82f1-9f0615eff7da.png)
You can see the difference here.

## How Has This Been Tested?
By fixing the linting issues in this PR as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Chore (Related to CI or Packaging to platforms)