### PR TITLE
fix: Write aliases to symlink if it exists

### DIFF
--- a/internal/config/writefile.go
+++ b/internal/config/writefile.go
@@ -5,10 +5,18 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/google/renameio"
 )
 
+// WriteFile to the path
+// If the path is smylink it will write to the symlink
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	pathToSymlink, err := filepath.EvalSymlinks(filename)
+	if err == nil {
+		filename = pathToSymlink
+	}
+
 	return renameio.WriteFile(filename, data, perm)
 }

--- a/internal/config/writefile_test.go
+++ b/internal/config/writefile_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_WriteFile(t *testing.T) {
@@ -15,25 +16,41 @@ func Test_WriteFile(t *testing.T) {
 	if err != nil {
 		t.Skipf("unexpected error while creating temporay directory = %s", err)
 	}
-	defer os.RemoveAll(dir)
-
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
 	fpath := filepath.Join(dir, "test-file")
 
-	err = WriteFile(fpath, []byte("profclems/glab"), 0644)
-	if err != nil {
-		t.Errorf("unexpected error = %s", err)
-	}
+	t.Run("regular", func(t *testing.T) {
+		require.Nilf(t,
+			WriteFile(fpath, []byte("profclems/glab"), 0644),
+			"unexpected error = %s", err,
+		)
 
-	result, err := ioutil.ReadFile(fpath)
-	if err != nil {
-		t.Errorf("failed to read file %q due to %q", fpath, err)
-	}
-	assert.Equal(t, "profclems/glab", string(result))
+		result, err := ioutil.ReadFile(fpath)
+		require.Nilf(t, err, "failed to read file %q due to %q", fpath, err)
+		assert.Equal(t, "profclems/glab", string(result))
 
-	permissions, err := os.Stat(fpath)
-	if err != nil {
-		t.Errorf("failed to get stats for file %q due to %q", fpath, err)
-	}
-	// TODO:
-	assert.Equal(t, "0644", fmt.Sprintf("%04o", permissions.Mode()))
+		permissions, err := os.Stat(fpath)
+		require.Nilf(t, err, "failed to get stats for file %q due to %q", fpath, err)
+		// TODO:
+		assert.Equal(t, "0644", fmt.Sprintf("%04o", permissions.Mode()))
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		symPath := filepath.Join(dir, "test-symlink")
+		require.Nil(t, os.Symlink(fpath, symPath), "failed to create a symlink")
+		require.Nilf(t,
+			WriteFile(symPath, []byte("profclems/glab/symlink"), 0644),
+			"unexpected error = %s", err,
+		)
+
+		result, err := ioutil.ReadFile(symPath)
+		require.Nilf(t, err, "failed to read file %q due to %q", symPath, err)
+		assert.Equal(t, "profclems/glab/symlink", string(result))
+
+		permissions, err := os.Lstat(symPath)
+		require.Nil(t, err, "failed to get info about the smylink", err)
+		assert.Equal(t, os.ModeSymlink, permissions.Mode()&os.ModeSymlink, "this file should be a symlink")
+	})
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In cases where `aliases.yaml` was smylinked to some other place(dotfiles
for example), it would remove the smylink and write to a new file.

This commit fixes that by resolving the smylink before writing to the
file.

The one thing I thought about is that maybe checking for smylinks in the
WriteFile function is not the correct place. Then again if we don't do that
there it might come with the problem that we have to check it everywhere before
writing and someone in a PR might forget about it.

If there is a better place where this would fit in, feel free to comment on
that.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #892

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and local tests:
- by creating a complete new config
- by updating existing regular file config
- by updating a symlinked config

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
