### PR TITLE
Fix incorrect examples of --status argument

### DIFF
--- a/docs/source/ci/list.rst
+++ b/docs/source/ci/list.rst
@@ -21,7 +21,7 @@ Examples
 ::
 
   $ glab ci list
-  $ glab ci list --state=failed
+  $ glab ci list --status=failed
   
 
 Options

--- a/docs/source/pipeline/list.rst
+++ b/docs/source/pipeline/list.rst
@@ -21,7 +21,7 @@ Examples
 ::
 
   $ glab pipeline list
-  $ glab pipeline list --state=failed
+  $ glab pipeline list --status=failed
   
 
 Options


### PR DESCRIPTION
## Description

In the examples, the --status argument is incorrectly referenced as --state. This fixes it.

## Related Issue
Resolves #966

## How Has This Been Tested?
Built the program and ran it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)