### PR TITLE
fix(ci status): add check for pending pipelines

### DIFF
--- a/commands/ci/status/status.go
+++ b/commands/ci/status/status.go
@@ -114,7 +114,7 @@ func NewCmdStatus(f *cmdutils.Factory) *cobra.Command {
 				if !f.IO.IsOutputTTY() || !f.IO.PromptEnabled() {
 					break
 				}
-				if runningPipeline.Status == "running" && live {
+				if (runningPipeline.Status == "pending" || runningPipeline.Status == "running") && live {
 					runningPipeline, err = api.GetLastPipeline(apiClient, repo.FullName(), branch)
 					if err != nil {
 						return err


### PR DESCRIPTION
## Description
New pipelines might take a while until they have the status "running". During that time they are "pending". I believe `glab ci status --live` should wait for pipelines that are about to start. Adding this change makes glab wait in those cases instead of showing the "Choose an action" prompt.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)