### PR TITLE
fix: copypasta errors for `glab issue view --help`

### DIFF
--- a/commands/issue/view/issue_view.go
+++ b/commands/issue/view/issue_view.go
@@ -104,9 +104,9 @@ func NewCmdView(f *cmdutils.Factory) *cobra.Command {
 		},
 	}
 
-	issueViewCmd.Flags().BoolVarP(&opts.ShowComments, "comments", "c", false, "Show mr comments and activities")
+	issueViewCmd.Flags().BoolVarP(&opts.ShowComments, "comments", "c", false, "Show issue comments and activities")
 	issueViewCmd.Flags().BoolVarP(&opts.ShowSystemLogs, "system-logs", "s", false, "Show system activities / logs")
-	issueViewCmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open mr in a browser. Uses default browser or browser specified in BROWSER variable")
+	issueViewCmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open issue in a browser. Uses default browser or browser specified in BROWSER variable")
 	issueViewCmd.Flags().IntVarP(&opts.CommentPageNumber, "page", "p", 1, "Page number")
 	issueViewCmd.Flags().IntVarP(&opts.CommentLimit, "per-page", "P", 20, "Number of items to list per page")
 


### PR DESCRIPTION
Fix `glab issue view --help` descriptions in `FLAGS` section for `--comments` and `--web` (mr -> issue)

## Description
Fix `glab issue view --help` descriptions in `FLAGS` section for `--comments` and `--web` (mr -> issue)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #972

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**test command**
```bash
❯ git grep -E 'issue.*mr'
```
**before**
```diff
commands/issue/create/issue_create.go:73:                       $ glab issue new -t "Fix CVE-YYYY-XXXX" -l security --linked-mr 123
commands/issue/create/issue_create.go:132:      issueCreateCmd.Flags().IntVarP(&opts.LinkedMR, "linked-mr", "", 0, "The IID of a merge request in which to resolve all issues")
commands/issue/view/issue_view.go:107:  issueViewCmd.Flags().BoolVarP(&opts.ShowComments, "comments", "c", false, "Show mr comments and activities")
commands/issue/view/issue_view.go:109:  issueViewCmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open mr in a browser. Uses default browser or browser specified in BROWSER variable")
commands/mr/issues/mr_issues.go:55:                     fmt.Fprintf(f.IO.StdOut, "%s\n%s\n", title.Describe(), issueutils.DisplayIssueList(f.IO, mrIssues, repo.FullName()))
docs/source/issue/create.rst:26:  $ glab issue new -t "Fix CVE-YYYY-XXXX" -l security --linked-mr 123
```

It appears that beside the auto-generated docs, there were no other places with similar changes to make. `issue_create.go:73,132` matches the 'test grep' because `--linked-mr`, so this is good, and similarly `mr_issues.go:55` appears intentional. So at least there is no other low hanging fruit

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)