### PR TITLE
fix: fix validation for GitLab 14.5 tokens

### DIFF
--- a/api/default.go
+++ b/api/default.go
@@ -3,10 +3,10 @@ package api
 var DefaultListLimit = 30
 
 //IsValidToken checks if a token provided is valid.
-// The token string must be 20 characters in length to be recognized as
-// a valid personal access token.
+// The token string must be 26 characters in length and have the 'glpat-'
+// prefix to be recognized as a valid personal access token.
 //
 // TODO: check if token has minimum scopes required by glab
 func IsValidToken(token string) bool {
-	return len(token) == 20
+    return len(token) == 26 && token[:6] == "glpat-"
 }

--- a/api/default.go
+++ b/api/default.go
@@ -4,9 +4,9 @@ var DefaultListLimit = 30
 
 //IsValidToken checks if a token provided is valid.
 // The token string must be 26 characters in length and have the 'glpat-'
-// prefix to be recognized as a valid personal access token.
+// prefix or just be 20 characters long to be recognized as a valid personal access token.
 //
 // TODO: check if token has minimum scopes required by glab
 func IsValidToken(token string) bool {
-    return len(token) == 26 && token[:6] == "glpat-"
+    return (len(token) == 26 && token[:6] == "glpat-") || len(token) == 20
 }

--- a/api/default.go
+++ b/api/default.go
@@ -8,5 +8,5 @@ var DefaultListLimit = 30
 //
 // TODO: check if token has minimum scopes required by glab
 func IsValidToken(token string) bool {
-    return (len(token) == 26 && token[:6] == "glpat-") || len(token) == 20
+	return (len(token) == 26 && token[:6] == "glpat-") || len(token) == 20
 }

--- a/commands/auth/status/status.go
+++ b/commands/auth/status/status.go
@@ -116,7 +116,7 @@ func statusRun(opts *StatusOpts) error {
 				c.GreenCheck(), c.Bold(graphQLEndpoint))
 		}
 		if token != "" {
-			tokenDisplay := "********************"
+			tokenDisplay := "**************************"
 			if opts.ShowToken {
 				tokenDisplay = token
 			}

--- a/commands/auth/status/status_test.go
+++ b/commands/auth/status/status_test.go
@@ -109,7 +109,7 @@ hosts:
   ✓ API calls for gitlab.alpinelinux.org are made over https protocol
   ✓ REST API Endpoint: https://gitlab.alpinelinux.org/api/v4/
   ✓ GraphQL Endpoint: https://gitlab.alpinelinux.org/api/graphql/
-  ✓ Token: ********************
+  ✓ Token: **************************
 `, cfgFile),
 		},
 		{
@@ -197,14 +197,14 @@ hosts:
   ✓ API calls for gitlab.alpinelinux.org are made over https protocol
   ✓ REST API Endpoint: https://gitlab.alpinelinux.org/api/v4/
   ✓ GraphQL Endpoint: https://gitlab.alpinelinux.org/api/graphql/
-  ✓ Token: ********************
+  ✓ Token: **************************
 another.host
   x another.host: api call failed: GET https://another.host/api/v4/user: 401 {message: invalid token}
   ✓ Git operations for another.host configured to use ssh protocol.
   ✓ API calls for another.host are made over https protocol
   ✓ REST API Endpoint: https://another.host/api/v4/
   ✓ GraphQL Endpoint: https://another.host/api/graphql/
-  ✓ Token: ********************
+  ✓ Token: **************************
   ! Invalid token provided
 gl.io
   x gl.io: api call failed: GET https://gl.io/api/v4/user: 401 {message: no token provided}


### PR DESCRIPTION

## Description

- update token validation both in token length and prefix (now standard on gitlab)

- update documentation for token validation

- update '*' based token alias showed in log for proper length

This solves the current gitlab.com issue with the command

`glab auth status`

But there are still some warning messages related to some db.org  and gl.io domains, but I don't really know what that's about :(

## Related Issue

Resolves #926

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)