### PR TITLE
goreleaser: switch to `use` instead of `use_buildx`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ dockers:
       - 'profclems/glab:{{ .Tag }}-amd64'
       - 'ghcr.io/profclems/glab:{{ .Tag }}-amd64'
     dockerfile: Dockerfile
-    use_buildx: true
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -50,7 +50,7 @@ dockers:
       - 'profclems/glab:{{ .Tag }}-arm64'
       - 'ghcr.io/profclems/glab:{{ .Tag }}-arm64'
     dockerfile: Dockerfile
-    use_buildx: true
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"


### PR DESCRIPTION
use_buildx is deprecated in favor of the more generalist use

https://goreleaser.com/deprecations/\#dockeruse_buildx
