### PR TITLE
Change flag which causes errors in some shells

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,7 @@ case $(uname -s) in
 esac
 
 printf "Fetching latest version\n"
-latest="$(curl -sL 'https://api.github.com/repos/profclems/glab/releases/latest' | grep 'tag_name' | grep --only 'v[0-9\.]\+' | cut -c 2-)"
+latest="$(curl -sL 'https://api.github.com/repos/profclems/glab/releases/latest' | grep 'tag_name' | grep -o 'v[0-9\.]\+' | cut -c 2-)"
 tempFolder="/tmp/glab_v${latest}"
 
 printf -- "Found version %s\n" "${latest}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,7 @@ case $(uname -s) in
 esac
 
 printf "Fetching latest version\n"
-latest="$(curl -sL 'https://api.github.com/repos/profclems/glab/releases/latest' | grep 'tag_name' | grep -o 'v[0-9\.]\+' | cut -c 2-)"
+latest="$(curl -sL 'https://api.github.com/repos/profclems/glab/releases/latest' | grep 'tag_name' | grep --only-matching 'v[0-9\.]\+' | cut -c 2-)"
 tempFolder="/tmp/glab_v${latest}"
 
 printf -- "Found version %s\n" "${latest}"


### PR DESCRIPTION
## Description

When installing glab on alpine 3.14 based Docker images, the following script throws a grep unexpected option error for the --only flag. Upon inspection of grep --help, --only does not exist. Use -o or --only-matching instead to have the same result. 

The installation command used here is:

curl -sL https://j.mp/glab-cli | sudo sh

## How Has This Been Tested?

I used this in my own Docker image based on the FROM python:3.7.12-alpine3.14 and it successfully installed version 1.22, i.e. the currently latest version of glab. 

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)