### PR TITLE
feat(ci retry): retry multiple jobs or entire pipeline

### DIFF
--- a/commands/ci/retry/retry.go
+++ b/commands/ci/retry/retry.go
@@ -2,9 +2,11 @@ package retry
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/profclems/glab/api"
 	"github.com/profclems/glab/commands/cmdutils"
+	"github.com/profclems/glab/pkg/git"
 	"github.com/profclems/glab/pkg/utils"
 
 	"github.com/MakeNowJust/heredoc"
@@ -17,10 +19,11 @@ func NewCmdRetry(f *cmdutils.Factory) *cobra.Command {
 		Short:   `Retry a CI job`,
 		Aliases: []string{},
 		Example: heredoc.Doc(`
-	$ glab ci retry 871528
+	$ glab ci retry 871528    # retries a specific job, 871528
+	$ glab ci retry           # retries most recent pipeline, if retry is necessary
+	$ glab ci retry --follow  # continues to retry most recent pipeline, until interrupted
 `),
 		Long: ``,
-		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
@@ -34,23 +37,101 @@ func NewCmdRetry(f *cmdutils.Factory) *cobra.Command {
 				return err
 			}
 
-			jobID := utils.StringToInt(args[0])
+			for i := range args {
+				jobID := utils.StringToInt(args[i])
 
-			if jobID < 1 {
-				fmt.Fprintln(f.IO.StdErr, "invalid job id:", args[0])
-				return cmdutils.SilentError
+				if jobID < 1 {
+					fmt.Fprintln(f.IO.StdErr, "invalid job id:", args[0])
+					return cmdutils.SilentError
+				}
+
+				job, err := api.RetryPipelineJob(apiClient, jobID, repo.FullName())
+				if err != nil {
+					return cmdutils.WrapError(err, fmt.Sprintf("Could not retry job with ID: %d", jobID))
+				}
+				fmt.Fprintln(f.IO.StdOut, "Retried job (id:", job.ID, "), status:", job.Status, ", ref:", job.Ref, ", weburl: ", job.WebURL, ")")
+			}
+			if len(args) > 0 {
+				// jobs specified on command line are retried, nothing more to do
+				return nil
 			}
 
-			job, err := api.RetryPipelineJob(apiClient, jobID, repo.FullName())
-			if err != nil {
-				return cmdutils.WrapError(err, fmt.Sprintf("Could not retry job with ID: %d", jobID))
+			// retry all failed jobs in pipeline
+
+			follow, _ := cmd.Flags().GetBool("follow")
+			branch, _ := cmd.Flags().GetString("branch")
+			if branch == "" {
+				branch, err = git.CurrentBranch()
+				if err != nil {
+					return err
+				}
 			}
-			fmt.Fprintln(f.IO.StdOut, "Retried job (id:", job.ID, "), status:", job.Status, ", ref:", job.Ref, ", weburl: ", job.WebURL, ")")
+
+			attempts := map[int]int{} // key is pipeline id, value is how may retries
+
+			for i := 0; i == 0 || follow; i++ {
+				if i > 0 {
+					// pause for retries triggered by prior iteration
+					time.Sleep(30 * time.Minute)
+				}
+
+				lastPipeline, err := api.GetLastPipeline(apiClient, repo.FullName(), branch)
+				if err != nil {
+					if follow {
+						continue
+					}
+					fmt.Fprintf(f.IO.StdOut, "No pipelines running or available on %s branch\n", branch)
+					return err
+				}
+
+				switch lastPipeline.Status {
+				case "canceled", "pending", "success", "skipped":
+					// nothing to retry
+					continue
+
+				default: // "running", "failed", "created"
+					// look for any failed jobs
+					failed := false
+					jobs, err := api.GetPipelineJobs(apiClient, lastPipeline.ID, repo.FullName())
+					if err != nil {
+						return err
+					}
+					for j := range jobs {
+						if jobs[j].Status == "failed" {
+							if jobs[j].AllowFailure {
+								fmt.Fprintf(f.IO.StdErr, "failed job (%s) allows failure, ignoring", jobs[i].WebURL)
+								continue
+							}
+
+							failed = true
+							break
+						}
+					}
+					if !failed {
+						continue // continue main loop, nothing to retry
+					}
+				}
+
+				count := attempts[lastPipeline.ID]
+				if count >= 3 {
+					fmt.Fprintf(f.IO.StdErr, "giving up on pipeline (%d), too many retries (%d)", lastPipeline.ID, count)
+					continue
+				}
+				attempts[lastPipeline.ID] = count + 1
+
+				fmt.Fprintf(f.IO.StdOut, "retrying pipeline (%s)", lastPipeline.WebURL)
+				_, err = api.RetryPipeline(apiClient, lastPipeline.ID, repo.FullName())
+				if err != nil {
+					fmt.Fprintf(f.IO.StdErr, "failed to retry pipeline (%s): %+v", lastPipeline.WebURL, err)
+				}
+			}
 
 			return nil
-
 		},
 	}
+
+	pipelineRetryCmd.Flags().StringP("branch", "b", "", "Retry latest pipeline associated with branch. (Default is current branch)")
+	pipelineRetryCmd.Flags().BoolP("follow", "f", false, "Retry when needed, until interrupted.")
 
 	return pipelineRetryCmd
 }


### PR DESCRIPTION

## Description

Before this PR, `glab ci retry <jobid>` would retry exactly one job, specified by job id. 

With this PR `glab ci retry` will retry the latest pipeline on the current branch, if it finds jobs have failed.

Also, `glab ci retry --follow` will continue to monitor pipelines on the current branch.  If jobs fail, it will trigger a pipeline retry.  It will do this until interrupted.

There are some baked-in values which ideally would be configurable.  For example, it retries any one pipeline up to 3 times (then gives up).  And, it polls for new pipelines every 30 minutes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

My motivation is to provide a "band-aid" for code which has a number of flaky tests.  They cause pipelines to fail, but often a retry will work.  Because it may take some time to address the underlying flaky tests, this is a workaround that should help more pipelines fail.

So, I've tested this a little bit in the scope of that project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (Related to CI or Packaging to platforms)