### PR TITLE
Add group issue boards to issue board view

### DIFF
--- a/api/board.go
+++ b/api/board.go
@@ -14,7 +14,19 @@ var CreateIssueBoard = func(client *gitlab.Client, projectID interface{}, opts *
 	return board, nil
 }
 
-var ListIssueBoards = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListIssueBoardsOptions) ([]*gitlab.IssueBoard, error) {
+var ListGroupIssueBoards = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupIssueBoardsOptions) ([]*gitlab.GroupIssueBoard, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	boards, _, err := client.GroupIssueBoards.ListGroupIssueBoards(groupID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return boards, nil
+}
+
+var ListProjectIssueBoards = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListIssueBoardsOptions) ([]*gitlab.IssueBoard, error) {
 	if client == nil {
 		client = apiClient.Lab()
 	}
@@ -26,11 +38,23 @@ var ListIssueBoards = func(client *gitlab.Client, projectID interface{}, opts *g
 	return boards, nil
 }
 
-var GetIssueBoardLists = func(client *gitlab.Client, projectID interface{}, boardID int, opts *gitlab.GetIssueBoardListsOptions) ([]*gitlab.BoardList, error) {
+var GetPojectIssueBoardLists = func(client *gitlab.Client, projectID interface{}, boardID int, opts *gitlab.GetIssueBoardListsOptions) ([]*gitlab.BoardList, error) {
 	if client == nil {
 		client = apiClient.Lab()
 	}
 	boardLists, _, err := client.Boards.GetIssueBoardLists(projectID, boardID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return boardLists, nil
+}
+
+var GetGroupIssueBoardLists = func(client *gitlab.Client, groupID interface{}, boardID int, opts *gitlab.ListGroupIssueBoardListsOptions) ([]*gitlab.BoardList, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	boardLists, _, err := client.GroupIssueBoards.ListGroupIssueBoardLists(groupID, boardID, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/issue.go
+++ b/api/issue.go
@@ -45,33 +45,19 @@ var GetIssue = func(client *gitlab.Client, projectID interface{}, issueID int) (
 	return issue, nil
 }
 
-var ProjectListIssueOptionsToGroup = func(l *gitlab.ListProjectIssuesOptions) *gitlab.ListGroupIssuesOptions {
-	return &gitlab.ListGroupIssuesOptions{
-		ListOptions:        l.ListOptions,
-		State:              l.State,
-		Labels:             l.Labels,
-		NotLabels:          l.NotLabels,
-		WithLabelDetails:   l.WithLabelDetails,
-		IIDs:               l.IIDs,
-		Milestone:          l.Milestone,
-		Scope:              l.Scope,
-		AuthorID:           l.AuthorID,
-		NotAuthorID:        l.NotAuthorID,
-		AssigneeID:         l.AssigneeID,
-		NotAssigneeID:      l.NotAssigneeID,
-		AssigneeUsername:   l.AssigneeUsername,
-		MyReactionEmoji:    l.MyReactionEmoji,
-		NotMyReactionEmoji: l.NotMyReactionEmoji,
-		OrderBy:            l.OrderBy,
-		Sort:               l.Sort,
-		Search:             l.Search,
-		In:                 l.In,
-		CreatedAfter:       l.CreatedAfter,
-		CreatedBefore:      l.CreatedBefore,
-		UpdatedAfter:       l.UpdatedAfter,
-		UpdatedBefore:      l.UpdatedBefore,
-		IssueType:          l.IssueType,
+var ListProjectIssues = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectIssuesOptions) ([]*gitlab.Issue, error) {
+	if client == nil {
+		client = apiClient.Lab()
 	}
+	if opts.PerPage == 0 {
+		opts.PerPage = DefaultListLimit
+	}
+	issues, _, err := client.Issues.ListProjectIssues(projectID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return issues, nil
 }
 
 var ListGroupIssues = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupIssuesOptions) ([]*gitlab.Issue, error) {
@@ -82,21 +68,6 @@ var ListGroupIssues = func(client *gitlab.Client, groupID interface{}, opts *git
 		opts.PerPage = DefaultListLimit
 	}
 	issues, _, err := client.Issues.ListGroupIssues(groupID, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return issues, nil
-}
-
-var ListIssues = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectIssuesOptions) ([]*gitlab.Issue, error) {
-	if client == nil {
-		client = apiClient.Lab()
-	}
-	if opts.PerPage == 0 {
-		opts.PerPage = DefaultListLimit
-	}
-	issues, _, err := client.Issues.ListProjectIssues(projectID, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/project.go
+++ b/api/project.go
@@ -73,6 +73,17 @@ var ListGroupProjects = func(client *gitlab.Client, groupID interface{}, opts *g
 	return project, nil
 }
 
+var ListProjectGroups = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectGroupOptions) ([]*gitlab.ProjectGroup, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	groups, _, err := client.Projects.ListProjectsGroups(projectID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
 var ListProjectMembers = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectMembersOptions) ([]*gitlab.ProjectMember, error) {
 	if client == nil {
 		client = apiClient.Lab()

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -72,7 +72,6 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 
 			type info struct {
 				id    int
-				kind  string
 				group *gitlab.Group
 			}
 

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -180,12 +180,12 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 
 				// append list name label to labels from cli
 				reqLabels := opts.Labels
-				if reqLabels == "" && !isSpecialList {
-					reqLabels = list.Label.Name
-				}
-
 				if reqLabels != "" && !isSpecialList {
 					reqLabels = reqLabels + "," + list.Label.Name
+				}
+
+				if reqLabels == "" && !isSpecialList {
+					reqLabels = list.Label.Name
 				}
 
 				if boardInfo[selectedBoard].group != nil {

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -107,7 +107,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				if err != nil {
 					return err
 				}
-			} else {
+			}
+
+			if boardInfo[selectedBoard].group == nil {
 				boardLists, err = api.GetPojectIssueBoardLists(apiClient, repo.FullName(),
 					boardInfo[selectedBoard].id, &gitlab.GetIssueBoardListsOptions{})
 				if err != nil {
@@ -148,7 +150,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				if list.Label == nil {
 					listTitle = "Unnamed"
 					listColor = "#FFA500" // orange
-				} else {
+				}
+
+				if list.Label != nil {
 					listTitle = list.Label.Name
 					listColor = list.Label.Color
 				}

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -22,12 +22,11 @@ var (
 	repo      glrepo.Interface
 )
 
-type IssueBoardViewOptions struct {
-	AssigneeUsername string
-	AssigneeID       int
-	Labels           string
-	Milestone        string
-	State            string
+type issueBoardViewOptions struct {
+	Assignee  string
+	Labels    string
+	Milestone string
+	State     string
 }
 
 func NewCmdView(f *cmdutils.Factory) *cobra.Command {
@@ -223,7 +222,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 					if issue.Assignee != nil {
 						assignee = issue.Assignee.Username
 					}
-					boardIssues += fmt.Sprintf("[white]%s\n[blue]%s\n[green]#%d[white] - %s\n\n", issue.Title, labelPrint, issue.IID, assignee)
+
+					boardIssues += fmt.Sprintf("[white::b]%s\n%s[green:-:-]#%d[darkgray] - %s\n\n",
+						issue.Title, labelPrint, issue.IID, assignee)
 				}
 				bx.SetText(boardIssues).SetWrap(true)
 				bx.SetBorder(true).SetTitle(listTitle).SetTitleColor(tcell.GetColor(listColor))
@@ -243,11 +244,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 		},
 	}
 
-	viewCmd.Flags().StringVarP(&opts.AssigneeUsername, "assignee-username", "u", "", "Filter board issues by assignee username")
-	viewCmd.Flags().IntVarP(&opts.AssigneeID, "assignee-id", "i", 0, "Filter board issues by assignee id")
+	viewCmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter board issues by assignee username")
 	viewCmd.Flags().StringVarP(&opts.Labels, "labels", "l", "", "Filter board issues by labels (comma separated)")
 	viewCmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter board issues by milestone")
-	viewCmd.Flags().StringVarP(&opts.State, "state", "s", "", "Filter board issues by state")
 	return viewCmd
 }
 
@@ -256,14 +255,8 @@ func parseListProjectIssueOptions(opts *IssueBoardViewOptions) (*gitlab.ListProj
 		return &gitlab.ListProjectIssuesOptions{}, fmt.Errorf("can't request assigneeID and assigneeUsername simultaneously")
 	}
 
-	reqOpts := &gitlab.ListProjectIssuesOptions{}
-
-	if opts.AssigneeID != 0 {
-		reqOpts.AssigneeID = &opts.AssigneeID
-	}
-
-	if opts.AssigneeUsername != "" {
-		reqOpts.AssigneeUsername = &opts.AssigneeUsername
+	if opts.Assignee != "" {
+		reqOpts.AssigneeUsername = &opts.Assignee
 	}
 
 	if opts.Labels != "" {
@@ -285,14 +278,8 @@ func parseListGroupIssueOptions(opts *IssueBoardViewOptions) (*gitlab.ListGroupI
 		return &gitlab.ListGroupIssuesOptions{}, fmt.Errorf("can't request assigneeID and assigneeUsername simultaneously")
 	}
 
-	reqOpts := &gitlab.ListGroupIssuesOptions{}
-
-	if opts.AssigneeID != 0 {
-		reqOpts.AssigneeID = &opts.AssigneeID
-	}
-
-	if opts.AssigneeUsername != "" {
-		reqOpts.AssigneeUsername = &opts.AssigneeUsername
+	if opts.Assignee != "" {
+		reqOpts.AssigneeUsername = &opts.Assignee
 	}
 
 	if opts.Labels != "" {

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -53,6 +53,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			// list the groups that are ancestors to project:
 			// https://docs.gitlab.com/ee/api/projects.html#list-a-projects-groups
 			projectGroups, err := api.ListProjectGroups(apiClient, project.ID, &gitlab.ListProjectGroupOptions{})
+			if err != nil {
+				return err
+			}
 
 			// get group issue boards for each ancestor group returned:
 			// https://docs.gitlab.com/ee/api/group_boards.html#list-all-group-issue-boards-in-a-group
@@ -179,6 +182,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 						return err
 					}
 					issues, err = api.ListGroupIssues(apiClient, boardInfo[selectedBoard].group.ID, opts)
+					if err != nil {
+						return err
+					}
 				}
 
 				if boardInfo[selectedBoard].group == nil {
@@ -187,6 +193,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 						return err
 					}
 					issues, err = api.ListProjectIssues(apiClient, repo.FullName(), opts)
+					if err != nil {
+						return err
+					}
 				}
 
 				if err != nil {

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -100,7 +100,7 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			}
 			selectedBoard := strings.Split(selectedOption, " ")[0]
 
-			boardLists := []*gitlab.BoardList{}
+			var boardLists []*gitlab.BoardList
 			if boardInfo[selectedBoard].group != nil {
 				boardLists, err = api.GetGroupIssueBoardLists(apiClient, boardInfo[selectedBoard].group.ID,
 					boardInfo[selectedBoard].id, &gitlab.ListGroupIssueBoardListsOptions{})

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"runtime/debug"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/gdamore/tcell/v2"
@@ -16,13 +17,14 @@ import (
 )
 
 var (
-	apiClient     *gitlab.Client
-	project       *gitlab.Project
-	repo          glrepo.Interface
-	selectedBoard string
+	apiClient *gitlab.Client
+	project   *gitlab.Project
+	repo      glrepo.Interface
 )
 
 func NewCmdView(f *cmdutils.Factory) *cobra.Command {
+	var assigneeUsername, labels, milestone, state string
+	var assigneeID int
 	var viewCmd = &cobra.Command{
 		Use:   "view [flags]",
 		Short: `View project issue board.`,
@@ -32,8 +34,6 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 
 			a := tview.NewApplication()
 			defer recoverPanic(a)
-
-			//out := utils.ColorableOut(cmd)
 
 			apiClient, err = f.HttpClient()
 			if err != nil {
@@ -50,64 +50,163 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				return fmt.Errorf("failed to get project: %w", err)
 			}
 
-			issueBoards, err := api.ListIssueBoards(apiClient, repo.FullName(), &gitlab.ListIssueBoardsOptions{})
+			// list the groups that are ancestors to project:
+			// https://docs.gitlab.com/ee/api/projects.html#list-a-projects-groups
+			projectGroups, err := api.ListProjectGroups(apiClient, project.ID, &gitlab.ListProjectGroupOptions{})
+
+			// get group issue boards for each ancestor group returned:
+			// https://docs.gitlab.com/ee/api/group_boards.html#list-all-group-issue-boards-in-a-group
+			projectGroupIssueBoards := []*gitlab.GroupIssueBoard{}
+			for _, projectGroup := range projectGroups {
+				groupIssueBoards, err := api.ListGroupIssueBoards(apiClient, projectGroup.ID, &gitlab.ListGroupIssueBoardsOptions{})
+				if err != nil {
+					return err
+				}
+				projectGroupIssueBoards = append(groupIssueBoards, projectGroupIssueBoards...)
+			}
+
+			projectIssueBoards, err := api.ListProjectIssueBoards(apiClient, repo.FullName(), &gitlab.ListIssueBoardsOptions{})
 			if err != nil {
 				return fmt.Errorf("error retrieving issue board: %w", err)
 			}
-			boardStr := make([]string, len(issueBoards))
-			boardInfo := map[string]int{}
-			for i, board := range issueBoards {
-				boardStr[i] = board.Name
-				boardInfo[boardStr[i]] = board.ID
+
+			type info struct {
+				id    int
+				kind  string
+				group *gitlab.Group
 			}
 
+			boardSelectionStr := []string{}
+			boardInfo := map[string]info{}
+			for _, board := range projectGroupIssueBoards {
+				boardSelectionStr = append(boardSelectionStr, fmt.Sprintf("%s%*s", board.Name, 50-len(board.Name), "(Group)"))
+				boardInfo[board.Name] = info{id: board.ID, group: board.Group}
+			}
+			for _, board := range projectIssueBoards {
+				boardSelectionStr = append(boardSelectionStr, fmt.Sprintf("%s%*s", board.Name, 50-len(board.Name), "(Project)"))
+				boardInfo[board.Name] = info{id: board.ID}
+			}
+
+			var selectedOption string
 			prompt := &survey.Select{
 				Message: "Select Board:",
-				Options: boardStr,
+				Options: boardSelectionStr,
 			}
-			err = survey.AskOne(prompt, &selectedBoard)
+			err = survey.AskOne(prompt, &selectedOption)
 			if err != nil {
 				return err
+			}
+			selectedBoard := strings.Split(selectedOption, " ")[0]
+
+			boardLists := []*gitlab.BoardList{}
+			if boardInfo[selectedBoard].group != nil {
+				boardLists, err = api.GetGroupIssueBoardLists(apiClient, boardInfo[selectedBoard].group.ID,
+					boardInfo[selectedBoard].id, &gitlab.ListGroupIssueBoardListsOptions{})
+				if err != nil {
+					return err
+				}
+			} else {
+				boardLists, err = api.GetPojectIssueBoardLists(apiClient, repo.FullName(),
+					boardInfo[selectedBoard].id, &gitlab.GetIssueBoardListsOptions{})
+				if err != nil {
+					return err
+				}
 			}
 
-			boadLists, err := api.GetIssueBoardLists(apiClient, repo.FullName(), boardInfo[selectedBoard], &gitlab.GetIssueBoardListsOptions{})
-			if err != nil {
-				return err
+			// manually add 'opened' and 'closed' lists before and after fetched lists
+			opened := &gitlab.BoardList{
+				Label: &gitlab.Label{
+					Name:      "Open",
+					Color:     "#fabd2f",
+					TextColor: "#000000",
+				},
+				Position: 0,
 			}
+			boardLists = append([]*gitlab.BoardList{opened}, boardLists...)
+
+			closed := &gitlab.BoardList{
+				Label: &gitlab.Label{
+					Name:      "Closed",
+					Color:     "#8ec07c",
+					TextColor: "#000000",
+				},
+				Position: len(boardLists),
+			}
+			boardLists = append(boardLists, closed)
 
 			root := tview.NewFlex()
 			var issues []*gitlab.Issue
-			// TODO: add `open` and `closed` board list. Both are not returned in the List API response payload
-			for _, list := range boadLists {
-				var boardIssues string
-				issues, err = api.ListIssues(apiClient, repo.FullName(), &gitlab.ListProjectIssuesOptions{
-					State:  gitlab.String("opened"),
-					Labels: gitlab.Labels{list.Label.Name},
-				})
+			for _, list := range boardLists {
+				if list.Label == nil {
+					continue
+				}
+
+				var boardIssues, listTitle, listColor string
+
+				if list.Label == nil {
+					listTitle = "Unnamed"
+					listColor = "#FFA500" // orange
+				} else {
+					listTitle = list.Label.Name
+					listColor = list.Label.Color
+				}
+
+				// automatically request using state for default "open" and "closed" lists
+				// this is required because these lists aren't returned with the board lists api call
+				if list.Label.Name == "Closed" {
+					state = "closed"
+				}
+
+				if list.Label.Name == "Open" {
+					state = "opened"
+				}
+
+				// "closed" and "open" are considered special lists since they
+				// need to be requested using state and not label
+				isSpecialList := list.Label.Name == "Open" || list.Label.Name == "Closed"
+
+				// append list name label to labels from cli
+				reqLabels := labels
+				if reqLabels == "" && !isSpecialList {
+					reqLabels = list.Label.Name
+				}
+				if reqLabels != "" && !isSpecialList {
+					reqLabels = reqLabels + "," + list.Label.Name
+				}
+
+				if boardInfo[selectedBoard].group != nil {
+					opts, err := parseListGroupIssueOptions(assigneeID, assigneeUsername, reqLabels, milestone, state)
+					if err != nil {
+						return err
+					}
+					issues, err = api.ListGroupIssues(apiClient, boardInfo[selectedBoard].group.ID, opts)
+				}
+
+				if boardInfo[selectedBoard].group == nil {
+					opts, err := parseListProjectIssueOptions(assigneeID, assigneeUsername, labels, milestone, state)
+					if err != nil {
+						return err
+					}
+					issues, err = api.ListProjectIssues(apiClient, repo.FullName(), opts)
+				}
+
 				if err != nil {
 					return fmt.Errorf("error retrieving list issues: %w", err)
 				}
+
 				bx := tview.NewTextView().SetDynamicColors(true)
 				for _, issue := range issues {
-					var labelPrint string
-					var assignee string
-					totalLables := len(issue.Labels)
-					if totalLables > 0 {
-						for i, l := range issue.Labels {
-							if i == (totalLables - 1) {
-								labelPrint += l
-							} else {
-								labelPrint += l + ", "
-							}
-						}
+					var assignee, labelPrint string
+					if len(issue.Labels) > 0 {
+						labelPrint = "(" + strings.Join(issue.Labels, ", ") + ")"
 					}
 					if issue.Assignee != nil {
 						assignee = issue.Assignee.Username
 					}
-					boardIssues += fmt.Sprintf("[white]%s\n[blue](%s)\n[green]#%d[white] - %s\n\n", issue.Title, labelPrint, issue.IID, assignee)
+					boardIssues += fmt.Sprintf("[white]%s\n[blue]%s\n[green]#%d[white] - %s\n\n", issue.Title, labelPrint, issue.IID, assignee)
 				}
 				bx.SetText(boardIssues).SetWrap(true)
-				bx.SetBorder(true).SetTitle(list.Label.Name).SetTitleColor(tcell.GetColor(list.Label.Color))
+				bx.SetBorder(true).SetTitle(listTitle).SetTitleColor(tcell.GetColor(listColor))
 				root.AddItem(bx, 0, 1, false)
 			}
 
@@ -120,12 +219,74 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 			if err := a.SetScreen(screen).SetRoot(root, true).Run(); err != nil {
 				return err
 			}
-
 			return nil
 		},
 	}
 
+	viewCmd.Flags().StringVarP(&assigneeUsername, "assignee-username", "u", "", "Filter board issues by assignee username")
+	viewCmd.Flags().IntVarP(&assigneeID, "assignee-id", "i", 0, "Filter board issues by assignee id")
+	viewCmd.Flags().StringVarP(&labels, "labels", "l", "", "Filter board issues by labels (comma separated)")
+	viewCmd.Flags().StringVarP(&milestone, "milestone", "m", "", "Filter board issues by milestone")
+	viewCmd.Flags().StringVarP(&milestone, "state", "s", "", "Filter board issues by state")
 	return viewCmd
+}
+
+func parseListProjectIssueOptions(assigneeID int, assigneeUsername, labels, milestone, state string) (*gitlab.ListProjectIssuesOptions, error) {
+	if assigneeID != 0 && assigneeUsername != "" {
+		return &gitlab.ListProjectIssuesOptions{}, fmt.Errorf("can't request assigneeID and assigneeUsername simultaneously")
+	}
+
+	opts := &gitlab.ListProjectIssuesOptions{}
+
+	if assigneeID != 0 {
+		opts.AssigneeID = &assigneeID
+	}
+
+	if assigneeUsername != "" {
+		opts.AssigneeUsername = &assigneeUsername
+	}
+
+	if labels != "" {
+		opts.Labels = gitlab.Labels(strings.Split(labels, ","))
+	}
+
+	if state != "" {
+		opts.State = &state
+	}
+
+	if milestone != "" {
+		opts.Milestone = &milestone
+	}
+	return opts, nil
+}
+
+func parseListGroupIssueOptions(assigneeID int, assigneeUsername, labels, milestone, state string) (*gitlab.ListGroupIssuesOptions, error) {
+	if assigneeID != 0 && assigneeUsername != "" {
+		return &gitlab.ListGroupIssuesOptions{}, fmt.Errorf("can't request assigneeID and assigneeUsername simultaneously")
+	}
+
+	opts := &gitlab.ListGroupIssuesOptions{}
+
+	if assigneeID != 0 {
+		opts.AssigneeID = &assigneeID
+	}
+
+	if assigneeUsername != "" {
+		opts.AssigneeUsername = &assigneeUsername
+	}
+
+	if labels != "" {
+		opts.Labels = gitlab.Labels(strings.Split(labels, ","))
+	}
+
+	if state != "" {
+		opts.State = &state
+	}
+
+	if milestone != "" {
+		opts.Milestone = &milestone
+	}
+	return opts, nil
 }
 
 func recoverPanic(app *tview.Application) {

--- a/commands/issue/board/view/issue_board_view.go
+++ b/commands/issue/board/view/issue_board_view.go
@@ -189,22 +189,22 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 				}
 
 				if boardInfo[selectedBoard].group != nil {
-					parsedOpts, err := parseListGroupIssueOptions(opts)
+					reqOpts, err := parseListGroupIssueOptions(opts)
 					if err != nil {
 						return err
 					}
-					issues, err = api.ListGroupIssues(apiClient, boardInfo[selectedBoard].group.ID, parsedOpts)
+					issues, err = api.ListGroupIssues(apiClient, boardInfo[selectedBoard].group.ID, reqOpts)
 					if err != nil {
 						return err
 					}
 				}
 
 				if boardInfo[selectedBoard].group == nil {
-					parsedOpts, err := parseListProjectIssueOptions(opts)
+					reqOpts, err := parseListProjectIssueOptions(opts)
 					if err != nil {
 						return err
 					}
-					issues, err = api.ListProjectIssues(apiClient, repo.FullName(), parsedOpts)
+					issues, err = api.ListProjectIssues(apiClient, repo.FullName(), reqOpts)
 					if err != nil {
 						return err
 					}
@@ -256,28 +256,28 @@ func parseListProjectIssueOptions(opts *IssueBoardViewOptions) (*gitlab.ListProj
 		return &gitlab.ListProjectIssuesOptions{}, fmt.Errorf("can't request assigneeID and assigneeUsername simultaneously")
 	}
 
-	parsedOpts := &gitlab.ListProjectIssuesOptions{}
+	reqOpts := &gitlab.ListProjectIssuesOptions{}
 
 	if opts.AssigneeID != 0 {
-		parsedOpts.AssigneeID = &opts.AssigneeID
+		reqOpts.AssigneeID = &opts.AssigneeID
 	}
 
 	if opts.AssigneeUsername != "" {
-		parsedOpts.AssigneeUsername = &opts.AssigneeUsername
+		reqOpts.AssigneeUsername = &opts.AssigneeUsername
 	}
 
 	if opts.Labels != "" {
-		parsedOpts.Labels = gitlab.Labels(strings.Split(opts.Labels, ","))
+		reqOpts.Labels = gitlab.Labels(strings.Split(opts.Labels, ","))
 	}
 
 	if opts.State != "" {
-		parsedOpts.State = &opts.State
+		reqOpts.State = &opts.State
 	}
 
 	if opts.Milestone != "" {
-		parsedOpts.Milestone = &opts.Milestone
+		reqOpts.Milestone = &opts.Milestone
 	}
-	return parsedOpts, nil
+	return reqOpts, nil
 }
 
 func parseListGroupIssueOptions(opts *IssueBoardViewOptions) (*gitlab.ListGroupIssuesOptions, error) {
@@ -285,28 +285,28 @@ func parseListGroupIssueOptions(opts *IssueBoardViewOptions) (*gitlab.ListGroupI
 		return &gitlab.ListGroupIssuesOptions{}, fmt.Errorf("can't request assigneeID and assigneeUsername simultaneously")
 	}
 
-	parsedOpts := &gitlab.ListGroupIssuesOptions{}
+	reqOpts := &gitlab.ListGroupIssuesOptions{}
 
 	if opts.AssigneeID != 0 {
-		parsedOpts.AssigneeID = &opts.AssigneeID
+		reqOpts.AssigneeID = &opts.AssigneeID
 	}
 
 	if opts.AssigneeUsername != "" {
-		parsedOpts.AssigneeUsername = &opts.AssigneeUsername
+		reqOpts.AssigneeUsername = &opts.AssigneeUsername
 	}
 
 	if opts.Labels != "" {
-		parsedOpts.Labels = gitlab.Labels(strings.Split(opts.Labels, ","))
+		reqOpts.Labels = gitlab.Labels(strings.Split(opts.Labels, ","))
 	}
 
 	if opts.State != "" {
-		parsedOpts.State = &opts.State
+		reqOpts.State = &opts.State
 	}
 
 	if opts.Milestone != "" {
-		parsedOpts.Milestone = &opts.Milestone
+		reqOpts.Milestone = &opts.Milestone
 	}
-	return parsedOpts, nil
+	return reqOpts, nil
 }
 
 func recoverPanic(app *tview.Application) {

--- a/commands/issue/list/issue_list.go
+++ b/commands/issue/list/issue_list.go
@@ -29,7 +29,6 @@ type ListOptions struct {
 	Milestone   string
 	Mine        bool
 	Search      string
-	Group       string
 
 	// issue states
 	State        string
@@ -125,7 +124,6 @@ func NewCmdList(f *cmdutils.Factory, runE func(opts *ListOptions) error) *cobra.
 	issueListCmd.Flags().BoolVarP(&opts.Confidential, "confidential", "C", false, "Filter by confidential issues")
 	issueListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
 	issueListCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page. (default 30)")
-	issueListCmd.Flags().StringVarP(&opts.Group, "group", "g", "", "Get issues from group and it's subgroups")
 
 	issueListCmd.Flags().BoolP("opened", "o", false, "Get only opened issues")
 	_ = issueListCmd.Flags().MarkHidden("opened")
@@ -216,22 +214,13 @@ func listRun(opts *ListOptions) error {
 		opts.ListType = "search"
 	}
 
-	var issues []*gitlab.Issue
-	title := utils.NewListTitle(opts.TitleQualifier + " issue")
-	title.RepoName = repo.FullName()
-	if opts.Group != "" {
-		issues, err = api.ListGroupIssues(apiClient, opts.Group, api.ProjectListIssueOptionsToGroup(listOpts))
-		if err != nil {
-			return err
-		}
-		title.RepoName = opts.Group
-	} else {
-		issues, err = api.ListIssues(apiClient, repo.FullName(), listOpts)
-		if err != nil {
-			return err
-		}
+	issues, err := api.ListProjectIssues(apiClient, repo.FullName(), listOpts)
+	if err != nil {
+		return err
 	}
 
+	title := utils.NewListTitle(opts.TitleQualifier + " issue")
+	title.RepoName = repo.FullName()
 	title.Page = listOpts.Page
 	title.ListActionType = opts.ListType
 	title.CurrentPageTotal = len(issues)


### PR DESCRIPTION
## Description
This adds the ability to choose group level boards when viewing issue
boards. Some additional flags such as label filtering are also added
since the Gitlab issue boards are mainly just the column layouts
including all issues in the project/group. "Opened" and "Closed" issue lists are now included in the view.

## Related Issue
https://github.com/profclems/glab/issues/840

## How Has This Been Tested?
Manually tested using existing group and project boards on a private Gitlab instance.

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)