### PR TITLE
fix ci pipeline view incorrect timestamp being used

### DIFF
--- a/commands/ci/view/view.go
+++ b/commands/ci/view/view.go
@@ -107,7 +107,7 @@ func drawView(opts ViewOpts) error {
 	root := tview.NewPages()
 	root.SetBorderPadding(1, 1, 2, 2).
 		SetBorder(true).
-		SetTitle(fmt.Sprintf(" Pipeline #%d triggered %s by %s ", opts.Commit.LastPipeline.ID, utils.TimeToPrettyTimeAgo(*opts.Commit.AuthoredDate), opts.Commit.AuthorName))
+		SetTitle(fmt.Sprintf(" Pipeline #%d triggered %s by %s ", opts.Commit.LastPipeline.ID, utils.TimeToPrettyTimeAgo(*opts.Commit.LastPipeline.CreatedAt), opts.Commit.AuthorName))
 
 	boxes = make(map[string]*tview.TextView)
 	jobsCh := make(chan []*gitlab.Job)


### PR DESCRIPTION
Fixes #858

## Description
Update the property used for printing the pipeline created at time within the `pipeline ci view` command

## How Has This Been Tested?
Compiled the code and tested against my own GitLab instance/pipelines.
Initiated a new pipeline from a commit that was made hours ago and verified the result.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)