### PR TITLE
docs: change --labels to --label

### DIFF
--- a/commands/mr/mr.go
+++ b/commands/mr/mr.go
@@ -33,7 +33,7 @@ func NewCmdMR(f *cmdutils.Factory) *cobra.Command {
 		Short: `Create, view and manage merge requests`,
 		Long:  ``,
 		Example: heredoc.Doc(`
-			$ glab mr create --fill --labels bugfix
+			$ glab mr create --fill --label bugfix
 			$ glab mr merge 123
 			$ glab mr note -m "needs to do X before it can be merged" branch-foo
 		`),


### PR DESCRIPTION
The correct parameter seems to be --label (singular) as opposed to
--labels (plural).

It is a bit strange that the same example is given in two different
places, so this may need centralisation in one place in the future.