### PR TITLE
fix broken link to "quick install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Table of Contents
 * [Demo](#demo)
 * [Documentation](#documentation)
 * [Installation](#installation)
-  * [Quick Install)](#quick-install)
+  * [Quick Install](#quick-install)
   * [Windows](#windows)
     * [WinGet](#winget)
     * [Scoop](#scoop)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Table of Contents
 * [Demo](#demo)
 * [Documentation](#documentation)
 * [Installation](#installation)
-  * [Quick Install (Bash)](#quick-install-bash)
+  * [Quick Install)](#quick-install)
   * [Windows](#windows)
     * [WinGet](#winget)
     * [Scoop](#scoop)


### PR DESCRIPTION
## Description

Just a minor broken link on the README.md

I cared to open this Pull Request just because "Quick Install" is a very attractive link to click. And it's frustrating when you click on a link like that and nothing happens.


## How Has This Been Tested?

I clicked on the fixed link, and now it works! :)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)