### PR TITLE
feat: Add group flag to mr list command

### DIFF
--- a/api/issue.go
+++ b/api/issue.go
@@ -45,6 +45,50 @@ var GetIssue = func(client *gitlab.Client, projectID interface{}, issueID int) (
 	return issue, nil
 }
 
+var ProjectListIssueOptionsToGroup = func(l *gitlab.ListProjectIssuesOptions) *gitlab.ListGroupIssuesOptions {
+	return &gitlab.ListGroupIssuesOptions{
+		ListOptions:        l.ListOptions,
+		State:              l.State,
+		Labels:             l.Labels,
+		NotLabels:          l.NotLabels,
+		WithLabelDetails:   l.WithLabelDetails,
+		IIDs:               l.IIDs,
+		Milestone:          l.Milestone,
+		Scope:              l.Scope,
+		AuthorID:           l.AuthorID,
+		NotAuthorID:        l.NotAuthorID,
+		AssigneeID:         l.AssigneeID,
+		NotAssigneeID:      l.NotAssigneeID,
+		AssigneeUsername:   l.AssigneeUsername,
+		MyReactionEmoji:    l.MyReactionEmoji,
+		NotMyReactionEmoji: l.NotMyReactionEmoji,
+		OrderBy:            l.OrderBy,
+		Sort:               l.Sort,
+		Search:             l.Search,
+		In:                 l.In,
+		CreatedAfter:       l.CreatedAfter,
+		CreatedBefore:      l.CreatedBefore,
+		UpdatedAfter:       l.UpdatedAfter,
+		UpdatedBefore:      l.UpdatedBefore,
+		IssueType:          l.IssueType,
+	}
+}
+
+var ListGroupIssues = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupIssuesOptions) ([]*gitlab.Issue, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	if opts.PerPage == 0 {
+		opts.PerPage = DefaultListLimit
+	}
+	issues, _, err := client.Issues.ListGroupIssues(groupID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return issues, nil
+}
+
 var ListIssues = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectIssuesOptions) ([]*gitlab.Issue, error) {
 	if client == nil {
 		client = apiClient.Lab()

--- a/api/merge_request.go
+++ b/api/merge_request.go
@@ -40,6 +40,51 @@ var GetMR = func(client *gitlab.Client, projectID interface{}, mrID int, opts *g
 	return mr, nil
 }
 
+var ListGroupMRs = func(client *gitlab.Client, groupID interface{}, opts *gitlab.ListGroupMergeRequestsOptions) ([]*gitlab.MergeRequest, error) {
+	if client == nil {
+		client = apiClient.Lab()
+	}
+	if opts.PerPage == 0 {
+		opts.PerPage = DefaultListLimit
+	}
+
+	mrs, _, err := client.MergeRequests.ListGroupMergeRequests(groupID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return mrs, nil
+}
+
+var ProjectListMROptionsToGroup = func(l *gitlab.ListProjectMergeRequestsOptions) *gitlab.ListGroupMergeRequestsOptions {
+	return &gitlab.ListGroupMergeRequestsOptions{
+		ListOptions:            l.ListOptions,
+		State:                  l.State,
+		OrderBy:                l.OrderBy,
+		Sort:                   l.Sort,
+		Milestone:              l.Milestone,
+		View:                   l.View,
+		Labels:                 l.Labels,
+		NotLabels:              l.NotLabels,
+		WithLabelsDetails:      l.WithLabelsDetails,
+		WithMergeStatusRecheck: l.WithMergeStatusRecheck,
+		CreatedAfter:           l.CreatedAfter,
+		CreatedBefore:          l.CreatedBefore,
+		UpdatedAfter:           l.UpdatedAfter,
+		UpdatedBefore:          l.UpdatedBefore,
+		Scope:                  l.Scope,
+		AuthorID:               l.AuthorID,
+		AssigneeID:             l.AssigneeID,
+		ReviewerID:             l.ReviewerID,
+		ReviewerUsername:       l.ReviewerUsername,
+		MyReactionEmoji:        l.MyReactionEmoji,
+		SourceBranch:           l.SourceBranch,
+		TargetBranch:           l.TargetBranch,
+		Search:                 l.Search,
+		WIP:                    l.WIP,
+	}
+}
+
 var ListMRs = func(client *gitlab.Client, projectID interface{}, opts *gitlab.ListProjectMergeRequestsOptions) ([]*gitlab.MergeRequest, error) {
 	if client == nil {
 		client = apiClient.Lab()

--- a/commands/issue/list/issue_list_test.go
+++ b/commands/issue/list/issue_list_test.go
@@ -143,22 +143,42 @@ func TestIssueList_tty(t *testing.T) {
 }
 
 func TestIssueList_tty_withFlags(t *testing.T) {
-	fakeHTTP := httpmock.New()
-	defer fakeHTTP.Verify(t)
+	t.Run("project", func(t *testing.T) {
+		fakeHTTP := httpmock.New()
+		defer fakeHTTP.Verify(t)
 
-	fakeHTTP.RegisterResponder("GET", "/projects/OWNER/REPO/issues",
-		httpmock.NewStringResponse(200, `[]`))
+		fakeHTTP.RegisterResponder("GET", "/projects/OWNER/REPO/issues",
+			httpmock.NewStringResponse(200, `[]`))
 
-	output, err := runCommand(fakeHTTP, true, "--opened -P1 -p100 --confidential -a someuser -l bug -m1", nil, "")
-	if err != nil {
-		t.Errorf("error running command `issue list`: %v", err)
-	}
+		output, err := runCommand(fakeHTTP, true, "--opened -P1 -p100 --confidential -a someuser -l bug -m1", nil, "")
+		if err != nil {
+			t.Errorf("error running command `issue list`: %v", err)
+		}
 
-	cmdtest.Eq(t, output.Stderr(), "")
-	cmdtest.Eq(t, output.String(), `No open issues match your search in OWNER/REPO
+		cmdtest.Eq(t, output.Stderr(), "")
+		cmdtest.Eq(t, output.String(), `No open issues match your search in OWNER/REPO
 
 
 `)
+	})
+	t.Run("group", func(t *testing.T) {
+		fakeHTTP := httpmock.New()
+		defer fakeHTTP.Verify(t)
+
+		fakeHTTP.RegisterResponder("GET", "/groups/GROUP/issues",
+			httpmock.NewStringResponse(200, `[]`))
+
+		output, err := runCommand(fakeHTTP, true, "--group GROUP", nil, "")
+		if err != nil {
+			t.Errorf("error running command `issue list`: %v", err)
+		}
+
+		cmdtest.Eq(t, output.Stderr(), "")
+		cmdtest.Eq(t, output.String(), `No open issues match your search in GROUP
+
+
+`)
+	})
 }
 
 func TestIssueList_tty_mine(t *testing.T) {

--- a/commands/mr/list/mr_list_test.go
+++ b/commands/mr/list/mr_list_test.go
@@ -174,25 +174,44 @@ func TestMergeRequestList_tty(t *testing.T) {
 }
 
 func TestMergeRequestList_tty_withFlags(t *testing.T) {
-	fakeHTTP := httpmock.New()
-	defer fakeHTTP.Verify(t)
+	t.Run("repo", func(t *testing.T) {
+		fakeHTTP := httpmock.New()
+		defer fakeHTTP.Verify(t)
 
-	fakeHTTP.RegisterResponder("GET", "/projects/OWNER/REPO/merge_requests",
-		httpmock.NewStringResponse(200, `[]`))
+		fakeHTTP.RegisterResponder("GET", "/projects/OWNER/REPO/merge_requests",
+			httpmock.NewStringResponse(200, `[]`))
 
-	fakeHTTP.RegisterResponder("GET", "/users",
-		httpmock.NewStringResponse(200, `[{"id" : 1, "iid" : 1, "username": "john_smith"}]`))
+		fakeHTTP.RegisterResponder("GET", "/users",
+			httpmock.NewStringResponse(200, `[{"id" : 1, "iid" : 1, "username": "john_smith"}]`))
 
-	output, err := runCommand(fakeHTTP, true, "--opened -P1 -p100 -a someuser -l bug -m1", nil, "")
-	if err != nil {
-		t.Errorf("error running command `issue list`: %v", err)
-	}
+		output, err := runCommand(fakeHTTP, true, "--opened -P1 -p100 -a someuser -l bug -m1", nil, "")
+		if err != nil {
+			t.Errorf("error running command `issue list`: %v", err)
+		}
 
-	cmdtest.Eq(t, output.Stderr(), "")
-	cmdtest.Eq(t, output.String(), `No open merge requests match your search in OWNER/REPO
+		cmdtest.Eq(t, output.Stderr(), "")
+		cmdtest.Eq(t, output.String(), `No open merge requests match your search in OWNER/REPO
 
 
 `)
+	})
+	t.Run("group", func(t *testing.T) {
+		fakeHTTP := httpmock.New()
+		defer fakeHTTP.Verify(t)
+
+		fakeHTTP.RegisterResponder("GET", "/groups/GROUP/merge_requests",
+			httpmock.NewStringResponse(200, `[]`))
+
+		output, err := runCommand(fakeHTTP, true, "--group GROUP", nil, "")
+		if err != nil {
+			t.Errorf("error running command `mr list`: %v", err)
+		}
+
+		cmdtest.Eq(t, output.Stderr(), "")
+		cmdtest.Eq(t, output.String(), `No open merge requests available on GROUP
+
+`)
+	})
 }
 
 func makeHyperlink(linkText, targetURL string) string {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This adds a flag for listing groups mrs. This works only for groups in
authenticated repos. This is acceptable since mr list only works on
authenticated repos too.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #909

## How Has This Been Tested?
Local testing and added a simple unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)
