### PR TITLE
mr: deprecate `mr for` command

### DIFF
--- a/commands/mr/for/mr_for.go
+++ b/commands/mr/for/mr_for.go
@@ -153,5 +153,7 @@ func NewCmdFor(f *cmdutils.Factory) *cobra.Command {
 	mrForCmd.Flags().StringP("target-branch", "b", "", "The target or base branch into which you want your code merged")
 	mrForCmd.Flags().BoolP("with-labels", "", false, "Copy labels from issue to the merge request")
 
+	mrForCmd.Deprecated = "use `glab mr create --related-issue <issueID>`"
+
 	return mrForCmd
 }


### PR DESCRIPTION
The `mr for` command works just like create but accepts
issue ID as argument.

It creates a related merge request for the specified.
But for some reasons, it lacks some options available
when using `mr create`.

This change deprecates the `mr for` command and
adds additional options to `mr create` to perform
be able to create related merge request for issues
