### PR TITLE
feat(mr): Only output MR URL to stdout if output is not a TTY

### DIFF
--- a/commands/issue/close/issue_close.go
+++ b/commands/issue/close/issue_close.go
@@ -46,7 +46,7 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 					return err
 				}
 				fmt.Fprintf(f.IO.StdOut, "%s Closed Issue #%d\n", c.RedCheck(), issue.IID)
-				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(c, issue))
+				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(c, issue, f.IO.IsaTTY))
 			}
 			return nil
 		},

--- a/commands/issue/create/issue_create.go
+++ b/commands/issue/create/issue_create.go
@@ -350,7 +350,7 @@ func createRun(opts *CreateOpts) error {
 				}
 			}
 		}
-		fmt.Fprintln(opts.IO.StdOut, issueutils.DisplayIssue(opts.IO.Color(), issue))
+		fmt.Fprintln(opts.IO.StdOut, issueutils.DisplayIssue(opts.IO.Color(), issue, opts.IO.IsaTTY))
 		return nil
 	}
 

--- a/commands/issue/issueutils/utils.go
+++ b/commands/issue/issueutils/utils.go
@@ -42,12 +42,15 @@ func DisplayIssueList(streams *iostreams.IOStreams, issues []*gitlab.Issue, proj
 	return table.Render()
 }
 
-func DisplayIssue(c *iostreams.ColorPalette, i *gitlab.Issue) string {
+func DisplayIssue(c *iostreams.ColorPalette, i *gitlab.Issue, isTTY bool) string {
 	duration := utils.TimeToPrettyTimeAgo(*i.CreatedAt)
 	issueID := IssueState(c, i)
 
-	return fmt.Sprintf("%s %s (%s)\n %s\n",
-		issueID, i.Title, duration, i.WebURL)
+	if isTTY {
+		return fmt.Sprintf("%s %s (%s)\n %s\n", issueID, i.Title, duration, i.WebURL)
+	} else {
+		return i.WebURL
+	}
 }
 
 func IssueState(c *iostreams.ColorPalette, i *gitlab.Issue) (issueID string) {

--- a/commands/issue/reopen/issue_reopen.go
+++ b/commands/issue/reopen/issue_reopen.go
@@ -54,7 +54,7 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				fmt.Fprintf(out, "%s Reopened Issue #%d\n", c.GreenCheck(), issue.IID)
-				fmt.Fprintln(out, issueutils.DisplayIssue(c, issue))
+				fmt.Fprintln(out, issueutils.DisplayIssue(c, issue, f.IO.IsaTTY))
 			}
 			return nil
 		},

--- a/commands/issue/subscribe/issue_subscribe.go
+++ b/commands/issue/subscribe/issue_subscribe.go
@@ -45,7 +45,7 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				fmt.Fprintln(f.IO.StdErr, c.GreenCheck(), "Subscribed")
-				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(c, issue))
+				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(c, issue, f.IO.IsaTTY))
 			}
 			return nil
 		},

--- a/commands/issue/unsubscribe/issue_unsubscribe.go
+++ b/commands/issue/unsubscribe/issue_unsubscribe.go
@@ -46,7 +46,7 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				fmt.Fprintln(f.IO.StdErr, c.RedCheck(), "Unsubscribed")
-				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(c, issue))
+				fmt.Fprintln(f.IO.StdOut, issueutils.DisplayIssue(c, issue, f.IO.IsaTTY))
 			}
 			return nil
 		},

--- a/commands/issue/update/issue_update.go
+++ b/commands/issue/update/issue_update.go
@@ -146,7 +146,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				fmt.Fprintln(out, c.GreenCheck(), s)
 			}
 
-			fmt.Fprintln(out, issueutils.DisplayIssue(c, issue))
+			fmt.Fprintln(out, issueutils.DisplayIssue(c, issue, f.IO.IsaTTY))
 			return nil
 		},
 	}

--- a/commands/mr/close/mr_close.go
+++ b/commands/mr/close/mr_close.go
@@ -57,7 +57,7 @@ func NewCmdClose(f *cmdutils.Factory) *cobra.Command {
 				mr.State = "closed"
 
 				fmt.Fprintf(f.IO.StdOut, "%s Closed Merge request !%d\n", c.RedCheck(), mr.IID)
-				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr))
+				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr, f.IO.IsaTTY))
 			}
 
 			return nil

--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -495,7 +495,7 @@ func createRun(opts *CreateOpts) error {
 			return err
 		}
 
-		fmt.Fprintln(out, mrutils.DisplayMR(c, mr))
+		fmt.Fprintln(out, mrutils.DisplayMR(c, mr, opts.IO.IsaTTY))
 		return nil
 	}
 

--- a/commands/mr/for/mr_for.go
+++ b/commands/mr/for/mr_for.go
@@ -137,7 +137,7 @@ func NewCmdFor(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(f.IO.Color(), mr))
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(f.IO.Color(), mr, f.IO.IsaTTY))
 
 			return nil
 		},

--- a/commands/mr/merge/mr_merge.go
+++ b/commands/mr/merge/mr_merge.go
@@ -241,7 +241,7 @@ func NewCmdMerge(f *cmdutils.Factory) *cobra.Command {
 				}
 				fmt.Fprintln(f.IO.StdOut, c.GreenCheck(), action)
 			}
-			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr))
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr, f.IO.IsaTTY))
 			return nil
 		},
 	}

--- a/commands/mr/mrutils/mrutils.go
+++ b/commands/mr/mrutils/mrutils.go
@@ -84,10 +84,13 @@ func MRCheckErrors(mr *gitlab.MergeRequest, err MRCheckErrOptions) error {
 	return nil
 }
 
