### PR TITLE
feat: add `repo list` command

### DIFF
--- a/commands/project/list/list.go
+++ b/commands/project/list/list.go
@@ -1,0 +1,99 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/profclems/glab/pkg/iostreams"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/tableprinter"
+	"github.com/profclems/glab/pkg/utils"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+type Options struct {
+	OrderBy string
+	Sort    string
+	PerPage int
+	Page    int
+
+	BaseRepo   func() (glrepo.Interface, error)
+	HTTPClient func() (*gitlab.Client, error)
+	IO         *iostreams.IOStreams
+}
+
+func NewCmdList(f *cmdutils.Factory) *cobra.Command {
+	opts := &Options{
+		IO: f.IO,
+	}
+	var repoListCmd = &cobra.Command{
+		Use:   "list",
+		Short: `Get list of your repositories.`,
+		Example: heredoc.Doc(`
+	$ glab repo list
+	`),
+		Args:    cobra.ExactArgs(0),
+		Aliases: []string{"users"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+			opts.HTTPClient = f.HttpClient
+
+			return runE(opts)
+		},
+	}
+
+	cmdutils.EnableRepoOverride(repoListCmd, f)
+
+	repoListCmd.Flags().StringVarP(&opts.OrderBy, "order", "o", "last_activity_at", "Return repositories ordered by id, created_at, or other fields")
+	repoListCmd.Flags().StringVarP(&opts.Sort, "sort", "s", "", "Return repositories sorted in asc or desc order")
+	repoListCmd.Flags().IntVarP(&opts.Page, "page", "p", 1, "Page number")
+	repoListCmd.Flags().IntVarP(&opts.PerPage, "per-page", "P", 30, "Number of items to list per page.")
+	return repoListCmd
+}
+
+func runE(opts *Options) error {
+	var err error
+	c := opts.IO.Color()
+
+	apiClient, err := opts.HTTPClient()
+	if err != nil {
+		return err
+	}
+
+	l := &gitlab.ListProjectsOptions{
+		OrderBy:        gitlab.String(opts.OrderBy),
+		MinAccessLevel: gitlab.AccessLevel(50), // Only projects you own
+	}
+	if opts.Sort != "" {
+		l.Sort = gitlab.String(opts.Sort)
+	}
+
+	l.PerPage = opts.PerPage
+	l.Page = opts.Page
+
+	projects, _, err := apiClient.Projects.ListProjects(l)
+	if err != nil {
+		return err
+	}
+
+	// Title
+	title := utils.NewListTitle("contributor")
+	title.RepoName = "FOO"
+	title.Page = l.Page
+	title.CurrentPageTotal = len(projects)
+
+	// List
+	table := tableprinter.NewTablePrinter()
+	for _, prj := range projects {
+		table.AddCell(c.Blue(prj.PathWithNamespace))
+		table.AddCell(prj.Description)
+		table.EndRow()
+	}
+
+	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title.Describe(), table.String())
+	return err
+}

--- a/commands/project/list/list.go
+++ b/commands/project/list/list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/profclems/glab/commands/cmdutils"
 	"github.com/profclems/glab/internal/glrepo"
 	"github.com/profclems/glab/pkg/tableprinter"
-	"github.com/profclems/glab/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
@@ -75,16 +74,13 @@ func runE(opts *Options) error {
 	l.PerPage = opts.PerPage
 	l.Page = opts.Page
 
-	projects, _, err := apiClient.Projects.ListProjects(l)
+	projects, resp, err := apiClient.Projects.ListProjects(l)
 	if err != nil {
 		return err
 	}
 
 	// Title
-	title := utils.NewListTitle("contributor")
-	title.RepoName = "FOO"
-	title.Page = l.Page
-	title.CurrentPageTotal = len(projects)
+	title := fmt.Sprintf("Showing %d of %d projects (Page %d of %d)\n", len(projects), resp.TotalItems, resp.CurrentPage, resp.TotalPages)
 
 	// List
 	table := tableprinter.NewTablePrinter()
@@ -94,6 +90,6 @@ func runE(opts *Options) error {
 		table.EndRow()
 	}
 
-	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title.Describe(), table.String())
+	fmt.Fprintf(opts.IO.StdOut, "%s\n%s\n", title, table.String())
 	return err
 }

