### PR TITLE
chore: Correct Arch Linux install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ Make sure you have [snap installed on your Linux Distro](https://snapcraft.io/do
 #### Arch Linux
 `glab` is available through the [community/glab](https://archlinux.org/packages/community/x86_64/glab/) package or download and install an archive from the [releases page](https://github.com/profclems/glab/releases/latest). Arch Linux also supports [snap](https://snapcraft.io/docs/installing-snap-on-arch-linux).
 ```sh
-yay -Sy glab
+pacman -S glab
 ```
-or any other [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) of your choice.
 
 #### KISS Linux
 > WARNING: It seems that KISS Linux may no longer be actively maintained, so links to its web domain have been removed from this README.


### PR DESCRIPTION
* Use official package manager (pacman) instead of unsupported AUR
  helper / pacman wrapper (yay) that was only necessary for unofficial
  packaging.

* Drop db sync flag (-y) because doing that while installing packages
  results in an unsupported partial-update scenario. The correct usage
  is to update the whole system first (if necessary) with `pacman Syu`,
  but Arch users will know that, so just the single relevant install
  command is best for projects to show.
