### PR TITLE
feature: Read config directory from GLAB_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Get a GitLab access token at <https://gitlab.com/-/profile/personal_access_token
 
 ## Configuration
 
-`glab` follows the XDG Base Directory [Spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html): global configuration file is saved at `~/.config/glab-cli`. Local configuration file is saved at `.git/glab-cli` in the current working git directory.
+By default, `glab` follows the XDG Base Directory [Spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html): global configuration file is saved at `~/.config/glab-cli`. Local configuration file is saved at `.git/glab-cli` in the current working git directory. Advanced workflows may override the location of the global configuration by setting the `GLAB_CONFIG_DIR` environment variable.
 
 **To set configuration globally**
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -62,6 +62,8 @@ func NewCmdRoot(f *cmdutils.Factory, version, buildDate string) *cobra.Command {
 			NO_COLOR: set to any value to avoid printing ANSI escape sequences for color output.
 
 			FORCE_HYPERLINKS: set to 1 to force hyperlinks to be output, even when not outputing to a TTY
+
+			GLAB_CONFIG_DIR: set to a directory path to override the global configuration location 
 		`),
 			"help:feedback": heredoc.Docf(`
 			Encountered a bug or want to suggest a feature?

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -18,6 +18,10 @@ var configError error
 
 // ConfigDir returns the config directory
 func ConfigDir() string {
+	glabDir := os.Getenv("GLAB_CONFIG_DIR")
+	if glabDir != "" {
+		return glabDir
+	}
 	usrConfigHome := os.Getenv("XDG_CONFIG_HOME")
 	if usrConfigHome == "" {
 		usrConfigHome = os.Getenv("HOME")


### PR DESCRIPTION
## Description

When working with many different gitlab instances for different
projects, the global config quickly gets cluttered up with
specific settings that do not clean up conveniently. On the other hand,
local configs are to local, restricting the config to one repository
instead of one project or instance that potentially contains many
relevant repositories.
This change introduces a middle ground solution via the GLAB_CONFIG_DIR
environment variable. Setting this variable will allow global
configuration to travel with the project instead of populating the XDG
global config.



- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)