### PR TITLE
fix: add linebreak to check-output msg

### DIFF
--- a/commands/update/check_update.go
+++ b/commands/update/check_update.go
@@ -43,7 +43,7 @@ func CheckUpdate(s *iostreams.IOStreams, version string, silentErr bool) error {
 			return nil
 		}
 		fmt.Fprintf(s.StdOut, "%v %v", c.GreenCheck(),
-			c.Green("You are already using the latest version of glab"))
+			c.Green("You are already using the latest version of glab\n"))
 	}
 	return nil
 }

--- a/commands/update/check_update_test.go
+++ b/commands/update/check_update_test.go
@@ -43,7 +43,7 @@ func TestNewCheckUpdateCmd(t *testing.T) {
 				s:       ioStream,
 				version: "v1.11.1",
 			},
-			stdOut: "✓ You are already using the latest version of glab",
+			stdOut: "✓ You are already using the latest version of glab\n",
 			stdErr: "",
 		},
 		{


### PR DESCRIPTION


## Description

This fix adds a linebreak after the check-update output message.

## Related Issue

none

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
