### PR TITLE
Fix hyperlinks rendering in less

### DIFF
--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -111,12 +111,9 @@ func (s *IOStreams) StartPager() error {
 			pagerEnv = append(pagerEnv[0:i], pagerEnv[i+1:]...)
 		}
 	}
-	if _, ok := os.LookupEnv("LESS"); !ok {
-		pagerEnv = append(pagerEnv, "LESS=FRX")
-	}
-	if _, ok := os.LookupEnv("LV"); !ok {
-		pagerEnv = append(pagerEnv, "LV=-c")
-	}
+
+	pagerEnv = append(pagerEnv, "LESS=FrX")
+	pagerEnv = append(pagerEnv, "LV=-c")
 
 	pagerCmd := exec.Command(pagerArgs[0], pagerArgs[1:]...)
 	pagerCmd.Env = pagerEnv

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -112,8 +112,7 @@ func (s *IOStreams) StartPager() error {
 		}
 	}
 
-	pagerEnv = append(pagerEnv, "LESS=FrX")
-	pagerEnv = append(pagerEnv, "LV=-c")
+	pagerEnv = append(pagerEnv, "LESS=FrX", "LV=-c")
 
 	pagerCmd := exec.Command(pagerArgs[0], pagerArgs[1:]...)
 	pagerCmd.Env = pagerEnv

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -112,7 +112,14 @@ func (s *IOStreams) StartPager() error {
 		}
 	}
 
-	pagerEnv = append(pagerEnv, "LESS=FrX", "LV=-c")
+	if s.shouldDisplayHyperlinks() {
+		pagerEnv = append(pagerEnv, "LESS=FrX")
+	} else if _, ok := os.LookupEnv("LESS"); !ok {
+		pagerEnv = append(pagerEnv, "LESS=FRX")
+	}
+	if _, ok := os.LookupEnv("LV"); !ok {
+		pagerEnv = append(pagerEnv, "LV=-c")
+	}
 
 	pagerCmd := exec.Command(pagerArgs[0], pagerArgs[1:]...)
 	pagerCmd.Env = pagerEnv


### PR DESCRIPTION
## Description

We should overwrite user's configuration of less.

## How Has This Been Tested?

### Actual behavior

The two commands below outputs a incorrect string.

```shell
LESS=FRX FORCE_HYPERLINKS=1 glab mr list
```

```shell
LESS=-R FORCE=HYPERLINKS=1 glab mr list
```

### Expected behavior

GLab should overwrite user's configurations of less. We should always use `LESS=FrX` to run the less

## Screenshots

### Actual behavior

<img width="855" alt="CleanShot 2022-01-08 at 16 20 55@2x" src="https://user-images.githubusercontent.com/8186898/148637354-276b6470-c177-44bd-936f-e7f417b27539.png">

### Expected behavior

<img width="426" alt="image" src="https://user-images.githubusercontent.com/8186898/148637385-329a230c-892b-4d96-bd70-882b8c203492.png">

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
