### PR TITLE
remove 'pipeline ci' commands from doc frontpage (it's now deprecated)

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -17,7 +17,7 @@ Core Commands
 
 -  ``glab mr [list, create, close, reopen, delete, ...]``
 -  ``glab issue [list, create, close, reopen, delete, ...]``
--  ``glab pipeline [list, delete, ci status, ci view, ...]``
+-  ``glab pipeline [list, delete, status, view, ...]``
 -  ``glab release``
 -  ``glab repo``
 -  ``glab label``


### PR DESCRIPTION
## Description

Just removing from the documentation frontpage the `glab pipeline ci` commands. They are now deprecated.


## Related Issue

https://github.com/profclems/glab/issues/372


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)