### PR TITLE
fix: obsolete % char for weights

### DIFF
--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -402,7 +402,7 @@ func generateIssueWebURL(opts *CreateOpts, repo glrepo.Interface) (string, error
 	}
 	if opts.Weight != 0 {
 		// this uses the slash commands to add weight to the description
-		description += fmt.Sprintf("\n/weight %%%d", opts.Weight)
+		description += fmt.Sprintf("\n/weight %d", opts.Weight)
 	}
 	if opts.IsConfidential {
 		// this uses the slash commands to add confidential to the description


### PR DESCRIPTION
## Description

This change removes the additional %-char that shows up when handing
over a new issue to the gitlab GUI.

## Related Issue

Resolves #874 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)