### PR TITLE
Add transfer command

### DIFF
--- a/commands/cmdutils/cmdutils.go
+++ b/commands/cmdutils/cmdutils.go
@@ -530,3 +530,27 @@ func (ua *UserAssignments) UsersFromAddRemove(
 	}
 	return assignedIDs, actions, nil
 }
+
+func ConfirmTransfer() error {
+	const (
+		performTransferLabel = "Confirm repository transfer"
+		abortTransferLabel   = "Abort repository transfer"
+	)
+
+	options := []string{abortTransferLabel, performTransferLabel}
+
+	var confirmTransfer string
+	err := prompt.Select(&confirmTransfer, "confirmation", "Do you wish to proceed with the repository transfer?", options)
+	if err != nil {
+		return fmt.Errorf("could not prompt: %w", err)
+	}
+
+	switch confirmTransfer {
+	case performTransferLabel:
+		return nil
+	case abortTransferLabel:
+		return fmt.Errorf("user aborted operation")
+	default:
+		return fmt.Errorf("invalid value: %s", confirmTransfer)
+	}
+}

--- a/commands/project/repo.go
+++ b/commands/project/repo.go
@@ -10,6 +10,7 @@ import (
 	repoCmdFork "github.com/profclems/glab/commands/project/fork"
 	repoCmdMirror "github.com/profclems/glab/commands/project/mirror"
 	repoCmdSearch "github.com/profclems/glab/commands/project/search"
+	repoCmdTransfer "github.com/profclems/glab/commands/project/transfer"
 	repoCmdView "github.com/profclems/glab/commands/project/view"
 
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ func NewCmdRepo(f *cmdutils.Factory) *cobra.Command {
 	repoCmd.AddCommand(repoCmdDelete.NewCmdDelete(f))
 	repoCmd.AddCommand(repoCmdFork.NewCmdFork(f, nil))
 	repoCmd.AddCommand(repoCmdSearch.NewCmdSearch(f))
+	repoCmd.AddCommand(repoCmdTransfer.NewCmdTransfer(f))
 	repoCmd.AddCommand(repoCmdView.NewCmdView(f))
 	repoCmd.AddCommand(repoCmdMirror.NewCmdMirror(f))
 

--- a/commands/project/transfer/project_transfer.go
+++ b/commands/project/transfer/project_transfer.go
@@ -1,0 +1,91 @@
+package transfer
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+func NewCmdTransfer(f *cmdutils.Factory) *cobra.Command {
+	var repoTransferCmd = &cobra.Command{
+		Use:   "transfer <command> [flags]",
+		Short: `Transfer a repository to a new namespace.`,
+		Example: heredoc.Doc(`
+			$ glab repo transfer profclems/glab --target-namespace notprofclems
+		`),
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			if len(args) != 0 {
+				err = f.RepoOverride(args[0])
+				if err != nil {
+					return err
+				}
+			}
+
+			apiClient, err := f.HttpClient()
+			if err != nil {
+				return err
+			}
+
+			repo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+
+			dontPromptForConfirmation, err := cmd.Flags().GetBool("danger-cannot-be-undone")
+			if err != nil {
+				return err
+			}
+
+			targetNamespace, err := cmd.Flags().GetString("target-namespace")
+			if err != nil {
+				return err
+			}
+
+			c := f.IO.Color()
+			fmt.Printf(heredoc.Doc(`
+				🔴 Danger 🔴
+
+				The operation you are about to perform is potentially irreversible.
+				You will lose control of the repository you are transferring in case you do not
+				have access to the target namespace. In addition, you won't be able to transfer
+				the repository back to the original namespace unless you have administrative access
+				to the target namespace.
+
+				Source repository: %s
+				Target namespace: %s
+
+			`), c.Yellow(repo.FullName()), c.Yellow(targetNamespace))
+
+			if !dontPromptForConfirmation {
+				err = cmdutils.ConfirmTransfer()
+				if err != nil {
+					return fmt.Errorf("unable to confirm: %w", err)
+				}
+			}
+
+			opt := &gitlab.TransferProjectOptions{}
+			opt.Namespace = targetNamespace
+
+			project, _, err := apiClient.Projects.TransferProject(repo.FullName(), opt)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(f.IO.StdOut, "%s Successfully transferred repository %s to %s\n",
+				c.GreenCheck(), c.Yellow(repo.FullName()), c.Yellow(project.PathWithNamespace))
+
+			return nil
+		},
+	}
+
+	repoTransferCmd.Flags().BoolP("yes", "y", false, "Danger: Skip confirmation prompt and force transfer operation. Transfer cannot be undone.")
+	repoTransferCmd.Flags().StringP("target-namespace", "t", "", "The namespace where your project should be transferred to")
+
+	return repoTransferCmd
+}

--- a/commands/project/transfer/project_transfer.go
+++ b/commands/project/transfer/project_transfer.go
@@ -11,12 +11,12 @@ import (
 
 func NewCmdTransfer(f *cmdutils.Factory) *cobra.Command {
 	var repoTransferCmd = &cobra.Command{
-		Use:   "transfer <command> [flags]",
+		Use:   "transfer [repo] [flags]",
 		Short: `Transfer a repository to a new namespace.`,
 		Example: heredoc.Doc(`
 			$ glab repo transfer profclems/glab --target-namespace notprofclems
 		`),
-		Args: cobra.MaximumNArgs(2),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
@@ -37,7 +37,7 @@ func NewCmdTransfer(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			dontPromptForConfirmation, err := cmd.Flags().GetBool("danger-cannot-be-undone")
+			dontPromptForConfirmation, err := cmd.Flags().GetBool("yes")
 			if err != nil {
 				return err
 			}
@@ -86,6 +86,8 @@ func NewCmdTransfer(f *cmdutils.Factory) *cobra.Command {
 
 	repoTransferCmd.Flags().BoolP("yes", "y", false, "Danger: Skip confirmation prompt and force transfer operation. Transfer cannot be undone.")
 	repoTransferCmd.Flags().StringP("target-namespace", "t", "", "The namespace where your project should be transferred to")
+
+	_ = repoTransferCmd.MarkFlagRequired("target-namespace")
 
 	return repoTransferCmd
 }


### PR DESCRIPTION
## Description

I've added a command that allows transferring repositories to other namespaces.

## Related Issue

Resolves #925

## How Has This Been Tested?

I've only manually tested my changes so far, with repositories on gitlab.com. 

## Screenshots (if appropriate)

Running `glab repo transfer fresskoma/iolite-mock --target-namespace ljenss/Museum` would yield

<img width="846" alt="Screenshot 2021-12-12 at 18 48 08" src="https://user-images.githubusercontent.com/243719/145723611-77c78f3b-6ca6-4a94-8b32-7708b88343e6.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)

## TODOs

- [x] Add proper descriptions of the command
- [ ] ~Update documentation~
- [ ] ...