### PR TITLE
fix: allow setting variable without using --value

### DIFF
--- a/commands/variable/set/set.go
+++ b/commands/variable/set/set.go
@@ -29,8 +29,6 @@ type SetOpts struct {
 	Protected bool
 	Masked    bool
 	Group     string
-
-	ValueSet bool
 }
 
 func NewCmdSet(f *cmdutils.Factory, runE func(opts *SetOpts) error) *cobra.Command {
@@ -67,11 +65,8 @@ func NewCmdSet(f *cmdutils.Factory, runE func(opts *SetOpts) error) *cobra.Comma
 			}
 
 			if opts.Value != "" && len(args) == 2 {
-				if opts.Value != "" {
-					err = cmdutils.FlagError{Err: errors.New("specify value either by second positional argument or --value flag")}
-					return
-				}
-				opts.Value = args[1]
+				err = cmdutils.FlagError{Err: errors.New("specify value either by second positional argument or --value flag")}
+				return
 			}
 
 			if cmd.Flags().Changed("scope") && opts.Group != "" {
@@ -79,8 +74,7 @@ func NewCmdSet(f *cmdutils.Factory, runE func(opts *SetOpts) error) *cobra.Comma
 				return
 			}
 
-			opts.ValueSet = cmd.Flags().Changed("value") || len(args) == 2
-			opts.Value, err = getValue(opts)
+			opts.Value, err = getValue(opts, args)
 			if err != nil {
 				return
 			}
@@ -156,9 +150,11 @@ func setRun(opts *SetOpts) error {
 	return nil
 }
 
-func getValue(opts *SetOpts) (string, error) {
-	if opts.Value != "" || opts.ValueSet {
+func getValue(opts *SetOpts, args []string) (string, error) {
+	if opts.Value != "" {
 		return opts.Value, nil
+	} else if len(args) == 2 {
+		return args[1], nil
 	}
 
 	if opts.IO.IsInTTY {

--- a/commands/variable/set/set_test.go
+++ b/commands/variable/set/set_test.go
@@ -83,10 +83,11 @@ func Test_getValue(t *testing.T) {
 			_, err := stdin.WriteString(tt.stdin)
 			assert.NoError(t, err)
 
+			args := []string{tt.valueArg}
 			value, err := getValue(&SetOpts{
 				Value: tt.valueArg,
 				IO:    io,
-			})
+			}, args)
 			assert.NoError(t, err)
 
 			assert.Equal(t, value, tt.want)


### PR DESCRIPTION
## Description
This PR addresses #880 by simplifying and consolidating the logic for setting `opts.Value`.

Currently if there are two args to the `glab variable set` command, `opts.Value` [is set to the second arg](https://github.com/profclems/glab/blob/0d47c686086a27da3ac1543db4a63587ea5f1c34/commands/variable/set/set.go#L74). Then later the `getValue` function is called, and further changes are made to the value.

This update:

- Removes the [redundant if statement](https://github.com/profclems/glab/blob/0d47c686086a27da3ac1543db4a63587ea5f1c34/commands/variable/set/set.go#L70)
- Removes the setting of opts.value [outside of the `getValue` function](https://github.com/profclems/glab/blob/0d47c686086a27da3ac1543db4a63587ea5f1c34/commands/variable/set/set.go#L74)
- Removes the [use of opts.ValueSet](https://github.com/profclems/glab/blob/0d47c686086a27da3ac1543db4a63587ea5f1c34/commands/variable/set/set.go#L82)
- Updates the logic in the `getValue` function to enable setting the variable with or without passing `--value` flag

## Related Issue
Resolves #880 

## How Has This Been Tested?

I ran all of the commands from the help command for `glab variable set` before and after my change:
```
$ glen | sort -r
export ORIGINAL_WITH_ARG=""
export ORIGINAL_SERVER_TOKEN="SERVER_TOKEN_VALUE"
export ORIGINAL_FROM_FLAG="some value"
export ORIGINAL_FROM_FILE="FROM_FILE_VALUE"
export ORIGINAL_FROM_ENV_WITH_FLAG="bradym"
export ORIGINAL_FROM_ENV_WITH_ARG=""
export FIXED_WITH_ARG="some value"
export FIXED_SERVER_TOKEN="SERVER_TOKEN_VALUE"
export FIXED_FROM_FLAG="some value"
export FIXED_FROM_FILE="FROM_FILE_VALUE"
export FIXED_FROM_ENV_WITH_FLAG="bradym"
export FIXED_FROM_ENV_WITH_ARG="bradym"
```
I also ran tests in a docker container using golang 1.16:

```
docker run --rm -ti --init -v "$PWD:/app" -w /app golang:1.15-buster bash
root@6c4876a30b19:/app# bin/gotestsum --packages ./commands/variable/set
✓  commands/variable/set (cached)

DONE 18 tests in 0.255s
```
I tried running `make test` but:

```
DONE 847 tests, 10 failures in 610.099s
```
Reviewing the errors it looks like it's due to permissions issues. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)