-func DisplayMR(c *iostreams.ColorPalette, mr *gitlab.MergeRequest) string {
+func DisplayMR(c *iostreams.ColorPalette, mr *gitlab.MergeRequest, isTTY bool) string {
 	mrID := MRState(c, mr)
-	return fmt.Sprintf("%s %s (%s)\n %s\n",
-		mrID, mr.Title, mr.SourceBranch, mr.WebURL)
+	if isTTY {
+		return fmt.Sprintf("%s %s (%s)\n %s\n", mrID, mr.Title, mr.SourceBranch, mr.WebURL)
+	} else {
+		return mr.WebURL
+	}
 }
 
 func MRState(c *iostreams.ColorPalette, m *gitlab.MergeRequest) string {

--- a/commands/mr/mrutils/mrutils_test.go
+++ b/commands/mr/mrutils/mrutils_test.go
@@ -17,9 +17,10 @@ import (
 
 func Test_DisplayMR(t *testing.T) {
 	testCases := []struct {
-		name   string
-		mr     *gitlab.MergeRequest
-		output string
+		name        string
+		mr          *gitlab.MergeRequest
+		output      string
+		outputToTTY bool
 	}{
 		{
 			name: "opened",
@@ -30,7 +31,8 @@ func Test_DisplayMR(t *testing.T) {
 				SourceBranch: "trunk",
 				WebURL:       "https://gitlab.com/profclems/glab/-/merge_requests/1",
 			},
-			output: "!1 This is open (trunk)\n https://gitlab.com/profclems/glab/-/merge_requests/1\n",
+			output:      "!1 This is open (trunk)\n https://gitlab.com/profclems/glab/-/merge_requests/1\n",
+			outputToTTY: true,
 		},
 		{
 			name: "merged",
@@ -41,7 +43,8 @@ func Test_DisplayMR(t *testing.T) {
 				SourceBranch: "trunk",
 				WebURL:       "https://gitlab.com/profclems/glab/-/merge_requests/2",
 			},
-			output: "!2 This is merged (trunk)\n https://gitlab.com/profclems/glab/-/merge_requests/2\n",
+			output:      "!2 This is merged (trunk)\n https://gitlab.com/profclems/glab/-/merge_requests/2\n",
+			outputToTTY: true,
 		},
 		{
 			name: "closed",
@@ -52,13 +55,26 @@ func Test_DisplayMR(t *testing.T) {
 				SourceBranch: "trunk",
 				WebURL:       "https://gitlab.com/profclems/glab/-/merge_requests/3",
 			},
-			output: "!3 This is closed (trunk)\n https://gitlab.com/profclems/glab/-/merge_requests/3\n",
+			output:      "!3 This is closed (trunk)\n https://gitlab.com/profclems/glab/-/merge_requests/3\n",
+			outputToTTY: true,
+		},
+		{
+			name: "non-tty terse output",
+			mr: &gitlab.MergeRequest{
+				IID:          4,
+				State:        "open",
+				Title:        "This shouldn't be visible",
+				SourceBranch: "trunk",
+				WebURL:       "https://gitlab.com/profclems/glab/-/merge_requests/4",
+			},
+			output:      "https://gitlab.com/profclems/glab/-/merge_requests/4",
+			outputToTTY: false,
 		},
 	}
 	streams, _, _, _ := iostreams.Test()
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
-			got := DisplayMR(streams.Color(), tC.mr)
+			got := DisplayMR(streams.Color(), tC.mr, tC.outputToTTY)
 			assert.Equal(t, tC.output, got)
 		})
 	}

--- a/commands/mr/reopen/mr_reopen.go
+++ b/commands/mr/reopen/mr_reopen.go
@@ -52,7 +52,7 @@ func NewCmdReopen(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				fmt.Fprintf(f.IO.StdOut, "%s Reopened Merge request !%d\n", c.GreenCheck(), mr.IID)
-				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(f.IO.Color(), mr))
+				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(f.IO.Color(), mr, f.IO.IsaTTY))
 			}
 
 			return nil

--- a/commands/mr/subscribe/mr_subscribe.go
+++ b/commands/mr/subscribe/mr_subscribe.go
@@ -52,7 +52,7 @@ func NewCmdSubscribe(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				fmt.Fprintf(f.IO.StdOut, "%s You have successfully subscribed to merge request !%d\n", c.GreenCheck(), mr.IID)
-				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr))
+				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr, f.IO.IsaTTY))
 			}
 
 			return nil

--- a/commands/mr/unsubscribe/mr_unsubscribe.go
+++ b/commands/mr/unsubscribe/mr_unsubscribe.go
@@ -52,7 +52,7 @@ func NewCmdUnsubscribe(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				fmt.Fprintf(f.IO.StdOut, "%s You have successfully unsubscribed from merge request !%d\n", c.RedCheck(), mr.IID)
-				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr))
+				fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr, f.IO.IsaTTY))
 			}
 
 			return nil

--- a/commands/mr/update/mr_update.go
+++ b/commands/mr/update/mr_update.go
@@ -214,7 +214,7 @@ func NewCmdUpdate(f *cmdutils.Factory) *cobra.Command {
 				fmt.Fprintln(f.IO.StdOut, c.GreenCheck(), s)
 			}
 
-			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr))
+			fmt.Fprintln(f.IO.StdOut, mrutils.DisplayMR(c, mr, f.IO.IsaTTY))
 			return nil
 		},
 	}


### PR DESCRIPTION
This enables "glab mr create -f -y | some command" to only pass the url
through the pipe.
