### PR TITLE
feat: provide /reviewer quick action

### DIFF
--- a/commands/mr/create/mr_create.go
+++ b/commands/mr/create/mr_create.go
@@ -672,6 +672,10 @@ func generateMRCompareURL(opts *CreateOpts) (string, error) {
 		// this uses the slash commands to add assignees to the description
 		description += fmt.Sprintf("\n/assign %s", strings.Join(opts.Assignees, ", "))
 	}
+	if len(opts.Reviewers) > 0 {
+		// this uses the slash commands to add reviewers to the description
+		description += fmt.Sprintf("\n/reviewer %s", strings.Join(opts.Reviewers, ", "))
+	}
 	if opts.MileStone != 0 {
 		// this uses the slash commands to add milestone to the description
 		description += fmt.Sprintf("\n/milestone %%%d", opts.MileStone)


### PR DESCRIPTION
This is when creating a merge request using the command line option
git mr create --reviewer -w. Other options, like -a and -l, have been
working, but this seems to have gone missed.

Delivers #974