--- a/commands/project/repo.go
+++ b/commands/project/repo.go
@@ -8,6 +8,7 @@ import (
 	repoCmdCreate "github.com/profclems/glab/commands/project/create"
 	repoCmdDelete "github.com/profclems/glab/commands/project/delete"
 	repoCmdFork "github.com/profclems/glab/commands/project/fork"
+	repoCmdList "github.com/profclems/glab/commands/project/list"
 	repoCmdSearch "github.com/profclems/glab/commands/project/search"
 	repoCmdView "github.com/profclems/glab/commands/project/view"
 
@@ -25,6 +26,7 @@ func NewCmdRepo(f *cmdutils.Factory) *cobra.Command {
 	repoCmd.AddCommand(repoCmdArchive.NewCmdArchive(f))
 	repoCmd.AddCommand(repoCmdClone.NewCmdClone(f, nil))
 	repoCmd.AddCommand(repoCmdContributors.NewCmdContributors(f))
+	repoCmd.AddCommand(repoCmdList.NewCmdList(f))
 	repoCmd.AddCommand(repoCmdCreate.NewCmdCreate(f))
 	repoCmd.AddCommand(repoCmdDelete.NewCmdDelete(f))
 	repoCmd.AddCommand(repoCmdFork.NewCmdFork(f, nil))

--- a/commands/project/repo.go
+++ b/commands/project/repo.go
@@ -8,8 +8,8 @@ import (
 	repoCmdCreate "github.com/profclems/glab/commands/project/create"
 	repoCmdDelete "github.com/profclems/glab/commands/project/delete"
 	repoCmdFork "github.com/profclems/glab/commands/project/fork"
-	repoCmdMirror "github.com/profclems/glab/commands/project/mirror"
 	repoCmdList "github.com/profclems/glab/commands/project/list"
+	repoCmdMirror "github.com/profclems/glab/commands/project/mirror"
 	repoCmdSearch "github.com/profclems/glab/commands/project/search"
 	repoCmdView "github.com/profclems/glab/commands/project/view"
 


### PR DESCRIPTION
## Description
Revive `glab repo list` PR https://github.com/profclems/glab/pull/684 and implement suggestions from https://github.com/profclems/glab/pull/684#discussion_r614600110

> @olearycrew If it's preferable to just keep https://github.com/profclems/glab/pull/684 open, please feel free to cherry pick and i'll close this.

- Add filters for all, owned, member and starred
   - The "all" filter is a little weird on public gitlab
- Default filter is owned
- Added ssh url to output (maybe a minimal flag would be nice that _only_ spit out ssh urls)

## Related Issue
Repos list issue: https://github.com/profclems/glab/issues/671
Existing PR: https://github.com/profclems/glab/pull/684

## How Has This Been Tested?
Only tested with my own repos, and I don't have a gitlab self hosted environment to test in.
```
make
./bin/glab repo list --all
./bin/glab repo list --starred
./bin/glab repo list --mine
```

## Screenshots (if appropriate)
```
❯ ./bin/glab repo list
Showing 25 of 25 projects (Page 1 of 1)

cfebs/patchnotes              git@gitlab.com:cfebs/patchnotes.git
cfebs/strife                  git@gitlab.com:cfebs/strife.git
cfebs/pmbootstrap             git@gitlab.com:cfebs/pmbootstrap.git             Sophisticated chroot/build/flash tool to develop and install postmarketOS
cfebs/crystal-stun            git@gitlab.com:cfebs/crystal-stun.git
cfebs/lowcall                 git@gitlab.com:cfebs/lowcall.git                 low requirement (no signaling server) webrtc call
cfebs/macaroni                git@gitlab.com:cfebs/macaroni.git
cfebs/foremanager             git@gitlab.com:cfebs/foremanager.git
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)