### PR TITLE
Include token name and required scopes in PAT link

### DIFF
--- a/commands/auth/login/login.go
+++ b/commands/auth/login/login.go
@@ -334,6 +334,6 @@ func getAccessTokenTip(hostname string) string {
 		glHostname = glinstance.OverridableDefault()
 	}
 	return fmt.Sprintf(`
-	Tip: you can generate a Personal Access Token here https://%s/-/profile/personal_access_tokens
+	Tip: you can generate a Personal Access Token here https://%s/-/profile/personal_access_tokens?name=GLab&scopes=api,write_repository
 	The minimum required scopes are 'api' and 'write_repository'.`, glHostname)
 }


### PR DESCRIPTION
## Description

Include a default name and required scopes in the URL to generate the personal access token.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Resolves #[issue_number]

## How Has This Been Tested?

I haven't tested this via the code (not sure how to build it), but you can see it working by visiting

<https://gitlab.com/-/profile/personal_access_tokens?name=GLab&scopes=api,write_repository>

I just found out about GLab and added the feature to support passing in the name and scopes to the PAT page on GitLab. When setting it up I noticed they weren't present and could simplify the set up for other new users.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)