### PR TITLE
feature: add variable delete command

### DIFF
--- a/api/variable.go
+++ b/api/variable.go
@@ -1,6 +1,10 @@
 package api
 
-import "github.com/xanzy/go-gitlab"
+import (
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/xanzy/go-gitlab"
+)
 
 var CreateProjectVariable = func(client *gitlab.Client, projectID interface{}, opts *gitlab.CreateProjectVariableOptions) (*gitlab.ProjectVariable, error) {
 	if client == nil {
@@ -26,6 +30,29 @@ var ListProjectVariables = func(client *gitlab.Client, projectID interface{}, op
 	return vars, nil
 }
 
+var DeleteProjectVariable = func(client *gitlab.Client, projectID interface{}, key string, scope string) error {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	var filter = func(request *retryablehttp.Request) error {
+		q := request.URL.Query()
+		q.Add("filter[environment_scope]", scope)
+
+		request.URL.RawQuery = q.Encode()
+
+		return nil
+	}
+
+	_, err := client.ProjectVariables.RemoveVariable(projectID, key, filter)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 var ListGroupVariables = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupVariablesOptions) ([]*gitlab.GroupVariable, error) {
 	if client == nil {
 		client = apiClient.Lab()
@@ -48,4 +75,18 @@ var CreateGroupVariable = func(client *gitlab.Client, groupID interface{}, opts 
 	}
 
 	return vars, nil
+}
+
+var DeleteGroupVariable = func(client *gitlab.Client, groupID interface{}, key string) error {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	_, err := client.GroupVariables.RemoveVariable(groupID, key)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/commands/variable/delete/delete.go
+++ b/commands/variable/delete/delete.go
@@ -1,0 +1,108 @@
+package delete
+
+import (
+	"fmt"
+
+	"errors"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/commands/variable/variableutils"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/iostreams"
+
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+type DeleteOpts struct {
+	HTTPClient func() (*gitlab.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (glrepo.Interface, error)
+
+	Key   string
+	Scope string
+	Group string
+}
+
+func NewCmdSet(f *cmdutils.Factory, runE func(opts *DeleteOpts) error) *cobra.Command {
+	opts := &DeleteOpts{
+		IO: f.IO,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "delete <key>",
+		Short:   "Delete a project or group variable",
+		Aliases: []string{"delete", "remove"},
+		Args:    cobra.ExactArgs(1),
+		Example: heredoc.Doc(`
+			$ glab variable delete VAR_NAME
+			$ glab variable delete VAR_NAME --scope=prod
+			$ glab variable delete VARNAME -g mygroup
+		`),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			opts.HTTPClient = f.HttpClient
+			opts.BaseRepo = f.BaseRepo
+			opts.Key = args[0]
+
+			if !variableutils.IsValidKey(opts.Key) {
+				err = cmdutils.FlagError{Err: fmt.Errorf("invalid key provided.\n%s", variableutils.ValidKeyMsg)}
+				return
+			} else if len(args) != 1 {
+				err = cmdutils.FlagError{Err: errors.New("no key provided")}
+			}
+
+			if cmd.Flags().Changed("scope") && opts.Group != "" {
+				err = cmdutils.FlagError{Err: errors.New("scope is not required for group variables")}
+				return
+			}
+
+			if runE != nil {
+				err = runE(opts)
+				return
+			}
+			err = deleteRun(opts)
+			return
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Scope, "scope", "s", "*", "The environment_scope of the variable. All (*), or specific environments")
+	cmd.Flags().StringVarP(&opts.Group, "group", "g", "", "Delete variable from a group")
+
+	return cmd
+
+}
+
+func deleteRun(opts *DeleteOpts) error {
+	c := opts.IO.Color()
+	httpClient, err := opts.HTTPClient()
+	if err != nil {
+		return err
+	}
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	if opts.Group == "" {
+		// Delete project-level variable
+		err = api.DeleteProjectVariable(httpClient, baseRepo.FullName(), opts.Key, opts.Scope)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(opts.IO.StdOut, "%s Deleted variable %s with scope %s for %s\n", c.GreenCheck(), opts.Key, opts.Scope, baseRepo.FullName())
+	} else {
+		// Delete group-level variable
+		err = api.DeleteGroupVariable(httpClient, opts.Group, opts.Key)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(opts.IO.StdOut, "%s Deleted variable %s for group %s\n", c.GreenCheck(), opts.Key, opts.Group)
+	}
+
+	return nil
+}

--- a/commands/variable/delete/delete.go
+++ b/commands/variable/delete/delete.go
@@ -34,7 +34,7 @@ func NewCmdSet(f *cmdutils.Factory, runE func(opts *DeleteOpts) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:     "delete <key>",
 		Short:   "Delete a project or group variable",
-		Aliases: []string{"delete", "remove"},
+		Aliases: []string{"remove"},
 		Args:    cobra.ExactArgs(1),
 		Example: heredoc.Doc(`
 			$ glab variable delete VAR_NAME

--- a/commands/variable/delete/delete_test.go
+++ b/commands/variable/delete/delete_test.go
@@ -1,0 +1,119 @@
+package delete
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/xanzy/go-gitlab"
+
+	"github.com/alecthomas/assert"
+	"github.com/google/shlex"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/pkg/httpmock"
+)
+
+func Test_NewCmdSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    DeleteOpts
+		stdinTTY bool
+		wantsErr bool
+	}{
+		{
+			name:     "delete var",
+			cli:      "cool_secret",
+			wantsErr: false,
+		},
+		{
+			name:     "delete scoped var",
+			cli:      "cool_secret --scope prod",
+			wantsErr: false,
+		},
+		{
+			name:     "delete group var",
+			cli:      "cool_secret -g mygroup",
+			wantsErr: false,
+		},
+		{
+			name:     "delete scoped group var",
+			cli:      "cool_secret -g mygroup --scope prod",
+			wantsErr: true,
+		},
+		{
+			name:     "no name",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name:     "invalid characters in name",
+			cli:      "BAD-SECRET",
+			wantsErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, _, _ := iostreams.Test()
+			f := &cmdutils.Factory{
+				IO: io,
+			}
+
+			io.IsInTTY = tt.stdinTTY
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			cmd := NewCmdSet(f, func(opts *DeleteOpts) error {
+				return nil
+			})
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_deleteRun_project(t *testing.T) {
+	reg := &httpmock.Mocker{
+		MatchURL: httpmock.PathAndQuerystring,
+	}
+	defer reg.Verify(t)
+
+	reg.RegisterResponder("DELETE", "projects/owner%2Frepo/variables/TEST_VAR?filter%5Benvironment_scope%5D=%2A",
+		httpmock.NewStringResponse(204, ""),
+	)
+
+	io, _, stdout, _ := iostreams.Test()
+
+	opts := &DeleteOpts{
+		HTTPClient: func() (*gitlab.Client, error) {
+			a, _ := api.TestClient(&http.Client{Transport: reg}, "", "gitlab.com", false)
+			return a.Lab(), nil
+		},
+		BaseRepo: func() (glrepo.Interface, error) {
+			return glrepo.FromFullName("owner/repo")
+		},
+		IO:    io,
+		Key:   "TEST_VAR",
+		Scope: "*",
+	}
+	_, _ = opts.HTTPClient()
+
+	err := deleteRun(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, stdout.String(), "✓ Deleted variable TEST_VAR with scope * for owner/repo\n")
+}

--- a/commands/variable/delete/delete_test.go
+++ b/commands/variable/delete/delete_test.go
@@ -87,33 +87,85 @@ func Test_NewCmdSet(t *testing.T) {
 	}
 }
 
-func Test_deleteRun_project(t *testing.T) {
+func Test_deleteRun(t *testing.T) {
 	reg := &httpmock.Mocker{
 		MatchURL: httpmock.PathAndQuerystring,
 	}
 	defer reg.Verify(t)
 
-	reg.RegisterResponder("DELETE", "projects/owner%2Frepo/variables/TEST_VAR?filter%5Benvironment_scope%5D=%2A",
-		httpmock.NewStringResponse(204, ""),
+	reg.RegisterResponder("DELETE", "/api/v4/projects/owner%2Frepo/variables/TEST_VAR?filter%5Benvironment_scope%5D=%2A",
+		httpmock.NewStringResponse(204, " "),
 	)
 
-	io, _, stdout, _ := iostreams.Test()
+	reg.RegisterResponder("DELETE", "/api/v4/projects/owner%2Frepo/variables/TEST_VAR?filter%5Benvironment_scope%5D=stage",
+		httpmock.NewStringResponse(204, " "),
+	)
 
-	opts := &DeleteOpts{
-		HTTPClient: func() (*gitlab.Client, error) {
-			a, _ := api.TestClient(&http.Client{Transport: reg}, "", "gitlab.com", false)
-			return a.Lab(), nil
-		},
-		BaseRepo: func() (glrepo.Interface, error) {
-			return glrepo.FromFullName("owner/repo")
-		},
-		IO:    io,
-		Key:   "TEST_VAR",
-		Scope: "*",
+	reg.RegisterResponder("DELETE", "/api/v4/groups/testGroup/variables/TEST_VAR",
+		httpmock.NewStringResponse(204, " "),
+	)
+
+	var httpClient = func() (*gitlab.Client, error) {
+		a, _ := api.TestClient(&http.Client{Transport: reg}, "", "gitlab.com", false)
+		return a.Lab(), nil
 	}
-	_, _ = opts.HTTPClient()
+	var baseRepo = func() (glrepo.Interface, error) {
+		return glrepo.FromFullName("owner/repo")
+	}
 
-	err := deleteRun(opts)
-	assert.NoError(t, err)
-	assert.Equal(t, stdout.String(), "✓ Deleted variable TEST_VAR with scope * for owner/repo\n")
+	tests := []struct {
+		name        string
+		opts        DeleteOpts
+		wantsErr    bool
+		wantsOutput string
+	}{
+		{
+			name: "delete project variable no scope",
+			opts: DeleteOpts{
+				HTTPClient: httpClient,
+				BaseRepo:   baseRepo,
+				Key:        "TEST_VAR",
+				Scope:      "*",
+			},
+			wantsErr:    false,
+			wantsOutput: "✓ Deleted variable TEST_VAR with scope * for owner/repo\n",
+		},
+		{
+			name: "delete project variable with stage scope",
+			opts: DeleteOpts{
+				HTTPClient: httpClient,
+				BaseRepo:   baseRepo,
+				Key:        "TEST_VAR",
+				Scope:      "stage",
+			},
+			wantsErr:    false,
+			wantsOutput: "✓ Deleted variable TEST_VAR with scope stage for owner/repo\n",
+		},
+		{
+			name: "delete group variable",
+			opts: DeleteOpts{
+				HTTPClient: httpClient,
+				BaseRepo:   baseRepo,
+				Key:        "TEST_VAR",
+				Scope:      "",
+				Group:      "testGroup",
+			},
+			wantsErr:    false,
+			wantsOutput: "✓ Deleted variable TEST_VAR for group testGroup\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _ = tt.opts.HTTPClient()
+
+			io, _, stdout, _ := iostreams.Test()
+			tt.opts.IO = io
+			io.IsInTTY = false
+
+			err := deleteRun(&tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, stdout.String(), tt.wantsOutput)
+		})
+	}
 }

--- a/commands/variable/set/set_test.go
+++ b/commands/variable/set/set_test.go
@@ -16,46 +16,6 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func Test_isValidKey(t *testing.T) {
-	type args struct {
-		key string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "key is empty",
-			args: args{
-				key: "",
-			},
-			want: false,
-		},
-		{
-			name: "key is valid",
-			args: args{
-				key: "abc123_",
-			},
-			want: true,
-		},
-		{
-			name: "key is invalid",
-			args: args{
-				key: "abc-123",
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isValidKey(tt.args.key); got != tt.want {
-				t.Errorf("isValidKey() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_getValue(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/commands/variable/variable.go
+++ b/commands/variable/variable.go
@@ -2,6 +2,7 @@ package variable
 
 import (
 	"github.com/profclems/glab/commands/cmdutils"
+	deleteCmd "github.com/profclems/glab/commands/variable/delete"
 	listCmd "github.com/profclems/glab/commands/variable/list"
 	setCmd "github.com/profclems/glab/commands/variable/set"
 	"github.com/spf13/cobra"
@@ -18,5 +19,6 @@ func NewVariableCmd(f *cmdutils.Factory) *cobra.Command {
 
 	cmd.AddCommand(setCmd.NewCmdSet(f, nil))
 	cmd.AddCommand(listCmd.NewCmdSet(f, nil))
+	cmd.AddCommand(deleteCmd.NewCmdSet(f, nil))
 	return cmd
 }

--- a/commands/variable/variableutils/key.go
+++ b/commands/variable/variableutils/key.go
@@ -1,0 +1,17 @@
+package variableutils
+
+import "regexp"
+
+// IsValidKey checks if a key is valid if it follows the following criteria:
+// must have no more than 255 characters;
+// only A-Z, a-z, 0-9, and _ are allowed
+func IsValidKey(key string) bool {
+	// check if key falls within range of 1-255
+	if len(key) > 255 || len(key) < 1 {
+		return false
+	}
+	keyRE := regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+	return keyRE.MatchString(key)
+}
+
+var ValidKeyMsg = "A valid key must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed"

--- a/commands/variable/variableutils/key_test.go
+++ b/commands/variable/variableutils/key_test.go
@@ -1,0 +1,43 @@
+package variableutils
+
+import "testing"
+
+func Test_isValidKey(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "key is empty",
+			args: args{
+				key: "",
+			},
+			want: false,
+		},
+		{
+			name: "key is valid",
+			args: args{
+				key: "abc123_",
+			},
+			want: true,
+		},
+		{
+			name: "key is invalid",
+			args: args{
+				key: "abc-123",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidKey(tt.args.key); got != tt.want {
+				t.Errorf("isValidKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/renameio v1.0.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gosuri/uilive v0.0.4
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/hashicorp/go-version v1.3.0
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51


### PR DESCRIPTION
## Description
This PR addresses #889 by adding a new `glab variable delete` command. 

I tried to follow established patterns as best I could, but please let me know what improvements you'd like to see. 

In addition to adding the delete command, I added a new `variableutils` package and moved the `isValidKey` function and `validKeyMsg` there so they could be shared between the `set` and `delete` commands.

I have marked this as a draft PR as I have not yet added tests for the new delete command code, I will work on that this week. I wanted to get this PR created to get any feedback you may have so I can address that while working on the tests.

## How Has This Been Tested?
So far I have tested by running the commands in the help output:

```
  $ glab variable delete VAR_NAME
  $ glab variable delete VAR_NAME --scope=prod
  $ glab variable delete VARNAME -g mygroup
```

I've also run existing tests to ensure my changes have not broken any existing functionality related to variables:

```
root@dd3ab0757245:/app# bin/gotestsum --packages ./commands/variable
✓  commands/variable (17ms)

DONE 1 tests in 0.971s


root@dd3ab0757245:/app# bin/gotestsum --packages ./commands/variable/set
✓  commands/variable/set (19ms)

DONE 14 tests in 1.026s


root@dd3ab0757245:/app# bin/gotestsum --packages ./commands/variable/variableutils
✓  commands/variable/variableutils (cached)

DONE 4 tests in 0.223s
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)