### PR TITLE
fix(mr_create/issue_create): add encoding to title and change description encoding

### DIFF
--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -416,7 +416,7 @@ func generateIssueWebURL(opts *CreateOpts) (string, error) {
 	u.Path += "/-/issues/new"
 	u.RawQuery = fmt.Sprintf(
 		"utf8=✓&issue[title]=%s&issue[description]=%s",
-		url.PathEscape(opts.Title),
-		url.PathEscape(description))
+		strings.ReplaceAll(url.PathEscape(opts.Title), "+", "%2B"),
+		strings.ReplaceAll(url.PathEscape(description), "+", "%2B"))
 	return u.String(), nil
 }

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -416,7 +416,7 @@ func generateIssueWebURL(opts *CreateOpts, repo glrepo.Interface) (string, error
 	u.Path += "/-/issues/new"
 	u.RawQuery = fmt.Sprintf(
 		"utf8=✓&issue[title]=%s&issue[description]=%s",
-		opts.Title,
-		url.QueryEscape(description))
+		url.PathEscape(opts.Title),
+		url.PathEscape(description))
 	return u.String(), nil
 }

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -415,7 +415,7 @@ func generateIssueWebURL(opts *CreateOpts) (string, error) {
 	}
 	u.Path += "/-/issues/new"
 	u.RawQuery = fmt.Sprintf(
-		"utf8=✓&issue[title]=%s&issue[description]=%s",
+		"issue[title]=%s&issue[description]=%s",
 		strings.ReplaceAll(url.PathEscape(opts.Title), "+", "%2B"),
 		strings.ReplaceAll(url.PathEscape(description), "+", "%2B"))
 	return u.String(), nil

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -368,7 +368,7 @@ func previewIssue(opts *CreateOpts) error {
 		return err
 	}
 
-	openURL, err := generateIssueWebURL(opts, repo)
+	openURL, err := generateIssueWebURL(opts)
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func previewIssue(opts *CreateOpts) error {
 	return utils.OpenInBrowser(openURL, browser)
 }
 
-func generateIssueWebURL(opts *CreateOpts, repo glrepo.Interface) (string, error) {
+func generateIssueWebURL(opts *CreateOpts) (string, error) {
 	description := opts.Description
 
 	if len(opts.Labels) > 0 {

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -629,7 +629,7 @@ func generateMRCompareURL(opts *CreateOpts) (string, error) {
 	}
 	u.Path += "/-/merge_requests/new"
 	u.RawQuery = fmt.Sprintf(
-		"utf8=✓&merge_request[title]=%s&merge_request[description]=%s&merge_request[source_branch]=%s&merge_request[target_branch]=%s&merge_request[source_project_id]=%d&merge_request[target_project_id]=%d",
+		"merge_request[title]=%s&merge_request[description]=%s&merge_request[source_branch]=%s&merge_request[target_branch]=%s&merge_request[source_project_id]=%d&merge_request[target_project_id]=%d",
 		strings.ReplaceAll(url.PathEscape(opts.Title), "+", "%2B"),
 		strings.ReplaceAll(url.PathEscape(description), "+", "%2B"),
 		opts.SourceBranch,

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -630,8 +630,8 @@ func generateMRCompareURL(opts *CreateOpts) (string, error) {
 	u.Path += "/-/merge_requests/new"
 	u.RawQuery = fmt.Sprintf(
 		"utf8=✓&merge_request[title]=%s&merge_request[description]=%s&merge_request[source_branch]=%s&merge_request[target_branch]=%s&merge_request[source_project_id]=%d&merge_request[target_project_id]=%d",
-		url.QueryEscape(opts.Title),
-		url.QueryEscape(description),
+		url.PathEscape(opts.Title),
+		url.PathEscape(description),
 		opts.SourceBranch,
 		opts.TargetBranch,
 		opts.SourceProject.ID,

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -630,8 +630,8 @@ func generateMRCompareURL(opts *CreateOpts) (string, error) {
 	u.Path += "/-/merge_requests/new"
 	u.RawQuery = fmt.Sprintf(
 		"utf8=✓&merge_request[title]=%s&merge_request[description]=%s&merge_request[source_branch]=%s&merge_request[target_branch]=%s&merge_request[source_project_id]=%d&merge_request[target_project_id]=%d",
-		url.PathEscape(opts.Title),
-		url.PathEscape(description),
+		strings.ReplaceAll(url.PathEscape(opts.Title), "+", "%2B"),
+		strings.ReplaceAll(url.PathEscape(description), "+", "%2B"),
 		opts.SourceBranch,
 		opts.TargetBranch,
 		opts.SourceProject.ID,


### PR DESCRIPTION
- Prevent browsers from converting a space containing query to a search query
- Allow users to add symbols to their title and description
    - QueryEscape does not escape '+' which is converted to a space by the browser

## Description
Used path encoding to convert spaces to `%20` which prevents Titles and Descriptions with spaces from getting converted to search queries
Did not use Query Encoding as it prevents the usage of `+` which won't be encoded and thus converted to a space 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #833 

## How Has This Been Tested?
Manually tested on
- firefox
- chrome
- chromium


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)