### PR TITLE
Escape titles in new MR preview URLs

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -630,7 +630,7 @@ func generateMRCompareURL(opts *CreateOpts) (string, error) {
 	u.Path += "/-/merge_requests/new"
 	u.RawQuery = fmt.Sprintf(
 		"utf8=✓&merge_request[title]=%s&merge_request[description]=%s&merge_request[source_branch]=%s&merge_request[target_branch]=%s&merge_request[source_project_id]=%d&merge_request[target_project_id]=%d",
-		opts.Title,
+		url.QueryEscape(opts.Title),
 		url.QueryEscape(description),
 		opts.SourceBranch,
 		opts.TargetBranch,


### PR DESCRIPTION
Fixes GH #833

## Description
Escape titles in new MR preview URLs

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #833

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing and running the test suite

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)