### PR TITLE
fix: weird condition when prompt disabled

### DIFF
--- a/commands/auth/login/login.go
+++ b/commands/auth/login/login.go
@@ -59,7 +59,7 @@ func NewCmdLogin(f *cmdutils.Factory) *cobra.Command {
 			$ glab auth login --hostname salsa.debian.org
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.IO.PromptEnabled() && (!tokenStdin || opts.Token == "") {
+			if !opts.IO.PromptEnabled() && !tokenStdin && opts.Token == "" {
 				return &cmdutils.FlagError{Err: errors.New("--stdin or --token required when not running interactively")}
 			}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
#823 didn't fix the `--token` behavior but actually completely broke the auth command when not being in non interactive shell.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #822

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I guess it has not 😆 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)