### PR TITLE
feat: accept GITLAB_ACCESS_TOKEN

### DIFF
--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -693,7 +693,7 @@ func EnvKeyEquivalence(key string) []string {
 	case "host":
 		return []string{"GITLAB_HOST", "GITLAB_URI", "GL_HOST"}
 	case "token":
-		return []string{"GITLAB_TOKEN", "OAUTH_TOKEN"}
+		return []string{"GITLAB_TOKEN", "GITLAB_ACCESS_TOKEN", "OAUTH_TOKEN"}
 	case "no_prompt":
 		return []string{"NO_PROMPT", "PROMPT_DISABLED"}
 	case "editor", "visual", "glab_editor":


### PR DESCRIPTION
the GitLab access token is specified as `GITLAB_ACCESS_TOKEN ` for the "Copy Terraform Init Command" feature (Infrastructure > Terraform > Actions menu in a state ? Copy...)

## Copy Terraform Init Command
![image](https://user-images.githubusercontent.com/9123665/149224625-8f301457-e692-4638-8608-285bcc052972.png)

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #[issue_number]

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)