### PR TITLE
Add artifact download

### DIFF
--- a/api/pipeline.go
+++ b/api/pipeline.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"sort"
@@ -370,4 +371,19 @@ var CreatePipeline = func(client *gitlab.Client, projectID interface{}, opts *gi
 	}
 	pipe, _, err := client.Pipelines.CreatePipeline(projectID, opts)
 	return pipe, err
+}
+
+var DownloadArtifactJob = func(client *gitlab.Client, repo string, ref string, opts *gitlab.DownloadArtifactsFileOptions) (*bytes.Reader, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+
+	if opts == nil {
+		opts = &gitlab.DownloadArtifactsFileOptions{}
+	}
+	jobs, _, err := client.Jobs.DownloadArtifactsFile(repo, ref, opts, nil)
+	if err != nil {
+		return nil, err
+	}
+	return jobs, nil
 }

--- a/commands/ci/artifact/artifact.go
+++ b/commands/ci/artifact/artifact.go
@@ -1,0 +1,76 @@
+package ci
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/api"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/internal/glrepo"
+	"github.com/profclems/glab/pkg/iostreams"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+type TraceOpts struct {
+	Branch string
+	JobID  int
+
+	BaseRepo   func() (glrepo.Interface, error)
+	HTTPClient func() (*gitlab.Client, error)
+	IO         *iostreams.IOStreams
+}
+
+func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
+	var jobArtifactCmd = &cobra.Command{
+		Use:     "artifact <refName> <jobName> [flags]",
+		Short:   `Download all Artifacts from the last pipeline`,
+		Aliases: []string{"push"},
+		Example: heredoc.Doc(`
+	$ glab ci artifact main build
+	$ glab ci artifact main deploy --path="artifacts/"
+	`),
+		Long: ``,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			repo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+			apiClient, err := f.HttpClient()
+			if err != nil {
+				return err
+			}
+			p, err := cmd.Flags().GetString("path")
+			if err != nil {
+				return err
+			}
+
+			artifact, _ := api.DownloadArtifactJob(apiClient, repo.FullName(), args[0], &gitlab.DownloadArtifactsFileOptions{Job: &args[1]})
+
+			zr, _ := zip.NewReader(artifact, artifact.Size())
+			os.Mkdir(p, 0777)
+			for _, v := range zr.File {
+				if v.FileInfo().IsDir() {
+					os.Mkdir(p+v.Name, 0777)
+				} else {
+					srcFile, _ := zr.Open(v.Name)
+					defer srcFile.Close()
+					dstFile, err := os.OpenFile(p+v.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, v.Mode())
+					if err != nil {
+						panic(err)
+					}
+					io.Copy(dstFile, srcFile)
+				}
+			}
+
+			return nil
+		},
+	}
+	jobArtifactCmd.Flags().StringP("path", "p", "", "Path to download the Artifact files (default ./)")
+
+	return jobArtifactCmd
+}

--- a/commands/ci/artifact/artifact.go
+++ b/commands/ci/artifact/artifact.go
@@ -8,20 +8,9 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
-	"github.com/profclems/glab/internal/glrepo"
-	"github.com/profclems/glab/pkg/iostreams"
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
 )
-
-type TraceOpts struct {
-	Branch string
-	JobID  int
-
-	BaseRepo   func() (glrepo.Interface, error)
-	HTTPClient func() (*gitlab.Client, error)
-	IO         *iostreams.IOStreams
-}
 
 func NewCmdRun(f *cmdutils.Factory) *cobra.Command {
 	var jobArtifactCmd = &cobra.Command{

--- a/commands/ci/ci.go
+++ b/commands/ci/ci.go
@@ -1,6 +1,7 @@
 package ci
 
 import (
+	jobArtifactCmd "github.com/profclems/glab/commands/ci/artifact"
 	pipeDeleteCmd "github.com/profclems/glab/commands/ci/delete"
 	legacyCICmd "github.com/profclems/glab/commands/ci/legacyci"
 	ciLintCmd "github.com/profclems/glab/commands/ci/lint"
@@ -34,5 +35,6 @@ func NewCmdCI(f *cmdutils.Factory) *cobra.Command {
 	ciCmd.AddCommand(pipeStatusCmd.NewCmdStatus(f))
 	ciCmd.AddCommand(pipeRetryCmd.NewCmdRetry(f))
 	ciCmd.AddCommand(pipeRunCmd.NewCmdRun(f))
+	ciCmd.AddCommand(jobArtifactCmd.NewCmdRun(f))
 	return ciCmd
 }


### PR DESCRIPTION
## Description
This changes create a new command to download all files inside the Artifact from the last pipeline.

## Related Issue
Resolves #888 

## How Has This Been Tested?
I tested this command with my own repository, generating the artifact from the pipeline with various directories and files.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [X] Chore (Related to CI or Packaging to platforms)